### PR TITLE
kernel-6.1: update to 6.1.127

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/ca7d1dca05ffe41b3ebcd7e15b4f380d255243c828ba559b79ba71a408d092d6/kernel-6.1.124-134.200.amzn2023.src.rpm"
-sha512 = "7d79d134070f46ba1b0860a3aad77821180f980ea60350e8006c97d3de210c0ca5ed266d8526d37cbbd176247413b4aa7a9f997f679009de79e2f6bc0bed131f"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/212bc04b7ec0b61ac8a1c362021351942740ebd04ed57143d95ef49d335ee37b/kernel-6.1.127-135.201.amzn2023.src.rpm"
+sha512 = "eb6b79d44cb1ad0e35a95ec918f5d238a315d58f392088369be88391f4601e94100c9a897e730ade17f668977cd1ef2dbe348d689448a42d155018cf5f7d409a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]


### PR DESCRIPTION
**Description of changes:**


Rebase to Amazon Linux upstream version 6.1.127-135.201.amzn2023.

Patches are no longer provided by AL with named ordering to apply. Adjust the kernel-6.1.spec file to find patches via the upstream SRPM's spec file.

kernel source tarball now `xz` compressed

**Patch Summary**

here's what a diff of patches looks like, given the naming changes (aka, everything is different!):

<details closed>
<summary> Open for a not so useful diff </summary>

