### PR TITLE
kernel: fix Lustre warnings for GCC 13

### DIFF
--- a/packages/kernel-5.10/6001-lustre-fix-Werror-enum-int-mismatch.patch
+++ b/packages/kernel-5.10/6001-lustre-fix-Werror-enum-int-mismatch.patch
@@ -1,0 +1,35 @@
+From 82032af947c7a8b17ec30483a6d4a2d44759561f Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 25 Feb 2025 01:25:49 +0000
+Subject: [PATCH] lustre: fix -Werror=enum-int-mismatch
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ drivers/staging/lustrefsx/lustre/include/lustre_net.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/lustrefsx/lustre/include/lustre_net.h b/drivers/staging/lustrefsx/lustre/include/lustre_net.h
+index 3a94a921e..c9c1862b1 100644
+--- a/drivers/staging/lustrefsx/lustre/include/lustre_net.h
++++ b/drivers/staging/lustrefsx/lustre/include/lustre_net.h
+@@ -2363,7 +2363,7 @@ void ptlrpc_buf_set_swabbed(struct ptlrpc_request *req, const int inout,
+ int ptlrpc_unpack_rep_msg(struct ptlrpc_request *req, int len);
+ int ptlrpc_unpack_req_msg(struct ptlrpc_request *req, int len);
+ 
+-int lustre_msg_check_version(struct lustre_msg *msg, __u32 version);
++int lustre_msg_check_version(struct lustre_msg *msg, enum lustre_msg_version version);
+ void lustre_init_msg_v2(struct lustre_msg_v2 *msg, int count, __u32 *lens,
+                         char **bufs);
+ int lustre_pack_request(struct ptlrpc_request *, __u32 magic, int count,
+@@ -2390,7 +2390,7 @@ __u32 lustre_msg_buflen(struct lustre_msg *m, __u32 n);
+ void lustre_msg_set_buflen(struct lustre_msg *m, __u32 n, __u32 len);
+ __u32 lustre_msg_bufcount(struct lustre_msg *m);
+ char *lustre_msg_string(struct lustre_msg *m, __u32 n, __u32 max_len);
+-__u32 lustre_msghdr_get_flags(struct lustre_msg *msg);
++enum lustre_msghdr lustre_msghdr_get_flags(struct lustre_msg *msg);
+ void lustre_msghdr_set_flags(struct lustre_msg *msg, __u32 flags);
+ __u32 lustre_msg_get_flags(struct lustre_msg *msg);
+ void lustre_msg_add_flags(struct lustre_msg *msg, __u32 flags);
+-- 
+2.47.0
+

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -32,6 +32,9 @@ Patch2001: 2001-kbuild-add-support-for-zstd-compressed-modules.patch
 # Fixup unused code inherited from AL
 Patch5001: 5001-Revert-netfilter-nf_tables-drop-map-element-referenc.patch
 
+# Fix Lustre warning for GCC 13+
+Patch6001: 6001-lustre-fix-Werror-enum-int-mismatch.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname

--- a/packages/kernel-5.15/6001-lustre-fix-Werror-enum-int-mismatch.patch
+++ b/packages/kernel-5.15/6001-lustre-fix-Werror-enum-int-mismatch.patch
@@ -1,0 +1,35 @@
+From 82032af947c7a8b17ec30483a6d4a2d44759561f Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 25 Feb 2025 01:25:49 +0000
+Subject: [PATCH] lustre: fix -Werror=enum-int-mismatch
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ drivers/staging/lustrefsx/lustre/include/lustre_net.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/lustrefsx/lustre/include/lustre_net.h b/drivers/staging/lustrefsx/lustre/include/lustre_net.h
+index 3a94a921e..c9c1862b1 100644
+--- a/drivers/staging/lustrefsx/lustre/include/lustre_net.h
++++ b/drivers/staging/lustrefsx/lustre/include/lustre_net.h
+@@ -2363,7 +2363,7 @@ void ptlrpc_buf_set_swabbed(struct ptlrpc_request *req, const int inout,
+ int ptlrpc_unpack_rep_msg(struct ptlrpc_request *req, int len);
+ int ptlrpc_unpack_req_msg(struct ptlrpc_request *req, int len);
+ 
+-int lustre_msg_check_version(struct lustre_msg *msg, __u32 version);
++int lustre_msg_check_version(struct lustre_msg *msg, enum lustre_msg_version version);
+ void lustre_init_msg_v2(struct lustre_msg_v2 *msg, int count, __u32 *lens,
+                         char **bufs);
+ int lustre_pack_request(struct ptlrpc_request *, __u32 magic, int count,
+@@ -2390,7 +2390,7 @@ __u32 lustre_msg_buflen(struct lustre_msg *m, __u32 n);
+ void lustre_msg_set_buflen(struct lustre_msg *m, __u32 n, __u32 len);
+ __u32 lustre_msg_bufcount(struct lustre_msg *m);
+ char *lustre_msg_string(struct lustre_msg *m, __u32 n, __u32 max_len);
+-__u32 lustre_msghdr_get_flags(struct lustre_msg *msg);
++enum lustre_msghdr lustre_msghdr_get_flags(struct lustre_msg *msg);
+ void lustre_msghdr_set_flags(struct lustre_msg *msg, __u32 flags);
+ __u32 lustre_msg_get_flags(struct lustre_msg *msg);
+ void lustre_msg_add_flags(struct lustre_msg *msg, __u32 flags);
+-- 
+2.47.0
+

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -27,6 +27,9 @@ Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 # Increase default of sysctl net.unix.max_dgram_qlen to 512.
 Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 
+# Fix Lustre warning for GCC 13+
+Patch6001: 6001-lustre-fix-Werror-enum-int-mismatch.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname

--- a/packages/kernel-6.1/6001-lustre-fix-Werror-enum-int-mismatch.patch
+++ b/packages/kernel-6.1/6001-lustre-fix-Werror-enum-int-mismatch.patch
@@ -1,0 +1,35 @@
+From 82032af947c7a8b17ec30483a6d4a2d44759561f Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 25 Feb 2025 01:25:49 +0000
+Subject: [PATCH] lustre: fix -Werror=enum-int-mismatch
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ drivers/staging/lustrefsx/lustre/include/lustre_net.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/staging/lustrefsx/lustre/include/lustre_net.h b/drivers/staging/lustrefsx/lustre/include/lustre_net.h
+index 3a94a921e..c9c1862b1 100644
+--- a/drivers/staging/lustrefsx/lustre/include/lustre_net.h
++++ b/drivers/staging/lustrefsx/lustre/include/lustre_net.h
+@@ -2363,7 +2363,7 @@ void ptlrpc_buf_set_swabbed(struct ptlrpc_request *req, const int inout,
+ int ptlrpc_unpack_rep_msg(struct ptlrpc_request *req, int len);
+ int ptlrpc_unpack_req_msg(struct ptlrpc_request *req, int len);
+ 
+-int lustre_msg_check_version(struct lustre_msg *msg, __u32 version);
++int lustre_msg_check_version(struct lustre_msg *msg, enum lustre_msg_version version);
+ void lustre_init_msg_v2(struct lustre_msg_v2 *msg, int count, __u32 *lens,
+                         char **bufs);
+ int lustre_pack_request(struct ptlrpc_request *, __u32 magic, int count,
+@@ -2390,7 +2390,7 @@ __u32 lustre_msg_buflen(struct lustre_msg *m, __u32 n);
+ void lustre_msg_set_buflen(struct lustre_msg *m, __u32 n, __u32 len);
+ __u32 lustre_msg_bufcount(struct lustre_msg *m);
+ char *lustre_msg_string(struct lustre_msg *m, __u32 n, __u32 max_len);
+-__u32 lustre_msghdr_get_flags(struct lustre_msg *msg);
++enum lustre_msghdr lustre_msghdr_get_flags(struct lustre_msg *msg);
+ void lustre_msghdr_set_flags(struct lustre_msg *msg, __u32 flags);
+ __u32 lustre_msg_get_flags(struct lustre_msg *msg);
+ void lustre_msg_add_flags(struct lustre_msg *msg, __u32 flags);
+-- 
+2.47.0
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -45,6 +45,9 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # options for nvidia are instead included through DRM_SIMPLE
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 
+# Fix Lustre warning for GCC 13+
+Patch6001: 6001-lustre-fix-Werror-enum-int-mismatch.patch
+
 BuildRequires: bc
 BuildRequires: elfutils-devel
 BuildRequires: hostname


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket-sdk/pull/258

**Description of changes:**
Fix two error-level warnings triggered by `-Werror=enum-int-mismatch` with GCC 13.


**Testing done:**
All kernels built successfully.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
