### PR TITLE
Move L4 and L40S cards to open gpu

### DIFF
--- a/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
+++ b/packages/kmod-5.10-nvidia/kmod-5.10-nvidia.spec
@@ -162,16 +162,12 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 # 10de:1eb8 is T4 (G4dn)
 # 10de:1eb4 is T4G (G5g)
 # 10de:2237 is A10G (G5)
-# 10de:27b8 is L4 (G6)
-# 10de:26b9 is L40S (G6e)
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
 and .devid != "0x1DEB8"
 and .devid != "0x1EB4"
-and .devid != "0x2237"
-and .devid != "0x27B8"
-and .devid != "0x26B9")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
+and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
 popd

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -162,16 +162,12 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 # 10de:1eb8 is T4 (G4dn)
 # 10de:1eb4 is T4G (G5g)
 # 10de:2237 is A10G (G5)
-# 10de:27b8 is L4 (G6)
-# 10de:26b9 is L40S (G6e)
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
 and .devid != "0x1DEB8"
 and .devid != "0x1EB4"
-and .devid != "0x2237"
-and .devid != "0x27B8"
-and .devid != "0x26B9")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
+and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
 popd

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -162,16 +162,12 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 # 10de:1eb8 is T4 (G4dn)
 # 10de:1eb4 is T4G (G5g)
 # 10de:2237 is A10G (G5)
-# 10de:27b8 is L4 (G6)
-# 10de:26b9 is L40S (G6e)
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
 and .devid != "0x1DEB8"
 and .devid != "0x1EB4"
-and .devid != "0x2237"
-and .devid != "0x27B8"
-and .devid != "0x26B9")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
+and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
 popd


### PR DESCRIPTION
**Description of changes:**
This removes the L4 and L40S cards from the list holding them back to the proprietary driver. Now G6 EC2 instances will use the open gpu driver.


**Testing done:**
Built an AMI and launched on `g6.6xlarge`.

Before the change for a `g6.large`:
```
[    9.199933] ghostdog[2069]: open-gpu is not preferred driver: tesla
```

After the change for a `g6.xlarge`:
```
[   22.075162] ghostdog[2071]: tesla is not preferred driver: open-gpu
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