```
Summary for kernel-6.1
Patches that changed:
Patches that were dropped:
0001-mm-memcg-throttle-the-memory-reclaim-given-dirty-wri.patch
0002-Sysfs-memory-probe-interface.patch
0003-arm64-mm-Enable-sysfs-based-memory-hot-remove-probe.patch
0004-memory-fix-offline_and_remove_memory-use.patch
0005-drivers-base-memory-use-MHP_MEMMAP_ON_MEMORY-from-th.patch
0006-mm-add-offline-page-reporting-interface.patch
0007-virtio-add-hack-to-allow-pre-mapped-scatterlists.patch
0008-virtio-balloon-optionally-report-offlined-memory-ran.patch
0009-Introduce-page-touching-DMA-ops-binding.patch
0010-Correct-read-overflow-in-page-touching-DMA-ops-bindi.patch
0011-x86-Disable-KASLR-when-Xen-is-detected.patch
0012-arm64-Export-acpi_psci_use_hvc-symbol.patch
0013-hwrng-Add-Gravition-RNG-driver.patch
0014-drivers-introduce-AMAZON_DRIVER_UPDATES.patch
0015-drivers-amazon-import-5.15-drivers.patch
0016-ENA-Update-to-v2.8.1.patch
0017-EFA-Update-to-v2.1.1.patch
0018-Enable-Algorithims-for-Amazon-Linux-6.1.y.patch
0019-xen-manage-keep-track-of-the-on-going-suspend-mode.patch
0020-xen-manage-introduce-helper-function-to-know-the-on-.patch
0021-xenbus-add-freeze-thaw-restore-callbacks-support.patch
0022-x86-xen-Introduce-new-function-to-map-HYPERVISOR_sha.patch
0023-x86-xen-add-system-core-suspend-and-resume-callbacks.patch
0024-xen-blkfront-add-callbacks-for-PM-suspend-and-hibern.patch
0025-xen-netfront-add-callbacks-for-PM-suspend-and-hibern.patch
0026-xen-time-introduce-xen_-save-restore-steal_clock.patch
0027-x86-xen-save-and-restore-steal-clock.patch
0028-xen-events-add-xen_shutdown_pirqs-helper-function.patch
0029-x86-xen-close-event-channels-for-PIRQs-in-system-cor.patch
0030-PM-hibernate-update-the-resume-offset-on-SNAPSHOT_SE.patch
0031-Revert-xen-dont-fiddle-with-event-channel-masking-in.patch
0032-xen-blkfront-Fixed-blkfront_restore-to-remove-a-call.patch
0033-x86-tsc-avoid-system-instability-in-hibernation.patch
0034-block-xen-blkfront-consider-new-dom0-features-on-res.patch
0035-xen-restore-pirqs-on-resume-from-hibernation.patch
0036-xen-Only-restore-the-ACPI-SCI-interrupt-in-xen_resto.patch
0037-xen-netfront-call-netif_device_attach-on-resume.patch
0038-xen-Restore-xen-pirqs-on-resume-from-hibernation.patch
0039-block-xen-blkfront-bump-the-maximum-number-of-indire.patch
0040-Revert-PCI-MSI-Let-core-code-free-MSI-descriptors.patch
0041-Revert-xen-x2apic-enable-x2apic-mode-when-supported-.patch
0042-msr-disable-MSR-writes-by-default.patch
0043-udp-Fix-memleaks-of-sk-and-zerocopy-skbs-with-TX-tim.patch
0044-ENA-Update-to-v2.8.3.patch
0045-Revert-selinux-runtime-disable-is-deprecated-add-som.patch
0046-AL2023-6.1-Update-ena-driver-to-2.8.6g.patch
0047-objtool-Add-generic-symbol-for-relocation-type.patch
0048-objtool-Specify-host-arch-for-making-LIBSUBCMD.patch
0049-tools-arm64-Make-aarch64-instruction-decoder-availab.patch
0050-objtool-arm64-Add-base-definition-for-arm64-backend.patch
0051-objtool-arm64-Decode-add-sub-instructions.patch
0052-objtool-arm64-Decode-jump-and-call-related-instructi.patch
0053-objtool-arm64-Decode-other-system-instructions.patch
0054-objtool-arm64-Decode-load-store-instructions.patch
0055-objtool-arm64-Decode-LDR-instructions.patch
0056-objtool-arm64-Accept-non-instruction-data-in-code-se.patch
0057-objtool-check-Support-data-in-text-section.patch
0058-objtool-arm64-Handle-supported-relocations-in-altern.patch
0059-objtool-arm64-Ignore-replacement-section-for-alterna.patch
0060-objtool-arm64-Enable-stack-validation-for-arm64.patch
0061-Revert-arm64-alternatives-add-shared-NOP-callback.patch
0062-objtool-arm64-Add-annotate_reachable-for-objtools.patch
0063-arm64-bug-Add-reachable-annotation-to-warning-macros.patch
0064-arm64-kgdb-Add-reachable-annotation-after-kgdb-brk.patch
0065-objtool-arm64-Add-unwind_hint-support.patch
0066-arm64-Change-symbol-type-annotations.patch
0067-arm64-Annotate-unwind_hint-for-symbols-with-empty-st.patch
0068-arm64-entry-Annotate-unwind_hint-for-entry.patch
0069-arm64-kvm-Annotate-unwind_hint-for-hyp-entry.patch
0070-arm64-efi-header-Mark-efi-header-as-data.patch
0071-arm64-head-Mark-constants-as-data.patch
0072-arm64-crypto-Mark-constant-as-data.patch
0073-arm64-crypto-Remove-unnecessary-stackframe.patch
0074-arm64-Set-intra-function-call-annotations.patch
0075-arm64-sleep-Properly-set-frame-pointer-before-call.patch
0076-arm64-entry-Align-stack-size-for-alternative.patch
0077-arm64-kernel-Skip-validation-of-proton-pack.c.patch
0078-arm64-kvm-vgic-v3-sr-Bug-when-trying-to-read-invalid.patch
0079-arm64-Introduce-stack-trace-reliability-checks-in-th.patch
0080-erm64-Create-a-list-of-SYM_CODE-functions-check-retu.patch
0081-arm64-Implement-arch_stack_walk_reliable.patch
0082-arm64-Define-HAVE_DYNAMIC_FTRACE_WITH_ARGS.patch
0083-arm64-implement-live-patching.patch
0084-arm64-module-Use-aarch64_insn_write-when-updating-re.patch
0085-crypto-testmgr-disallow-certain-DRBG-hash-functions-.patch
0086-crypto-testmgr-disallow-plain-cbcmac-aes-in-FIPS-mod.patch
0087-crypto-testmgr-disallow-plain-ghash-in-FIPS-mode.patch
0088-crypto-jitter-replace-LFSR-with-SHA3-256.patch
0089-crypto-testmgr-Remove-xts4096-paes-and-xts512-paes.patch
0090-crypto-ecdh-zeroize-crpytographic-keys-after-use.patch
0091-Revert-drm-fb_helper-improve-CONFIG_FB-dependency.patch
0092-random-Add-hook-to-override-device-reads-and-getrand.patch
0093-crypto-rng-Override-drivers-char-random-in-FIPS-mode.patch
0094-crypto-rsa-allow-only-odd-e-and-restrict-value-in-FI.patch
0095-crypto-Only-allow-GCM-in-FIPS-when-instantiated-via-.patch
0096-crypto-tcrypt.c-Add-selftest-for-ffdhe-algorithims.patch
0097-net-ipv6-Improve-performance-of-inet6_ehashfn.patch
0098-random-allow-reseeding-DRBG-with-getrandom.patch
0099-crypto-rng-Use-a-different-crypto_rng-for-reseeding.patch
0100-crypto-dh-Add-SP800-56A-rev-3-Pair-wise-Consistency-.patch
0101-crypto-ecc-Add-SP800-56A-rev-3-Pair-wise-Consistency.patch
0102-KEYS-use-kfree_sensitive-with-key.patch
0103-mm-add-bdi_set_strict_limit-function.patch
0104-mm-add-knob-sys-class-bdi-bdi-strict_limit.patch
0105-mm-document-sys-class-bdi-bdi-strict_limit-knob.patch
0106-ip-Bump-default-ttl-to-127.patch
0107-Enable-ptIOMMU-for-all-supported-platforms.patch
0108-KEYS-Make-use-of-platform-keyring-for-module-signatu.patch
0109-scripts-sign_file-Add-option-to-keep-signing-certifi.patch
0110-AL2023-6.1-Update-ena-driver-to-2.8.9g.patch
0111-KVM-arm64-Discard-any-SVE-state-when-entering-KVM-gu.patch
0112-arm64-fpsimd-Track-the-saved-FPSIMD-state-type-separ.patch
0113-arm64-fpsimd-Have-KVM-explicitly-say-which-FP-regist.patch
0114-arm64-fpsimd-Stop-using-TIF_SVE-to-manage-register-s.patch
0115-arm64-fpsimd-Load-FP-state-based-on-recorded-data-ty.patch
0116-arm64-fpsimd-SME-no-longer-requires-SVE-register-sta.patch
0117-arm64-sve-Leave-SVE-enabled-on-syscall-if-we-don-t-c.patch
0118-KVM-arm64-Prevent-the-donation-of-no-map-pages.patch
0119-KVM-arm64-Prevent-unconditional-donation-of-unmapped.patch
0120-cgroup-add-cgroup_favordynmods-command-line-option.patch
0121-selftests-bpf-add-generic-BPF-program-tester-loader.patch
0122-selftests-bpf-convert-dynptr_fail-and-map_kptr_fail-.patch
0123-selftests-bpf-convenience-macro-for-use-with-asm-vol.patch
0124-selftests-bpf-Add-dynptr-pruning-tests.patch
0125-selftests-bpf-Add-dynptr-var_off-tests.patch
0126-selftests-bpf-Add-dynptr-partial-slot-overwrite-test.patch
0127-bpf-Refactor-ARG_PTR_TO_DYNPTR-checks-into-process_d.patch
0128-bpf-Propagate-errors-from-process-checks-in-check_f.patch
0129-bpf-Rework-process_dynptr_func.patch
0130-bpf-Rework-check_func_arg_reg_off.patch
0131-bpf-Move-PTR_TO_STACK-alignment-check-to-process_dyn.patch
0132-bpf-Use-memmove-for-bpf_dynptr_-read-write.patch
0133-bpf-Fix-state-pruning-for-STACK_DYNPTR-stack-slots.patch
0134-bpf-Fix-missing-var_off-check-for-ARG_PTR_TO_DYNPTR.patch
0135-bpf-Fix-partial-dynptr-stack-slot-reads-writes.patch
0136-Revert-perf-x86-amd-core-Fix-overflow-reset-on-hotpl.patch
0137-AL2023-6.1-Update-ena-driver-to-2.10.0g.patch
0138-arm64-Add-ID_DFR0_EL1.PerfMon-values-for-PMUv3p7-and.patch
0139-KVM-arm64-PMU-Move-the-ID_AA64DFR0_EL1.PMUver-limit-.patch
0140-KVM-arm64-PMU-Allow-ID_AA64DFR0_EL1.PMUver-to-be-set.patch
0141-KVM-arm64-PMU-Allow-ID_DFR0_EL1.PerfMon-to-be-set-fr.patch
0142-KVM-arm64-Save-ID-registers-sanitized-value-per-gues.patch
0143-KVM-arm64-Use-per-guest-ID-register-for-ID_AA64PFR0_.patch
0144-KVM-arm64-Use-per-guest-ID-register-for-ID_AA64DFR0_.patch
0145-KVM-arm64-Reuse-fields-of-sys_reg_desc-for-idreg.patch
0146-KVM-arm64-Refactor-writings-for-PMUVer-CSV2-CSV3.patch
0147-KVM-arm64-Update-id_reg-limit-value-based-on-per-vcp.patch
0148-KVM-arm64-Move-non-per-vcpu-flag-checks-out-of-kvm_a.patch
0149-KVM-arm64-Enable-writable-for-ID_AA64DFR0_EL1.patch
0150-KVM-arm64-Enable-writable-for-ID_DFR0_EL1.patch
0151-KVM-arm64-Enable-writable-for-ID_AA64PFR0_EL1.patch
0152-KVM-arm64-Enable-writable-for-ID_AA64MMFR-0-1-2-EL1.patch
0153-KVM-arm64-Enable-writable-for-ID_AA64ISAR0_EL0.patch
0154-KVM-arm64-Enable-writable-for-ID_AA64ISAR1_EL0.patch
0155-KVM-arm64-Enable-writable-for-ID_AA64ISAR2_EL0.patch
0156-Revert-objtool-Propagate-early-errors.patch
0157-AL2023-6.1-Compile-ENA-driver-with-PHC-flag.patch
0158-AL2023-6.1-Update-ENA-driver-to-2.11.0g.patch
0159-arm64-pauth-don-t-sign-leaf-functions.patch
0160-AL2023-6.1-Update-ena-driver-to-2.11.1g.patch
0161-AL2023-6.1-Update-EFA-driver-to-2.8.0.patch
0162-Config-glue-for-2.15-Lustre-client.patch
0163-Initial-2.15-Lustre-client-commit.patch
0164-AL2023-6.1-Update-ena-driver-to-2.12.0g.patch
0165-x86-sev-Harden-VC-instruction-emulation-somewhat.patch
0166-firmware-psci-Add-definitions-for-PSCI-v1.3-specific.patch
0167-arm64-Use-SYSTEM_OFF2-PSCI-call-to-power-off-for-hib.patch
0168-ACPICA-Detect-FACS-even-for-hardware-reduced-platfor.patch
0169-arm64-acpi-Honour-firmware_signature-field-of-FACS-i.patch
0170-dma-contiguous-support-per-numa-CMA-for-all-architec.patch
0171-dma-contiguous-support-numa-CMA-for-specified-node.patch
0172-arm64-mm-Don-t-remap-pgtables-per-cont-pte-pmd-block.patch
0173-arm64-mm-Batch-dsb-and-isb-when-populating-pgtables.patch
0174-cifs-use-origin-fullpath-for-automounts.patch
0175-AL2023-6.1-Update-ena-driver-to-2.12.3g.patch
0176-ptp-Add-vDSO-style-vmclock-support.patch
0177-virt-vmgenid-change-implementation-to-use-a-platform.patch
0178-virt-vmgenid-add-support-for-devicetree-bindings.patch
0179-acpi-Support-CONFIG_ACPI-without-CONFIG_PCI.patch
0180-drivers-misc-sysgenid-add-system-generation-id-drive.patch
0181-dma-Automatically-enable-page-touching-on-Caspian.patch
0182-Add-out-of-tree-mpi3mr-8.9.1-driver.patch
0183-scsi-mpi3mr-Sanitise-num_phys.patch
0184-scsi-mpi3mr-Avoid-memcpy-field-spanning-write-WARNIN.patch
0185-bpf-add-mrtt-and-srtt-as-BPF_SOCK_OPS_RTT_CB-args.patch
0186-x86-ioremap-Use-is_ioremap_addr-in-iounmap.patch
0187-AL2023-6.1-Update-ena-driver-to-2.13.0g.patch
0188-AL2023-6.1-Update-lustrefsx-to-2.15.4-fsx7-commit.patch
0189-smb-client-fix-use-after-free-in-smb2_query_info_com.patch
0190-blk-throttle-Fix-io-statistics-for-cgroup-v1.patch
0191-crypto-jitter-add-RCT-APT-support-for-different-OSRs.patch
0192-crypto-jitter-Allow-configuration-of-oversampling-ra.patch
0193-crypto-jitter-set-default-OSR-to-3.patch
0194-Revert-ext4-don-t-set-SB_RDONLY-after-filesystem-err.patch
0195-LU-17887-obd-do-not-update-obd_memory-from-RCU.patch
0196-smb-client-Fix-use-after-free-of-network-namespace.patch
0197-AL2023-6.1-Update-ena-driver-to-2.13.2g.patch
0198-AL2023-6.1-Update-EFA-driver-to-2.13.0.patch
0199-AL2023-6.1-Update-lustrefsx-to-2.15.6-fsx13-commit.patch
Patches that were added:
ACPICA-Detect-FACS-even-for-hardware-reduced-platfor.patch
acpi-Support-CONFIG_ACPI-without-CONFIG_PCI.patch
Add-out-of-tree-mpi3mr-8.9.1-driver.patch
AL2023-6.1-Compile-ENA-driver-with-PHC-flag.patch
AL2023-6.1-Update-EFA-driver-to-2.13.0.patch
AL2023-6.1-Update-EFA-driver-to-2.8.0.patch
AL2023-6.1-Update-ena-driver-to-2.10.0g.patch
AL2023-6.1-Update-ENA-driver-to-2.11.0g.patch
AL2023-6.1-Update-ena-driver-to-2.11.1g.patch
AL2023-6.1-Update-ena-driver-to-2.12.0g.patch
AL2023-6.1-Update-ena-driver-to-2.12.3g.patch
AL2023-6.1-Update-ena-driver-to-2.13.0g.patch
AL2023-6.1-Update-ena-driver-to-2.13.2g.patch
AL2023-6.1-Update-ena-driver-to-2.8.6g.patch
AL2023-6.1-Update-ena-driver-to-2.8.9g.patch
AL2023-6.1-Update-lustrefsx-to-2.15.4-fsx7-commit.patch
AL2023-6.1-Update-lustrefsx-to-2.15.6-fsx13-commit.patch
arm64-acpi-Honour-firmware_signature-field-of-FACS-i.patch
arm64-Add-ID_DFR0_EL1.PerfMon-values-for-PMUv3p7-and.patch
arm64-Annotate-unwind_hint-for-symbols-with-empty-st.patch
arm64-bug-Add-reachable-annotation-to-warning-macros.patch
arm64-Change-symbol-type-annotations.patch
arm64-crypto-Mark-constant-as-data.patch
arm64-crypto-Remove-unnecessary-stackframe.patch
arm64-Define-HAVE_DYNAMIC_FTRACE_WITH_ARGS.patch
arm64-efi-header-Mark-efi-header-as-data.patch
arm64-entry-Align-stack-size-for-alternative.patch
arm64-entry-Annotate-unwind_hint-for-entry.patch
arm64-Export-acpi_psci_use_hvc-symbol.patch
arm64-fpsimd-Have-KVM-explicitly-say-which-FP-regist.patch
arm64-fpsimd-Load-FP-state-based-on-recorded-data-ty.patch
arm64-fpsimd-SME-no-longer-requires-SVE-register-sta.patch
arm64-fpsimd-Stop-using-TIF_SVE-to-manage-register-s.patch
arm64-fpsimd-Track-the-saved-FPSIMD-state-type-separ.patch
arm64-head-Mark-constants-as-data.patch
arm64-Implement-arch_stack_walk_reliable.patch
arm64-implement-live-patching.patch
arm64-Introduce-stack-trace-reliability-checks-in-th.patch
arm64-kernel-Skip-validation-of-proton-pack.c.patch
arm64-kgdb-Add-reachable-annotation-after-kgdb-brk.patch
arm64-kvm-Annotate-unwind_hint-for-hyp-entry.patch
arm64-kvm-vgic-v3-sr-Bug-when-trying-to-read-invalid.patch
arm64-mm-Batch-dsb-and-isb-when-populating-pgtables.patch
arm64-mm-Don-t-remap-pgtables-per-cont-pte-pmd-block.patch
arm64-mm-Enable-sysfs-based-memory-hot-remove-probe.patch
arm64-module-Use-aarch64_insn_write-when-updating-re.patch
arm64-pauth-don-t-sign-leaf-functions.patch
arm64-Set-intra-function-call-annotations.patch
arm64-sleep-Properly-set-frame-pointer-before-call.patch
arm64-sve-Leave-SVE-enabled-on-syscall-if-we-don-t-c.patch
arm64-Use-SYSTEM_OFF2-PSCI-call-to-power-off-for-hib.patch
blk-throttle-Fix-io-statistics-for-cgroup-v1.patch
block-xen-blkfront-bump-the-maximum-number-of-indire.patch
block-xen-blkfront-consider-new-dom0-features-on-res.patch
bpf-add-mrtt-and-srtt-as-BPF_SOCK_OPS_RTT_CB-args.patch
bpf-Fix-missing-var_off-check-for-ARG_PTR_TO_DYNPTR.patch
bpf-Fix-partial-dynptr-stack-slot-reads-writes.patch
bpf-Fix-state-pruning-for-STACK_DYNPTR-stack-slots.patch
bpf-Move-PTR_TO_STACK-alignment-check-to-process_dyn.patch
bpf-Propagate-errors-from-process-checks-in-check_f.patch
bpf-Refactor-ARG_PTR_TO_DYNPTR-checks-into-process_d.patch
bpf-Rework-check_func_arg_reg_off.patch
bpf-Rework-process_dynptr_func.patch
bpf-Use-memmove-for-bpf_dynptr_-read-write.patch
cgroup-add-cgroup_favordynmods-command-line-option.patch
cifs-use-origin-fullpath-for-automounts.patch
Config-glue-for-2.15-Lustre-client.patch
Correct-read-overflow-in-page-touching-DMA-ops-bindi.patch
crypto-dh-Add-SP800-56A-rev-3-Pair-wise-Consistency-.patch
crypto-ecc-Add-SP800-56A-rev-3-Pair-wise-Consistency.patch
crypto-ecdh-zeroize-crpytographic-keys-after-use.patch
crypto-jitter-add-RCT-APT-support-for-different-OSRs.patch
crypto-jitter-Allow-configuration-of-oversampling-ra.patch
crypto-jitter-replace-LFSR-with-SHA3-256.patch
crypto-jitter-set-default-OSR-to-3.patch
crypto-Only-allow-GCM-in-FIPS-when-instantiated-via-.patch
crypto-rng-Override-drivers-char-random-in-FIPS-mode.patch
crypto-rng-Use-a-different-crypto_rng-for-reseeding.patch
crypto-rsa-allow-only-odd-e-and-restrict-value-in-FI.patch
crypto-tcrypt.c-Add-selftest-for-ffdhe-algorithims.patch
crypto-testmgr-disallow-certain-DRBG-hash-functions-.patch
crypto-testmgr-disallow-plain-cbcmac-aes-in-FIPS-mod.patch
crypto-testmgr-disallow-plain-ghash-in-FIPS-mode.patch
crypto-testmgr-Remove-xts4096-paes-and-xts512-paes.patch
dma-Automatically-enable-page-touching-on-Caspian.patch
dma-contiguous-support-numa-CMA-for-specified-node.patch
dma-contiguous-support-per-numa-CMA-for-all-architec.patch
drivers-amazon-import-5.15-drivers.patch
drivers-base-memory-use-MHP_MEMMAP_ON_MEMORY-from-th.patch
drivers-introduce-AMAZON_DRIVER_UPDATES.patch
drivers-misc-sysgenid-add-system-generation-id-drive.patch
EFA-Update-to-v2.1.1.patch
Enable-Algorithims-for-Amazon-Linux-6.1.y.patch
Enable-ptIOMMU-for-all-supported-platforms.patch
ENA-Update-to-v2.8.1.patch
ENA-Update-to-v2.8.3.patch
erm64-Create-a-list-of-SYM_CODE-functions-check-retu.patch
firmware-psci-Add-definitions-for-PSCI-v1.3-specific.patch
fs-ntfs3-Add-rough-attr-alloc_size-check.patch
hwrng-Add-Gravition-RNG-driver.patch
Initial-2.15-Lustre-client-commit.patch
Introduce-page-touching-DMA-ops-binding.patch
ip-Bump-default-ttl-to-127.patch
KEYS-Make-use-of-platform-keyring-for-module-signatu.patch
KEYS-use-kfree_sensitive-with-key.patch
KVM-arm64-Discard-any-SVE-state-when-entering-KVM-gu.patch
KVM-arm64-Enable-writable-for-ID_AA64DFR0_EL1.patch
KVM-arm64-Enable-writable-for-ID_AA64ISAR0_EL0.patch
KVM-arm64-Enable-writable-for-ID_AA64ISAR1_EL0.patch
KVM-arm64-Enable-writable-for-ID_AA64ISAR2_EL0.patch
KVM-arm64-Enable-writable-for-ID_AA64MMFR-0-1-2-EL1.patch
KVM-arm64-Enable-writable-for-ID_AA64PFR0_EL1.patch
KVM-arm64-Enable-writable-for-ID_DFR0_EL1.patch
KVM-arm64-Move-non-per-vcpu-flag-checks-out-of-kvm_a.patch
KVM-arm64-PMU-Allow-ID_AA64DFR0_EL1.PMUver-to-be-set.patch
KVM-arm64-PMU-Allow-ID_DFR0_EL1.PerfMon-to-be-set-fr.patch
KVM-arm64-PMU-Move-the-ID_AA64DFR0_EL1.PMUver-limit-.patch
KVM-arm64-Prevent-the-donation-of-no-map-pages.patch
KVM-arm64-Prevent-unconditional-donation-of-unmapped.patch
KVM-arm64-Refactor-writings-for-PMUVer-CSV2-CSV3.patch
KVM-arm64-Reuse-fields-of-sys_reg_desc-for-idreg.patch
KVM-arm64-Save-ID-registers-sanitized-value-per-gues.patch
KVM-arm64-Update-id_reg-limit-value-based-on-per-vcp.patch
KVM-arm64-Use-per-guest-ID-register-for-ID_AA64DFR0.patch
KVM-arm64-Use-per-guest-ID-register-for-ID_AA64PFR0_.patch
LU-17887-obd-do-not-update-obd_memory-from-RCU.patch
memory-fix-offline_and_remove_memory-use.patch
mm-add-bdi_set_strict_limit-function.patch
mm-add-knob-sys-class-bdi-bdi-strict_limit.patch
mm-add-offline-page-reporting-interface.patch
mm-document-sys-class-bdi-bdi-strict_limit-knob.patch
mm-memcg-throttle-the-memory-reclaim-given-dirty-wri.patch
msr-disable-MSR-writes-by-default.patch
net-ipv6-Improve-performance-of-inet6_ehashfn.patch
objtool-Add-generic-symbol-for-relocation-type.patch
objtool-arm64-Accept-non-instruction-data-in-code-se.patch
objtool-arm64-Add-annotate_reachable-for-objtools.patch
objtool-arm64-Add-base-definition-for-arm64-backend.patch
objtool-arm64-Add-unwind_hint-support.patch
objtool-arm64-Decode-add-sub-instructions.patch
objtool-arm64-Decode-jump-and-call-related-instructi.patch
objtool-arm64-Decode-LDR-instructions.patch
objtool-arm64-Decode-load-store-instructions.patch
objtool-arm64-Decode-other-system-instructions.patch
objtool-arm64-Enable-stack-validation-for-arm64.patch
objtool-arm64-Handle-supported-relocations-in-altern.patch
objtool-arm64-Ignore-replacement-section-for-alterna.patch
objtool-check-Support-data-in-text-section.patch
objtool-Specify-host-arch-for-making-LIBSUBCMD.patch
PM-hibernate-update-the-resume-offset-on-SNAPSHOT_SE.patch
ptp-Add-vDSO-style-vmclock-support.patch
random-Add-hook-to-override-device-reads-and-getrand.patch
random-allow-reseeding-DRBG-with-getrandom.patch
Revert-arm64-alternatives-add-shared-NOP-callback.patch
Revert-drm-fb_helper-improve-CONFIG_FB-dependency.patch
Revert-ext4-don-t-set-SB_RDONLY-after-filesystem-err.patch
Revert-objtool-Propagate-early-errors.patch
Revert-PCI-MSI-Let-core-code-free-MSI-descriptors.patch
Revert-perf-x86-amd-core-Fix-overflow-reset-on-hotpl.patch
Revert-selinux-runtime-disable-is-deprecated-add-som.patch
Revert-xen-dont-fiddle-with-event-channel-masking-in.patch
Revert-xen-x2apic-enable-x2apic-mode-when-supported-.patch
scripts-sign_file-Add-option-to-keep-signing-certifi.patch
scsi-mpi3mr-Avoid-memcpy-field-spanning-write-WARNIN.patch
scsi-mpi3mr-Sanitise-num_phys.patch
selftests-bpf-Add-dynptr-partial-slot-overwrite-test.patch
selftests-bpf-Add-dynptr-pruning-tests.patch
selftests-bpf-Add-dynptr-var_off-tests.patch
selftests-bpf-add-generic-BPF-program-tester-loader.patch
selftests-bpf-convenience-macro-for-use-with-asm-vol.patch
selftests-bpf-convert-dynptr_fail-and-map_kptr_fail-.patch
smb-client-fix-use-after-free-in-smb2_query_info_com.patch
smb-client-Fix-use-after-free-of-network-namespace.patch
Sysfs-memory-probe-interface.patch
tools-arm64-Make-aarch64-instruction-decoder-availab.patch
udp-Fix-memleaks-of-sk-and-zerocopy-skbs-with-TX-tim.patch
virtio-add-hack-to-allow-pre-mapped-scatterlists.patch
virtio-balloon-optionally-report-offlined-memory-ran.patch
virt-vmgenid-add-support-for-devicetree-bindings.patch
virt-vmgenid-change-implementation-to-use-a-platform.patch
x86-Disable-KASLR-when-Xen-is-detected.patch
x86-ioremap-Use-is_ioremap_addr-in-iounmap.patch
x86-sev-Harden-VC-instruction-emulation-somewhat.patch
x86-tsc-avoid-system-instability-in-hibernation.patch
x86-xen-add-system-core-suspend-and-resume-callbacks.patch
x86-xen-close-event-channels-for-PIRQs-in-system-cor.patch
x86-xen-Introduce-new-function-to-map-HYPERVISOR_sha.patch
x86-xen-save-and-restore-steal-clock.patch
xen-blkfront-add-callbacks-for-PM-suspend-and-hibern.patch
xen-blkfront-Fixed-blkfront_restore-to-remove-a-call.patch
xenbus-add-freeze-thaw-restore-callbacks-support.patch
xen-events-add-xen_shutdown_pirqs-helper-function.patch
xen-manage-introduce-helper-function-to-know-the-on-.patch
xen-manage-keep-track-of-the-on-going-suspend-mode.patch
xen-netfront-add-callbacks-for-PM-suspend-and-hibern.patch
xen-netfront-call-netif_device_attach-on-resume.patch
xen-Only-restore-the-ACPI-SCI-interrupt-in-xen_resto.patch
xen-restore-pirqs-on-resume-from-hibernation.patch
xen-Restore-xen-pirqs-on-resume-from-hibernation.patch
xen-time-introduce-xen_-save-restore-_steal_clock.patch
```

