### PR TITLE
twoliter-lock: bump sdk version to 0.50.1

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -3,7 +3,7 @@ kit = []
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.50.0"
+version = "0.50.1"
 vendor = "bottlerocket"
 source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.50.1"
 digest = "HEh3Lx3F6P4OEPnFubF++RMpMW2vlfp/Tc/tGjnBRcM="


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Update twoliter config based on SDK 0.50.1

**Testing done:**

Check GH actions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
