### PR TITLE
chore: bump twoliter to v0.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ TWOLITER_DIR := $(TOOLS_DIR)/twoliter
 TWOLITER := $(TWOLITER_DIR)/twoliter
 CARGO_HOME := $(TOP).cargo
 
-TWOLITER_VERSION ?= "0.6.0"
-TWOLITER_SHA256_AARCH64 ?= "73a961ff8b9e829b764a86e096b9c2630b452dadc2099f678d57b2146f6a18f9"
-TWOLITER_SHA256_X86_64 ?= "739c5ed0bbd9b0f50ca641964e03b1a92ae9b2c814b1c3463e22f54bc8968e35"
+TWOLITER_VERSION ?= "0.7.2"
+TWOLITER_SHA256_AARCH64 ?= "45fdf25fbc3dc914d1a413aa3a4a87a5569bd17c0f2b7998aa71a03c945842cb"
+TWOLITER_SHA256_X86_64 ?= "cb17a9332a55d83a1cf200711b745d725a6e2b0440ba34e1cbf3d6456d3a0074"
 KIT ?= bottlerocket-kernel-kit
 UNAME_ARCH = $(shell uname -m)
 ARCH ?= $(UNAME_ARCH)
@@ -38,7 +38,7 @@ update: prep
 fetch: prep
 	@$(TWOLITER) fetch --arch $(ARCH)
 
-build: fetch 
+build: fetch
 	@$(TWOLITER) build kit $(KIT) --arch $(ARCH)
 
 publish: prep


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Update twoliter to v0.7.2

**Testing done:**

```bash
make
```

ensured that the right version of twoliter was installed

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
