### PR TITLE
kernels: find and sort upstream patches based on spec definitions 

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -107,12 +107,16 @@ Summary: Header files for the Linux kernel for use by glibc
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch"
+rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch" kernel.spec
 tar -xof linux-%{version}.tar; rm linux-%{version}.tar
+# Find patch ordering based on the Source0 kernel.spec file from the SRPM.
+# First, find all `PatchNNN` lines. Then, sort by the patch number (-k1.6 in sort sets the 6th char
+# in field 1 of input as the sort parameter). Finally, capture just the patch file name specified.
+readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)
 %setup -TDn linux-%{version}
 # Patches from the Source0 SRPM
-for patch in ../*.patch; do
-    patch -p1 <"$patch"
+for patch in ${patches[@]}; do
+    patch -p1 <../"$patch"
 done
 # Patches listed in this spec (Patch0001...)
 %autopatch -p1

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -174,10 +174,10 @@ rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar.xz config-%{_cross_arch} "*.patch" kernel.spec
 tar -xof linux-%{version}.tar.xz; rm linux-%{version}.tar.xz
-# In kernel-6.1.127-135.20.amzn2023.src.rpm, provided patches are no longer numbered.
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.
-# This regex assumes the "PatchNNN: x-x.patch" lines in the upstream spec are ordered.
-readarray -t patches < <(grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)
+# First, find all `PatchNNN` lines. Then, sort by the patch number (-k1.6 in sort sets the 6th char
+# in field 1 of input as the sort parameter). Finally, capture just the patch file name specified.
+readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)
 %setup -TDn linux-%{version}
 # Patches from the Source0 SRPM
 for patch in ${patches[@]}; do


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #39 

**Description of changes:**

Instead of relying on patch files vended by the upstream to be numerically ordered, find patch files from the upstream spec file for a respective package and sort based on patch number to apply patches in order.

**Testing done:**

`make` for both architectures

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