</details>


The real diff
```
Patches that were changed:
Patches that were added:
fs-ntfs3-Add-rough-attr-alloc_size-check.patch
Patches that were dropped
```

Obtained by trimming numbers from original patch file names and diffing with the ordered list of patches included in `6.1.127-135.201.amzn2023.src.rpm`

**Config changes**

None. Diff is showing differences in `CONFIG_EXTRA_FIRMWARE` but that's due to missing #28 in previous release

<details>

```
< # Linux/arm64 6.1.124 Kernel Configuration
---                                                                                                                                                                                        > # Linux/arm64 6.1.127 Kernel Configuration                                                                                                                                               diff --color ../current-latest/config-6.1-x86_64.config ../updated-configs/config-6.1-x86_64.config                                                                                        3c3
< # Linux/x86 6.1.124 Kernel Configuration
---
> # Linux/x86 6.1.127 Kernel Configuration
1888c1888
< CONFIG_EXTRA_FIRMWARE="intel-ucode/06-ba-03 intel-ucode/06-08-01 intel-ucode/06-17-07 intel-ucode/06-2f-02 intel-ucode/06-3e-04 intel-ucode/06-25-02 intel-ucode/06-4c-04 intel-ucode/06-5c-02 intel-ucode/06-5e-03 intel-ucode/0f-06-08 intel-ucode/06-25-05 intel-ucode/06-0b-01 intel-ucode/06-8f-06 intel-ucode/06-0f-0b intel-ucode/0f-02-05 intel-ucode/06-8e-0c intel-ucode/06-97-05 intel-ucode/0f-04-0a intel-ucode/0f-02-07 intel-ucode/06-a5-05 intel-ucode/06-aa-04 intel-ucode/06-0f-06 intel-ucode/06-9e-0d intel-ucode/0f-02-06 intel-ucode/06-0d-06 intel-ucode/06-0e-0c intel-ucode/06-7a-01 intel-ucode/06-05-02 intel-ucode/06-56-04 intel-ucode/06-9c-00 intel-ucode/0f-03-03 intel-ucode/06-8e-09 intel-ucode/06-be-00 intel-ucode/0f-04-07 intel-ucode/06-9e-0a intel-ucode/0f-06-05 intel-ucode/06-55-0b intel-ucode/06-8f-05 intel-ucode/06-3d-04 intel-ucode/06-0f-07 intel-ucode/06-08-0a intel-ucode/06-b7-01 intel-ucode/06-17-06 intel-ucode/06-97-02 intel-ucode/06-a5-03 intel-ucode/06-07-03 intel-ucode/06-8c-01 intel-ucode/0f-06-02 intel-ucode/06-55-05 intel-ucode/06-3f-02 intel-ucode/06-66-03 intel-ucode/06-2c-02 intel-ucode/06-55-04 intel-ucode/06-55-07 intel-ucode/06-3e-07 intel-ucode/0f-03-02 intel-ucode/06-07-02 intel-ucode/06-bf-02 intel-ucode/0f-02-09 intel-ucode/06-9e-0c intel-ucode/06-8c-02 intel-ucode/06-9a-03 intel-ucode/06-ba-02 intel-ucode/06-3f-04 intel-ucode/06-1a-04 intel-ucode/06-45-01 intel-ucode/06-0b-04 intel-ucode/06-8e-0b intel-ucode/0f-04-09 intel-ucode/0f-06-04 intel-ucode/06-2d-06 intel-ucode/06-4e-03 intel-ucode/06-0f-0d intel-ucode/06-08-06 intel-ucode/06-37-08 intel-ucode/06-ba-08 intel-ucode/06-56-03 intel-ucode/06-06-05 intel-ucode/06-5c-0a intel-ucode/06-9a-04 intel-ucode/06-2e-06 intel-ucode/06-4d-08 intel-ucode/06-05-00 intel-ucode/06-06-00 intel-ucode/06-56-02 intel-ucode/06-8f-08 intel-ucode/06-05-03 intel-ucode/0f-02-04 intel-ucode/06-a6-01 intel-ucode/0f-00-07 intel-ucode/06-3a-09 intel-ucode/0f-04-01 intel-ucode/06-9e-0b intel-ucode/06-a7-01 intel-ucode/06-46-01 intel-ucode/06-cf-01 intel-ucode/06-7a-08 intel-ucode/06-4f-01 intel-ucode/0f-03-04 intel-ucode/06-5c-09 intel-ucode/06-0e-08 intel-ucode/06-0f-0a intel-ucode/06-17-0a intel-ucode/06-8f-07 intel-ucode/06-26-01 intel-ucode/06-0a-00 intel-ucode/06-96-01 intel-ucode/06-37-09 intel-ucode/06-7e-05 intel-ucode/0f-00-0a intel-ucode/06-6c-01 intel-ucode/06-1a-05 intel-ucode/06-1c-02 intel-ucode/06-a6-00 intel-ucode/06-3c-03 intel-ucode/06-0a-01 intel-ucode/06-bf-05 intel-ucode/06-03-02 intel-ucode/0f-04-08 intel-ucode/06-0f-02 intel-ucode/06-1c-0a intel-ucode/0f-01-02 intel-ucode/06-2d-07 intel-ucode/06-55-03 intel-ucode/06-56-05 intel-ucode/06-06-0d intel-ucode/06-9e-09 intel-ucode/06-2a-07 intel-ucode/06-5f-01 intel-ucode/06-4c-03 intel-ucode/06-1e-05 intel-ucode/0f-04-04 intel-ucode/06-8e-0a intel-ucode/06-06-0a intel-ucode/06-05-01 intel-ucode/06-1d-01 intel-ucode/06-08-03 intel-ucode/06-6a-05 intel-ucode/06-55-06 intel-ucode/06-16-01 intel-ucode/06-3e-06 intel-ucode/06-07-01 intel-ucode/06-6a-06 intel-ucode/06-09-05 intel-ucode/06-cf-02 intel-ucode/06-8a-01 intel-ucode/0f-04-03 intel-ucode/06-a5-02 intel-ucode/06-8d-01 intel-ucode/06-47-01 amd-ucode/microcode_amd_fam17h.bin amd-ucode/microcode_amd_fam19h.bin amd-ucode/microcode_amd_fam15h.bin amd-ucode/microcode_amd_fam16h.bin amd-ucode/microcode_amd.bin "
---
> CONFIG_EXTRA_FIRMWARE="amd-ucode/microcode_amd.bin amd-ucode/microcode_amd_fam15h.bin amd-ucode/microcode_amd_fam16h.bin amd-ucode/microcode_amd_fam17h.bin amd-ucode/microcode_amd_fam19h.bin intel-ucode/06-03-02 intel-ucode/06-05-00 intel-ucode/06-05-01 intel-ucode/06-05-02 intel-ucode/06-05-03 intel-ucode/06-06-00 intel-ucode/06-06-05 intel-ucode/06-06-0a intel-ucode/06-06-0d intel-ucode/06-07-01 intel-ucode/06-07-02 intel-ucode/06-07-03 intel-ucode/06-08-01 intel-ucode/06-08-03 intel-ucode/06-08-06 intel-ucode/06-08-0a intel-ucode/06-09-05 intel-ucode/06-0a-00 intel-ucode/06-0a-01 intel-ucode/06-0b-01 intel-ucode/06-0b-04 intel-ucode/06-0d-06 intel-ucode/06-0e-08 intel-ucode/06-0e-0c intel-ucode/06-0f-02 intel-ucode/06-0f-06 intel-ucode/06-0f-07 intel-ucode/06-0f-0a intel-ucode/06-0f-0b intel-ucode/06-0f-0d intel-ucode/06-16-01 intel-ucode/06-17-06 intel-ucode/06-17-07 intel-ucode/06-17-0a intel-ucode/06-1a-04 intel-ucode/06-1a-05 intel-ucode/06-1c-02 intel-ucode/06-1c-0a intel-ucode/06-1d-01 intel-ucode/06-1e-05 intel-ucode/06-25-02 intel-ucode/06-25-05 intel-ucode/06-26-01 intel-ucode/06-2a-07 intel-ucode/06-2c-02 intel-ucode/06-2d-06 intel-ucode/06-2d-07 intel-ucode/06-2e-06 intel-ucode/06-2f-02 intel-ucode/06-37-08 intel-ucode/06-37-09 intel-ucode/06-3a-09 intel-ucode/06-3c-03 intel-ucode/06-3d-04 intel-ucode/06-3e-04 intel-ucode/06-3e-06 intel-ucode/06-3e-07 intel-ucode/06-3f-02 intel-ucode/06-3f-04 intel-ucode/06-45-01 intel-ucode/06-46-01 intel-ucode/06-47-01 intel-ucode/06-4c-03 intel-ucode/06-4c-04 intel-ucode/06-4d-08 intel-ucode/06-4e-03 intel-ucode/06-4f-01 intel-ucode/06-55-03 intel-ucode/06-55-04 intel-ucode/06-55-05 intel-ucode/06-55-06 intel-ucode/06-55-07 intel-ucode/06-55-0b intel-ucode/06-56-02 intel-ucode/06-56-03 intel-ucode/06-56-04 intel-ucode/06-56-05 intel-ucode/06-5c-02 intel-ucode/06-5c-09 intel-ucode/06-5c-0a intel-ucode/06-5e-03 intel-ucode/06-5f-01 intel-ucode/06-66-03 intel-ucode/06-6a-05 intel-ucode/06-6a-06 intel-ucode/06-6c-01 intel-ucode/06-7a-01 intel-ucode/06-7a-08 intel-ucode/06-7e-05 intel-ucode/06-8a-01 intel-ucode/06-8c-01 intel-ucode/06-8c-02 intel-ucode/06-8d-01 intel-ucode/06-8e-09 intel-ucode/06-8e-0a intel-ucode/06-8e-0b intel-ucode/06-8e-0c intel-ucode/06-8f-05 intel-ucode/06-8f-06 intel-ucode/06-8f-07 intel-ucode/06-8f-08 intel-ucode/06-96-01 intel-ucode/06-97-02 intel-ucode/06-97-05 intel-ucode/06-9a-03 intel-ucode/06-9a-04 intel-ucode/06-9c-00 intel-ucode/06-9e-09 intel-ucode/06-9e-0a intel-ucode/06-9e-0b intel-ucode/06-9e-0c intel-ucode/06-9e-0d intel-ucode/06-a5-02 intel-ucode/06-a5-03 intel-ucode/06-a5-05 intel-ucode/06-a6-00 intel-ucode/06-a6-01 intel-ucode/06-a7-01 intel-ucode/06-aa-04 intel-ucode/06-b7-01 intel-ucode/06-ba-02 intel-ucode/06-ba-03 intel-ucode/06-ba-08 intel-ucode/06-be-00 intel-ucode/06-bf-02 intel-ucode/06-bf-05 intel-ucode/06-cf-01 intel-ucode/06-cf-02 intel-ucode/0f-00-07 intel-ucode/0f-00-0a intel-ucode/0f-01-02 intel-ucode/0f-02-04 intel-ucode/0f-02-05 intel-ucode/0f-02-06 intel-ucode/0f-02-07 intel-ucode/0f-02-09 intel-ucode/0f-03-02 intel-ucode/0f-03-03 intel-ucode/0f-03-04 intel-ucode/0f-04-01 intel-ucode/0f-04-03 intel-ucode/0f-04-04 intel-ucode/0f-04-07 intel-ucode/0f-04-08 intel-ucode/0f-04-09 intel-ucode/0f-04-0a intel-ucode/0f-06-02 intel-ucode/0f-06-04 intel-ucode/0f-06-05 intel-ucode/0f-06-08 "
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
