### PR TITLE
kernel-6.1: update to 6.1.128

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/212bc04b7ec0b61ac8a1c362021351942740ebd04ed57143d95ef49d335ee37b/kernel-6.1.127-135.201.amzn2023.src.rpm"
-sha512 = "eb6b79d44cb1ad0e35a95ec918f5d238a315d58f392088369be88391f4601e94100c9a897e730ade17f668977cd1ef2dbe348d689448a42d155018cf5f7d409a"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/ffe00924daa42edd797a396d01fb21af95701161e56f101e909ddd3f70c830ef/kernel-6.1.128-136.201.amzn2023.src.rpm"
+sha512 = "fab5bc1eb2c00bb5fece465614cc887fdf5c358237399b062bd2530a5580b56386dc830ded56247037618ae8990dcdef5303f2df27edce1da3e89deaeaf08ad7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.127
+Version: 6.1.128
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/212bc04b7ec0b61ac8a1c362021351942740ebd04ed57143d95ef49d335ee37b/kernel-6.1.127-135.201.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/ffe00924daa42edd797a396d01fb21af95701161e56f101e909ddd3f70c830ef/kernel-6.1.128-136.201.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 6.1.128-136.201.amzn2023.

**Description of changes:**

There were no kernel configuration changes and no patch changes in this release.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
