### PR TITLE
Package update kmod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v1.0.4 (2025-01-16)
+
+## OS Changes
+* Update neruon dkms for kernel-5.10, kernel-5.15 and kernel-6.1 ([#16], ([#17]))
+* Update to drivers for kmod-5.10-nvidia, kmod-5.15-nvidia and kmod-6.1-nvidia ([#21])
+
+[#16]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/16
+[#17]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/17
+[#21]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/21
+
 # v1.0.2 (2024-12-20)
 
 ## Build Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.0.2"
+release-version = "1.0.4"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/kmod-5.10-nvidia/0001-makefile-allow-to-use-any-kernel-arch.patch
+++ b/packages/kmod-5.10-nvidia/0001-makefile-allow-to-use-any-kernel-arch.patch
@@ -1,0 +1,65 @@
+From 8d9bbc893466da39eea9f5b92dc2797cb7d79e12 Mon Sep 17 00:00:00 2001
+From: Shikha Vyaghra <vyaghras@amazon.com>
+Date: Wed, 8 Jan 2025 19:42:26 +0000
+Subject: [PATCH] makefile: allow to use any kernel arch
+
+The added check results in failing build for x86_64 architecture when we use
+`_cross_karch` in make commands in spec file and fails for aarch64 while
+using _cross_arch in the make commands.
+
+This check has been added recently and do not allow us to use
+Kernel_ARCH we want.
+
+We need different Kernel arch as we do cross builds.
+
+Signed-off-by: Shikha Vyaghra <vyaghras@amazon.com>
+---
+ kernel-open/Makefile | 10 ----------
+ kernel/Makefile      | 10 ----------
+ 2 files changed, 20 deletions(-)
+
+diff --git a/kernel-open/Makefile b/kernel-open/Makefile
+index 72672c2..187f39e 100644
+--- a/kernel-open/Makefile
++++ b/kernel-open/Makefile
+@@ -80,16 +80,6 @@ else
+     )
+   endif
+ 
+-  KERNEL_ARCH = $(ARCH)
+-
+-  ifneq ($(filter $(ARCH),i386 x86_64),)
+-    KERNEL_ARCH = x86
+-  else
+-    ifeq ($(filter $(ARCH),arm64 powerpc),)
+-        $(error Unsupported architecture $(ARCH))
+-    endif
+-  endif
+-
+   NV_KERNEL_MODULES ?= $(wildcard nvidia nvidia-uvm nvidia-vgpu-vfio nvidia-modeset nvidia-drm nvidia-peermem)
+   NV_KERNEL_MODULES := $(filter-out $(NV_EXCLUDE_KERNEL_MODULES), \
+                                     $(NV_KERNEL_MODULES))
+diff --git a/kernel/Makefile b/kernel/Makefile
+index 72672c2..187f39e 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -80,16 +80,6 @@ else
+     )
+   endif
+ 
+-  KERNEL_ARCH = $(ARCH)
+-
+-  ifneq ($(filter $(ARCH),i386 x86_64),)
+-    KERNEL_ARCH = x86
+-  else
+-    ifeq ($(filter $(ARCH),arm64 powerpc),)
+-        $(error Unsupported architecture $(ARCH))
+-    endif
+-  endif
+-
+   NV_KERNEL_MODULES ?= $(wildcard nvidia nvidia-uvm nvidia-vgpu-vfio nvidia-modeset nvidia-drm nvidia-peermem)
+   NV_KERNEL_MODULES := $(filter-out $(NV_EXCLUDE_KERNEL_MODULES), \
+                                     $(NV_KERNEL_MODULES))
+-- 
+2.40.1
+

--- a/packages/kmod-5.10-nvidia/Cargo.toml
+++ b/packages/kmod-5.10-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.216.01/NVIDIA-Linux-x86_64-535.216.01.run"
-sha512 = "3b4ae3584368fcc5f81a680dd8588d8b9e48f43dafe2490f5414ed258fa8c9799ebd40d2fd115e20bd02648eeb3e5c6dff39562d89353580fa679d011cebf6f8"
+url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-x86_64-535.230.02.run"
+sha512 = "2154e28682fe1663dc64b18569c67839995d496a6c1b353fcdc17fc4520420c8d629d441312a6cedc054d6322a267d6f275d1daef210d2f24a179d931a4c99b8"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.216.01/NVIDIA-Linux-aarch64-535.216.01.run"
-sha512 = "f68794249bf18ba626c6a665880721c8cc0dada6c7c1d8b15bf17174a4cac35ca2ab534fff2410c8bc0326c48f6ab913b6d9a92630505eeb768e02610a7772d9"
+url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-aarch64-535.230.02.run"
+sha512 = "7954350fe91419fa85c25483e2572e63c14da3e6fef27ffd13b5a4fcc814cde32faf4cd289333d6a22db26c64658f3e2df0ff8a9ec17094e29a25d35517048e4"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.216.01-1.x86_64.rpm"
-sha512 = "9208004779a57418cef4e0eacfad549e01fc3e193cda24a4f809325fee3a74910350c7752372d5dba7b74e9d5bf9da5807bc8de2bedade6dbe23b270c3047dfe"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.230.02-1.x86_64.rpm"
+sha512 = "18672058020ada0c7903308da5b9384f42aed742c79a358a0552feae263a27f77cf01612684deab98d77587b977a5dc29da1894c52780403d0816e46fd3cc64b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.216.01-1.aarch64.rpm"
-sha512 = "1f553e4627953cceef8f630d2be907829f8b78b789ffee7691ace541f759bdb07016e364c20e1d5779ce463f0b48448cea292f58a9899523ec840bb5a0c37b0e"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.230.02-1.aarch64.rpm"
+sha512 = "87b616aebe6a6e34fd4087fceffe352a843e2d5912483c6dfb36f22da9135ec030fd2cddfceb0e916b0d804df0722b9d990ad70a3c82cb4d2df65798a768c58d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 216
-%global tesla_patch 01
+%global tesla_minor 230
+%global tesla_patch 02
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa
@@ -56,6 +56,8 @@ Source307: load-tesla-kernel-modules.service.in
 Source308: copy-open-gpu-kernel-modules.service.in
 Source309: load-open-gpu-kernel-modules.service.in
 
+Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
+
 BuildRequires: %{_cross_os}kernel-5.10-archive
 
 %description
@@ -94,6 +96,10 @@ Requires: %{name}-open-gpu-%{tesla_major}
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
+# Move to the sources directory
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
+%patch 1 -p1
+popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.

--- a/packages/kmod-5.15-nvidia/0001-makefile-allow-to-use-any-kernel-arch.patch
+++ b/packages/kmod-5.15-nvidia/0001-makefile-allow-to-use-any-kernel-arch.patch
@@ -1,0 +1,65 @@
+From 8d9bbc893466da39eea9f5b92dc2797cb7d79e12 Mon Sep 17 00:00:00 2001
+From: Shikha Vyaghra <vyaghras@amazon.com>
+Date: Wed, 8 Jan 2025 19:42:26 +0000
+Subject: [PATCH] makefile: allow to use any kernel arch
+
+The added check results in failing build for x86_64 architecture when we use
+`_cross_karch` in make commands in spec file and fails for aarch64 while
+using _cross_arch in the make commands.
+
+This check has been added recently and do not allow us to use
+Kernel_ARCH we want.
+
+We need different Kernel arch as we do cross builds.
+
+Signed-off-by: Shikha Vyaghra <vyaghras@amazon.com>
+---
+ kernel-open/Makefile | 10 ----------
+ kernel/Makefile      | 10 ----------
+ 2 files changed, 20 deletions(-)
+
+diff --git a/kernel-open/Makefile b/kernel-open/Makefile
+index 72672c2..187f39e 100644
+--- a/kernel-open/Makefile
++++ b/kernel-open/Makefile
+@@ -80,16 +80,6 @@ else
+     )
+   endif
+ 
+-  KERNEL_ARCH = $(ARCH)
+-
+-  ifneq ($(filter $(ARCH),i386 x86_64),)
+-    KERNEL_ARCH = x86
+-  else
+-    ifeq ($(filter $(ARCH),arm64 powerpc),)
+-        $(error Unsupported architecture $(ARCH))
+-    endif
+-  endif
+-
+   NV_KERNEL_MODULES ?= $(wildcard nvidia nvidia-uvm nvidia-vgpu-vfio nvidia-modeset nvidia-drm nvidia-peermem)
+   NV_KERNEL_MODULES := $(filter-out $(NV_EXCLUDE_KERNEL_MODULES), \
+                                     $(NV_KERNEL_MODULES))
+diff --git a/kernel/Makefile b/kernel/Makefile
+index 72672c2..187f39e 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -80,16 +80,6 @@ else
+     )
+   endif
+ 
+-  KERNEL_ARCH = $(ARCH)
+-
+-  ifneq ($(filter $(ARCH),i386 x86_64),)
+-    KERNEL_ARCH = x86
+-  else
+-    ifeq ($(filter $(ARCH),arm64 powerpc),)
+-        $(error Unsupported architecture $(ARCH))
+-    endif
+-  endif
+-
+   NV_KERNEL_MODULES ?= $(wildcard nvidia nvidia-uvm nvidia-vgpu-vfio nvidia-modeset nvidia-drm nvidia-peermem)
+   NV_KERNEL_MODULES := $(filter-out $(NV_EXCLUDE_KERNEL_MODULES), \
+                                     $(NV_KERNEL_MODULES))
+-- 
+2.40.1
+

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.216.01/NVIDIA-Linux-x86_64-535.216.01.run"
-sha512 = "3b4ae3584368fcc5f81a680dd8588d8b9e48f43dafe2490f5414ed258fa8c9799ebd40d2fd115e20bd02648eeb3e5c6dff39562d89353580fa679d011cebf6f8"
+url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-x86_64-535.230.02.run"
+sha512 = "2154e28682fe1663dc64b18569c67839995d496a6c1b353fcdc17fc4520420c8d629d441312a6cedc054d6322a267d6f275d1daef210d2f24a179d931a4c99b8"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.216.01/NVIDIA-Linux-aarch64-535.216.01.run"
-sha512 = "f68794249bf18ba626c6a665880721c8cc0dada6c7c1d8b15bf17174a4cac35ca2ab534fff2410c8bc0326c48f6ab913b6d9a92630505eeb768e02610a7772d9"
+url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-aarch64-535.230.02.run"
+sha512 = "7954350fe91419fa85c25483e2572e63c14da3e6fef27ffd13b5a4fcc814cde32faf4cd289333d6a22db26c64658f3e2df0ff8a9ec17094e29a25d35517048e4"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.216.01-1.x86_64.rpm"
-sha512 = "9208004779a57418cef4e0eacfad549e01fc3e193cda24a4f809325fee3a74910350c7752372d5dba7b74e9d5bf9da5807bc8de2bedade6dbe23b270c3047dfe"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.230.02-1.x86_64.rpm"
+sha512 = "18672058020ada0c7903308da5b9384f42aed742c79a358a0552feae263a27f77cf01612684deab98d77587b977a5dc29da1894c52780403d0816e46fd3cc64b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.216.01-1.aarch64.rpm"
-sha512 = "1f553e4627953cceef8f630d2be907829f8b78b789ffee7691ace541f759bdb07016e364c20e1d5779ce463f0b48448cea292f58a9899523ec840bb5a0c37b0e"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.230.02-1.aarch64.rpm"
+sha512 = "87b616aebe6a6e34fd4087fceffe352a843e2d5912483c6dfb36f22da9135ec030fd2cddfceb0e916b0d804df0722b9d990ad70a3c82cb4d2df65798a768c58d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 216
-%global tesla_patch 01
+%global tesla_minor 230
+%global tesla_patch 02
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa
@@ -56,6 +56,8 @@ Source307: load-tesla-kernel-modules.service.in
 Source308: copy-open-gpu-kernel-modules.service.in
 Source309: load-open-gpu-kernel-modules.service.in
 
+Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
+
 BuildRequires: %{_cross_os}kernel-5.15-archive
 
 %description
@@ -94,6 +96,10 @@ Requires: %{name}-open-gpu-%{tesla_major}
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
+# Move to the sources directory and apply patch
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
+%patch 1 -p1
+popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.

--- a/packages/kmod-6.1-nvidia/0001-makefile-allow-to-use-any-kernel-arch.patch
+++ b/packages/kmod-6.1-nvidia/0001-makefile-allow-to-use-any-kernel-arch.patch
@@ -1,0 +1,65 @@
+From 8d9bbc893466da39eea9f5b92dc2797cb7d79e12 Mon Sep 17 00:00:00 2001
+From: Shikha Vyaghra <vyaghras@amazon.com>
+Date: Wed, 8 Jan 2025 19:42:26 +0000
+Subject: [PATCH] makefile: allow to use any kernel arch
+
+The added check results in failing build for x86_64 architecture when we use
+`_cross_karch` in make commands in spec file and fails for aarch64 while
+using _cross_arch in the make commands.
+
+This check has been added recently and do not allow us to use
+Kernel_ARCH we want.
+
+We need different Kernel arch as we do cross builds.
+
+Signed-off-by: Shikha Vyaghra <vyaghras@amazon.com>
+---
+ kernel-open/Makefile | 10 ----------
+ kernel/Makefile      | 10 ----------
+ 2 files changed, 20 deletions(-)
+
+diff --git a/kernel-open/Makefile b/kernel-open/Makefile
+index 72672c2..187f39e 100644
+--- a/kernel-open/Makefile
++++ b/kernel-open/Makefile
+@@ -80,16 +80,6 @@ else
+     )
+   endif
+ 
+-  KERNEL_ARCH = $(ARCH)
+-
+-  ifneq ($(filter $(ARCH),i386 x86_64),)
+-    KERNEL_ARCH = x86
+-  else
+-    ifeq ($(filter $(ARCH),arm64 powerpc),)
+-        $(error Unsupported architecture $(ARCH))
+-    endif
+-  endif
+-
+   NV_KERNEL_MODULES ?= $(wildcard nvidia nvidia-uvm nvidia-vgpu-vfio nvidia-modeset nvidia-drm nvidia-peermem)
+   NV_KERNEL_MODULES := $(filter-out $(NV_EXCLUDE_KERNEL_MODULES), \
+                                     $(NV_KERNEL_MODULES))
+diff --git a/kernel/Makefile b/kernel/Makefile
+index 72672c2..187f39e 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -80,16 +80,6 @@ else
+     )
+   endif
+ 
+-  KERNEL_ARCH = $(ARCH)
+-
+-  ifneq ($(filter $(ARCH),i386 x86_64),)
+-    KERNEL_ARCH = x86
+-  else
+-    ifeq ($(filter $(ARCH),arm64 powerpc),)
+-        $(error Unsupported architecture $(ARCH))
+-    endif
+-  endif
+-
+   NV_KERNEL_MODULES ?= $(wildcard nvidia nvidia-uvm nvidia-vgpu-vfio nvidia-modeset nvidia-drm nvidia-peermem)
+   NV_KERNEL_MODULES := $(filter-out $(NV_EXCLUDE_KERNEL_MODULES), \
+                                     $(NV_KERNEL_MODULES))
+-- 
+2.40.1
+

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.216.01/NVIDIA-Linux-x86_64-535.216.01.run"
-sha512 = "3b4ae3584368fcc5f81a680dd8588d8b9e48f43dafe2490f5414ed258fa8c9799ebd40d2fd115e20bd02648eeb3e5c6dff39562d89353580fa679d011cebf6f8"
+url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-x86_64-535.230.02.run"
+sha512 = "2154e28682fe1663dc64b18569c67839995d496a6c1b353fcdc17fc4520420c8d629d441312a6cedc054d6322a267d6f275d1daef210d2f24a179d931a4c99b8"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.216.01/NVIDIA-Linux-aarch64-535.216.01.run"
-sha512 = "f68794249bf18ba626c6a665880721c8cc0dada6c7c1d8b15bf17174a4cac35ca2ab534fff2410c8bc0326c48f6ab913b6d9a92630505eeb768e02610a7772d9"
+url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-aarch64-535.230.02.run"
+sha512 = "7954350fe91419fa85c25483e2572e63c14da3e6fef27ffd13b5a4fcc814cde32faf4cd289333d6a22db26c64658f3e2df0ff8a9ec17094e29a25d35517048e4"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.216.01-1.x86_64.rpm"
-sha512 = "9208004779a57418cef4e0eacfad549e01fc3e193cda24a4f809325fee3a74910350c7752372d5dba7b74e9d5bf9da5807bc8de2bedade6dbe23b270c3047dfe"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.230.02-1.x86_64.rpm"
+sha512 = "18672058020ada0c7903308da5b9384f42aed742c79a358a0552feae263a27f77cf01612684deab98d77587b977a5dc29da1894c52780403d0816e46fd3cc64b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.216.01-1.aarch64.rpm"
-sha512 = "1f553e4627953cceef8f630d2be907829f8b78b789ffee7691ace541f759bdb07016e364c20e1d5779ce463f0b48448cea292f58a9899523ec840bb5a0c37b0e"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.230.02-1.aarch64.rpm"
+sha512 = "87b616aebe6a6e34fd4087fceffe352a843e2d5912483c6dfb36f22da9135ec030fd2cddfceb0e916b0d804df0722b9d990ad70a3c82cb4d2df65798a768c58d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 216
-%global tesla_patch 01
+%global tesla_minor 230
+%global tesla_patch 02
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa
@@ -56,6 +56,8 @@ Source307: load-tesla-kernel-modules.service.in
 Source308: copy-open-gpu-kernel-modules.service.in
 Source309: load-open-gpu-kernel-modules.service.in
 
+Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
+
 BuildRequires: %{_cross_os}kernel-6.1-archive
 
 %description
@@ -94,6 +96,10 @@ Requires: %{name}-open-gpu-%{tesla_major}
 # Extract nvidia sources with `-x`, otherwise the script will try to install
 # the driver in the current run
 sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
+# Move to the sources directory and apply patch
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
+%patch 1 -p1
+popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
changelog: create version 1.0.4
7d45992 kit: bump version to 1.0.4
df95630 kmod-6.1-nvidia: Update NVIDIA and fabric manager drivers
977570b kmod-5.15-nvidia: Update NVIDIA and fabric manager drivers
d8026ae kmod-5.10-nvidia: Update NVIDIA and fabric manager drivers
Update Neuron packages for kernel
```

**Testing done:**
x86_64 and aarch64 on
- [x] aws-k8s-1.30-nvidia (for Kmod 6.1)
- [x] aws-k8s-1.24-nvidia (for Kmod 5.15)
- [ ] aws-ecs-2-nvidia (for Kmod 6.1)
- [ ] aws-ecs-1-nvidia (for Kmod 5.10)
- [x] Fabric manager service run successfully on Bottlerocket hosts for aws-k8s-1.30-nvidia,  aws-k8s-1.24-nvidia, aws-ecs-2-nvidia and aws-ecs-1-nvidia

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
