### PR TITLE
advisories: add BRSA's for kernel kit v1.0.7

### DIFF
--- a/advisories/1.0.7/BRSA-edhp8onrudst.toml
+++ b/advisories/1.0.7/BRSA-edhp8onrudst.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-edhp8onrudst"
+title = "kernel CVE-2024-56658"
+cve = "CVE-2024-56658"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: net: defer final 'struct net' free in netns dismantle"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[updateinfo]
+author = "agarrcia"
+issue-date = 2025-02-04T18:59:20Z
+arches = ["x86_64", "aarch64"]
+version = "1.0.7"

--- a/advisories/1.0.7/BRSA-hyiqpdbm9eve.toml
+++ b/advisories/1.0.7/BRSA-hyiqpdbm9eve.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-hyiqpdbm9eve"
+title = "kernel CVE-2024-50242"
+cve = "CVE-2024-50242"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: fs/ntfs3: Additional check in ntfs_file_release"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[updateinfo]
+author = "agarrcia"
+issue-date = 2025-02-04T18:59:20Z
+arches = ["x86_64", "aarch64"]
+version = "1.0.7"

--- a/advisories/1.0.7/BRSA-ivzwmzklr5el.toml
+++ b/advisories/1.0.7/BRSA-ivzwmzklr5el.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "BRSA-ivzwmzklr5el"
+title = "kernel CVE-2024-50067"
+cve = "CVE-2024-50067"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: uprobe: avoid out-of-bounds memory access of fetching args"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[updateinfo]
+author = "agarrcia"
+issue-date = 2025-02-04T18:59:20Z
+arches = ["aarch64", "x86_64"]
+version = "1.0.7"

--- a/advisories/1.0.7/BRSA-nwdrgeullswh.toml
+++ b/advisories/1.0.7/BRSA-nwdrgeullswh.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-nwdrgeullswh"
+title = "kernel CVE-2024-50246"
+cve = "CVE-2024-50246"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: fs/ntfs3: Add rough attr alloc_size check"
+
+[[advisory.products]]
+package-name = "kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[updateinfo]
+author = "agarrcia"
+issue-date = 2025-02-04T18:59:20Z
+arches = ["aarch64", "x86_64"]
+version = "1.0.7"

--- a/advisories/1.0.7/BRSA-ycnjrulkhn9g.toml
+++ b/advisories/1.0.7/BRSA-ycnjrulkhn9g.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-ycnjrulkhn9g"
+title = "kernel CVE-2024-50143"
+cve = "CVE-2024-50143"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: udf: fix uninit-value use in udf_get_fileshortad"
+
+[[advisory.products]]
+package-name = "kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[updateinfo]
+author = "agarrcia"
+issue-date = 2025-02-04T18:59:20Z
+arches = ["x86_64", "aarch64"]
+version = "1.0.7"


### PR DESCRIPTION
**Description of changes:**

Add BSRA advisories for kernel kit v1.0.7


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
