### PR TITLE
kernel-5.10: use SHA-512 for module signing

### DIFF
--- a/packages/kernel-5.10/config-bottlerocket
+++ b/packages/kernel-5.10/config-bottlerocket
@@ -58,6 +58,13 @@ CONFIG_SECURITY_LOCKDOWN_LSM=y
 # kernel command line, it can be enforced.
 CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y
 
+# Use SHA-512 for module signing.
+# CONFIG_MODULE_SIG_SHA1 is not set
+# CONFIG_MODULE_SIG_SHA224 is not set
+# CONFIG_MODULE_SIG_SHA256 is not set
+# CONFIG_MODULE_SIG_SHA384 is not set
+CONFIG_MODULE_SIG_SHA512=y
+
 # Enable zstd compression for squashfs.
 CONFIG_SQUASHFS_ZSTD=y
 


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/244

**Description of changes:**
Use SHA-512 rather than SHA-1 for signing the 5.10 kernel's modules.

Otherwise, the build fails on newer versions of the SDK if the underlying distro has disabled SHA-1, as Fedora 41 has.


**Testing done:**
Built `aws-dev` with the 5.10 kernel, verified that kernel modules loaded.

```
# diff-summary
config-aarch64-5.10-diff:         0 removed,   0 added,   3 changed
config-x86_64-5.10-diff:          0 removed,   0 added,   0 changed

# diff-report
==> config-aarch64-5.10-diff <==
 MODULE_SIG_HASH "sha1" -> "sha512"
 MODULE_SIG_SHA1 y -> n
 MODULE_SIG_SHA512 n -> y

==> config-x86_64-5.10-diff <==
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
