### PR TITLE
actions: add CHANGELOG validation script

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -1,0 +1,13 @@
+name: Validate CHANGELOG
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'CHANGELOG.md'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./tools/validate-changelog.sh

--- a/tools/validate-changelog.sh
+++ b/tools/validate-changelog.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# check that all `# headers` are formatted as a version, e.g. v1.2.3
+# this should be sufficient to validate the CHANGELOG for our CI, provided that
+# every new tag has a corresponding CHANGELOG update, as we always parse the
+# CHANGELOG between two headers with a tagged version.
+if diff <(grep -ne '^# ' CHANGELOG.md) <(grep -ne '^# v[0-9]\+\.[0-9]\+\.[0-9]\+' CHANGELOG.md); then
+  echo "CHANGELOG validation PASSED!"
+else
+  echo "CHANGELOG validation FAILED! Headers must match the regex '^# v[0-9]\+\.[0-9]\+\.[0-9]\+.'"
+  exit 1
+fi


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Adds some rudimentary CHANGELOG validation to the build action that runs on PRs. This should ensure that we don't merge a CHANGELOG that can't be parsed by the release CI.

**Testing done:**

Tested script locally. Against current CHANGELOG:

```bash
$ ./tools/validate-changelog.sh  
CHANGELOG validation PASSED!
```

Against the CHANGELOG with a "v" removed from a version header:

```bash
$ ./tools/validate-changelog.sh
1d0
< 1:# 1.0.2 (2024-12-20)
CHANGELOG validation FAILED! Headers must match the regex '^# v[0-9]\+\.[0-9]\+\.[0-9]\+.'
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
