### PR TITLE
Update 5.x series kernels

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/819da0cc69144487b23a5bcd638ffdb111ebcd98fb2ae69a74979028f67d59c5/kernel-5.10.233-224.894.amzn2.src.rpm"
-sha512 = "99637d9c1d6e0d467a49384f27b2cd8e44e2b145d0e747e4481edf4e60cd41ad0db02414d920458204b9081e30557732183a8e92665b055f89aa40ed82c963f3"
+url = "https://cdn.amazonlinux.com/blobstore/f23a0c9ea605c78f33dd6ee85972cd11eb4353ae23abfe9b434756a645844cb4/kernel-5.10.234-225.895.amzn2.src.rpm"
+sha512 = "28e5955eb206be1c01cc262d2681dd0b9fb6e9d9f78ae70cf6af9d89e32a1fb1e3e2704c4123ecf6fabd3bb4211d536058c8e2c3005447983ccc4c3d5fe9e29a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.10
-Version: 5.10.233
+Version: 5.10.234
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/819da0cc69144487b23a5bcd638ffdb111ebcd98fb2ae69a74979028f67d59c5/kernel-5.10.233-224.894.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/f23a0c9ea605c78f33dd6ee85972cd11eb4353ae23abfe9b434756a645844cb4/kernel-5.10.234-225.895.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/34db58841ee6e3f91a76e8989bd1dbf8edec488bc3e977aeb18856f7428c3619/kernel-5.15.176-118.178.amzn2.src.rpm"
-sha512 = "6ce905680eaed0771dcb3f0e2b40de0e751e38e41a0f0c0eb92e31b86da3b88fcd5682319d6f82b417507b992df9602f3cefffe5742d4734bd191d93b3df712c"
+url = "https://cdn.amazonlinux.com/blobstore/54de66dab22b2c48ec0f7771a6561caca6d72acca4765533d5d0936c9be05b18/kernel-5.15.178-120.178.amzn2.src.rpm"
+sha512 = "0ea90ec77bd08bc2944cf0069b5665e8f4351c2660f32a0e173bead0275ae383f55cdb1645e6a07a268273a9e07246d40fb023fa7680ebbbc41d161c8ec6749a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.176
+Version: 5.15.178
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/34db58841ee6e3f91a76e8989bd1dbf8edec488bc3e977aeb18856f7428c3619/kernel-5.15.176-118.178.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/54de66dab22b2c48ec0f7771a6561caca6d72acca4765533d5d0936c9be05b18/kernel-5.15.178-120.178.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update the 5.10 and 5.15 kernels to the latest versions from Amazon Linux


**Testing done:**
```
diff ../current-latest/config-5.10-aarch64.config ../updated-configs/config-5.10-aarch64.config
3c3
< # Linux/arm64 5.10.233 Kernel Configuration
---
> # Linux/arm64 5.10.234 Kernel Configuration
838c838
< CONFIG_MODULE_SIG_SHA1=y
---
> # CONFIG_MODULE_SIG_SHA1 is not set
842,843c842,843
< # CONFIG_MODULE_SIG_SHA512 is not set
< CONFIG_MODULE_SIG_HASH="sha1"
---
> CONFIG_MODULE_SIG_SHA512=y
> CONFIG_MODULE_SIG_HASH="sha512"
diff ../current-latest/config-5.10-x86_64.config ../updated-configs/config-5.10-x86_64.config
3c3
< # Linux/x86 5.10.233 Kernel Configuration
---
> # Linux/x86 5.10.234 Kernel Configuration
diff ../current-latest/config-5.15-aarch64.config ../updated-configs/config-5.15-aarch64.config
3c3
< # Linux/arm64 5.15.176 Kernel Configuration
---
> # Linux/arm64 5.15.178 Kernel Configuration
diff ../current-latest/config-5.15-x86_64.config ../updated-configs/config-5.15-x86_64.config
3c3
< # Linux/x86 5.15.176 Kernel Configuration
---
> # Linux/x86 5.15.178 Kernel Configuration
```

Note: due to a git versioning number change, all patches show as "changed". The full changed list is available [here](https://gist.github.com/rpkelly/1317e437341b7d46df84d747c10e0a42)

```
Summary for kernel-5.10

Patches that were dropped:
Patches that were added:
0894-net-defer-final-struct-net-free-in-netns-dismantle.patch
Summary for kernel-5.15

Patches that were dropped:
0173-fs-ntfs3-Additional-check-in-ntfs_file_release.patch
Patches that were added:
0177-ext4-fix-timer-use-after-free-on-failed-mount.patch
Not summary file for kernel-6.1
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
