### PR TITLE
Fix 5.15 kernel spec file

### DIFF
--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -109,10 +109,18 @@ rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch" kernel.spec
 tar -xof linux-%{version}.tar; rm linux-%{version}.tar
+# Count all the patches extracted from the SRPM
+patches_count=$(find -name "*.patch" | wc -l)
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.
 # First, find all `PatchNNN` lines. Then, sort by the patch number (-k1.6 in sort sets the 6th char
 # in field 1 of input as the sort parameter). Finally, capture just the patch file name specified.
 readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)
+# Fail the build if there is a mismatch in the number of patches found
+if [[ "${patches_count}" -ne "${#patches[@]}" ]]; then
+  echo "Mismatch on patches count!"
+  exit 1
+fi
+
 %setup -TDn linux-%{version}
 # Patches from the Source0 SRPM
 for patch in ${patches[@]}; do

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -102,12 +102,20 @@ Summary: Header files for the Linux kernel for use by glibc
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch"
+rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch" kernel.spec
 tar -xof linux-%{version}.tar; rm linux-%{version}.tar
+# Count all the patches extracted from the SRPM
+patches_count=$(find -name "*.patch" | wc -l)
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.
 # First, find all `PatchNNN` lines. Then, sort by the patch number (-k1.6 in sort sets the 6th char
 # in field 1 of input as the sort parameter). Finally, capture just the patch file name specified.
 readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)
+# Fail the build if there is a mismatch in the number of patches found
+if [[ "${patches_count}" -ne "${#patches[@]}" ]]; then
+  echo "Mismatch on patches count!"
+  exit 1
+fi
+
 %setup -TDn linux-%{version}
 # Patches from the Source0 SRPM
 for patch in ${patches[@]}; do


### PR DESCRIPTION
**Issue number:**

Closes #42

**Description of changes:**

In 5b853d34 the 5.15 kernel spec file was not updated to extract the kernel.spec file from the SRPM, preventing the patches from being applied


**Testing done:**

I built the kernel kit without the change and confirmed the list of patches returned by the `grep` command was empty due to the missing `kernel.spec` file. With this change, the list isn't empty and the patches are applied.

For the patch count heuristic, I removed `kernel.spec` from each kernel spec file and confirmed the build fail with the message `Mismatch on patches count!`.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
