### PR TITLE
kernels: sort microcode firmware configs

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -118,7 +118,7 @@ done
 %autopatch -p1
 
 %if "%{_cross_arch}" == "x86_64"
-microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P ')"
+microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P\n' | sort | tr '\n' ' ')"
 cat <<EOF > ../config-microcode
 CONFIG_EXTRA_FIRMWARE="${microcode}"
 CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -113,7 +113,7 @@ done
 %autopatch -p1
 
 %if "%{_cross_arch}" == "x86_64"
-microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P ')"
+microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P\n' | sort | tr '\n' ' ')"
 cat <<EOF > ../config-microcode
 CONFIG_EXTRA_FIRMWARE="${microcode}"
 CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -183,7 +183,7 @@ done
 %autopatch -p1
 
 %if "%{_cross_arch}" == "x86_64"
-microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P ')"
+microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P\n' | sort | tr '\n' ' ')"
 cat <<EOF > ../config-microcode
 CONFIG_EXTRA_FIRMWARE="${microcode}"
 CONFIG_EXTRA_FIRMWARE_DIR="%{_cross_libdir}/firmware"


### PR DESCRIPTION
**Description of changes:**

Sort the list of firmware set in `CONFIG_EXTRA_FIRMWARE` to ensure consistent comparisons between kernel configs when updating a kernel package.

**Testing done:**

Build the kernel-kit from 3f46879 and extract configs before making this change: 

```
tools/collect-kernel-config -o ./kernel_configs_pre_sort
```

And after building with this change

```
tools/collect-kernel-config -o ./kernel_configs_sorted
```

No diff:

```
diff <(grep "CONFIG_EXTRA_FIRMWARE=" ./kernel_configs_pre_sort/config-6.1-x86_64.config) <(grep "CONFIG_EXTRA_FIRMWARE=" ./kernel_configs_sorted/config-6.1-x86_64.config)
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
