### PR TITLE
prepare for release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v1.2.0 (2024-02-26)
+
+## Build Changes
+ * Update `twoliter` from 0.7.2 to 0.7.3 ([#51])
+
+[#51]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/51
+
 # v1.1.4 (2025-02-25)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "1.1.4"
+release-version = "1.2.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

Preparing for release 1.2.0 which bumps to twoliter 0.7.3 and kit metadata version v3

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
