### PR TITLE
tools: use ECR for image source in latest-kernel-srpm-url.sh

### DIFF
--- a/packages/kernel-5.10/latest-kernel-srpm-url.sh
+++ b/packages/kernel-5.10/latest-kernel-srpm-url.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm amazonlinux:2 sh -c 'amazon-linux-extras enable kernel-5.10 >/dev/null && yum install -q -y yum-utils && yumdownloader -q --source --urls kernel | grep ^http'
+docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2 sh -c 'amazon-linux-extras enable kernel-5.10 >/dev/null && yum install -q -y yum-utils && yumdownloader -q --source --urls kernel | grep ^http'

--- a/packages/kernel-5.15/latest-kernel-srpm-url.sh
+++ b/packages/kernel-5.15/latest-kernel-srpm-url.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm amazonlinux:2 sh -c 'amazon-linux-extras enable kernel-5.15 >/dev/null && yum install -q -y yum-utils && yumdownloader -q --source --urls kernel | grep ^http'
+docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2 sh -c 'amazon-linux-extras enable kernel-5.15 >/dev/null && yum install -q -y yum-utils && yumdownloader -q --source --urls kernel | grep ^http'

--- a/packages/kernel-6.1/latest-kernel-srpm-url.sh
+++ b/packages/kernel-6.1/latest-kernel-srpm-url.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cmd='dnf install -q -y --releasever=latest yum-utils && yumdownloader -q --releasever=latest --source --urls kernel'
-docker run --rm amazonlinux:2023 sh -c "${cmd}" \
+docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2023 sh -c "${cmd}" \
     | grep '^http' \
     | xargs --max-args=1 --no-run-if-empty realpath --canonicalize-missing --relative-to=. \
     | sed 's_:/_://_'


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Use public ECR image for amazonlinux in `latest-kernel-srpm-url.sh` to avoid Docker rate limiting


**Testing done:**

* Ran the `latest-kernel-srpm-url.sh` command locally for all 3 kernel packages


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
