### PR TITLE
prepare for SDK update

### DIFF
--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -101,10 +101,10 @@ Summary: Tools for the bootloader with support for Linux and more
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu grub-%{version}.tar.xz \
-  bootstrap bootstrap.conf \
-  gitignore %{gnulib_version}.tar.gz \
-  "*.patch"
+rpm2cpio %{S:0} | cpio -iu {,./}grub-%{version}.tar.xz \
+  {,./}bootstrap {,./}bootstrap.conf \
+  {,./}gitignore {,./}%{gnulib_version}.tar.gz \
+  {,./}"*.patch"
 
 # Mimic prep from upstream spec to prepare for patching.
 tar -xof grub-%{version}.tar.xz; rm grub-%{version}.tar.xz

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -107,7 +107,7 @@ Summary: Header files for the Linux kernel for use by glibc
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch" kernel.spec
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
 tar -xof linux-%{version}.tar; rm linux-%{version}.tar
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -102,7 +102,7 @@ Summary: Header files for the Linux kernel for use by glibc
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar config-%{_cross_arch} "*.patch" kernel.spec
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
 tar -xof linux-%{version}.tar; rm linux-%{version}.tar
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -172,7 +172,7 @@ Conflicts: %{_cross_os}image-feature(no-fips)
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu linux-%{version}.tar.xz config-%{_cross_arch} "*.patch" kernel.spec
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar.xz {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
 tar -xof linux-%{version}.tar.xz; rm linux-%{version}.tar.xz
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -467,7 +467,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/modules.builtin.alias.bin
 %{_cross_kmoddir}/modules.builtin.bin
 %{_cross_kmoddir}/modules.builtin.modinfo
-%{_cross_kmoddir}/modules.dep
+%{_cross_kmoddir}/modules.*dep
 %{_cross_kmoddir}/modules.dep.bin
 %{_cross_kmoddir}/modules.devname
 %{_cross_kmoddir}/modules.order

--- a/packages/libkcapi/libkcapi.spec
+++ b/packages/libkcapi/libkcapi.spec
@@ -40,7 +40,7 @@ Requires: %{name}
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu libkcapi-%{version}.tar.xz
+rpm2cpio %{S:0} | cpio -iu {,./}libkcapi-%{version}.tar.xz
 tar -xof libkcapi-%{version}.tar.xz; rm libkcapi-%{version}.tar.xz
 %setup -TDn libkcapi-%{version}
 


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/244

**Description of changes:**
Update all of the `rpm2cpio | cpio -iu` pipelines to account for the new `rpm2cpio` behavior of prefixing files in the archive with `./`, and let the kernel 6.1 package include a potential `modules.weakdep` file that the new `kmod` creates.

**Testing done:**
Built the kernel kit with and without the newer SDKs.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
