### PR TITLE
kernels: update sha for neruon dkms

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -20,7 +20,7 @@ force-upstream = true
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm"
-sha512 = "5c0938f513101e7b6234d5ef4c450151c913976fec89bcba5f46ce57cba5cef764f1085080f7e145516ed9b49f7c4aad4e16b7ac07fda848b654ba34448051a0"
+sha512 = "f93aa097ea0515533817ce9737810cb8b025c35c3d4367c2e667292c0692d525ffbc9b7972fe957174e206a82e394cc7e076e5b399e1050f2c5f6ed129d4d739"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -20,7 +20,7 @@ force-upstream = true
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm"
-sha512 = "5c0938f513101e7b6234d5ef4c450151c913976fec89bcba5f46ce57cba5cef764f1085080f7e145516ed9b49f7c4aad4e16b7ac07fda848b654ba34448051a0"
+sha512 = "f93aa097ea0515533817ce9737810cb8b025c35c3d4367c2e667292c0692d525ffbc9b7972fe957174e206a82e394cc7e076e5b399e1050f2c5f6ed129d4d739"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -20,7 +20,7 @@ force-upstream = true
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm"
-sha512 = "5c0938f513101e7b6234d5ef4c450151c913976fec89bcba5f46ce57cba5cef764f1085080f7e145516ed9b49f7c4aad4e16b7ac07fda848b654ba34448051a0"
+sha512 = "f93aa097ea0515533817ce9737810cb8b025c35c3d4367c2e667292c0692d525ffbc9b7972fe957174e206a82e394cc7e076e5b399e1050f2c5f6ed129d4d739"
 force-upstream = true
 
 [build-dependencies]


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

The Neuron team overwrote the RPM for v2.19.64.0 because they resigned the package. Update shas for these packages for builds to succeed.

The Bottleocket team had a copy of the "old" RPM for confirming:

Checking RPM metadata:

```
╰─➤   rpm -qip ./old/aws-neuronx-dkms-2.19.64.0.noarch.rpm
warning: ./old/aws-neuronx-dkms-2.19.64.0.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID 646d9185: NOKEY
Name        : aws-neuronx-dkms
Version     : 2.19.64.0
Release     : dkms
Architecture: noarch
Install Date: (not installed)
Group       : System/Kernel
Size        : 902082
License     : GPL-2.0
Signature   : RSA/SHA256, Sat 21 Dec 2024 07:08:18 AM UTC, Key ID 5749cad8646d9185
Source RPM  : aws-neuronx-dkms-2.19.64.0-dkms.src.rpm
Build Date  : Tue 17 Dec 2024 03:17:48 AM UTC
Build Host  : 97d6fe14bdaa
Packager    : DKMS <dkms-devel@lists.us.dell.com>
Summary     : aws-neuronx 2.19.64.0 dkms package
Description :
Kernel modules for aws-neuronx 2.19.64.0 in a DKMS wrapper.

╰─➤   rpm -qip ./new/aws-neuronx-dkms-2.19.64.0.noarch.rpm
warning: ./new/aws-neuronx-dkms-2.19.64.0.noarch.rpm: Header V3 RSA/SHA256 Signature, key ID 646d9185: NOKEY
Name        : aws-neuronx-dkms
Version     : 2.19.64.0
Release     : dkms
Architecture: noarch
Install Date: (not installed)
Group       : System/Kernel
Size        : 902082
License     : GPL-2.0
Signature   : RSA/SHA256, Wed 15 Jan 2025 04:01:37 AM UTC, Key ID 5749cad8646d9185
Source RPM  : aws-neuronx-dkms-2.19.64.0-dkms.src.rpm
Build Date  : Tue 17 Dec 2024 03:17:48 AM UTC
Build Host  : 97d6fe14bdaa
Packager    : DKMS <dkms-devel@lists.us.dell.com>
Summary     : aws-neuronx 2.19.64.0 dkms package
Description :
Kernel modules for aws-neuronx 2.19.64.0 in a DKMS wrapper.

╰─➤  sha512sum ./old/aws-neuronx-dkms-2.19.64.0.noarch.rpm
5c0938f513101e7b6234d5ef4c450151c913976fec89bcba5f46ce57cba5cef764f1085080f7e145516ed9b49f7c4aad4e16b7ac07fda848b654ba34448051a0  ./old/aws-neuronx-dkms-2.19.64.0.noarch.rpm

╰─➤  sha512sum ./new/aws-neuronx-dkms-2.19.64.0.noarch.rpm
f93aa097ea0515533817ce9737810cb8b025c35c3d4367c2e667292c0692d525ffbc9b7972fe957174e206a82e394cc7e076e5b399e1050f2c5f6ed129d4d739  ./new/aws-neuronx-dkms-2.19.64.0.noarch.rpm
```

It looks like the RPM was resigned Wed 15 Jan 2025 04:01:37 AM UTC

Confirmed this is only a metadata change by extracting RPMs:

```
# Extract respective RPMs, placed in a folder "neuron"
rpm2cpio ws-neuronx-dkms-2.19.64.0.noarch.rpm | cpio -idmv
```

```
╰─➤  ls old
aws-neuronx-dkms-2.19.64.0.noarch.rpm  neuron

╰─➤  ls new
aws-neuronx-dkms-2.19.64.0.noarch.rpm  neuron
```

```
# No diff
diff -rw new/neuron old/neuron
```

**Testing done:**

`make ARCH=x86_64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
