### PR TITLE
Update kernels 6.1, 5.10 and 5.15

### DIFF
--- a/packages/kernel-5.10/Cargo.toml
+++ b/packages/kernel-5.10/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/f23a0c9ea605c78f33dd6ee85972cd11eb4353ae23abfe9b434756a645844cb4/kernel-5.10.234-225.895.amzn2.src.rpm"
-sha512 = "28e5955eb206be1c01cc262d2681dd0b9fb6e9d9f78ae70cf6af9d89e32a1fb1e3e2704c4123ecf6fabd3bb4211d536058c8e2c3005447983ccc4c3d5fe9e29a"
+url = "https://cdn.amazonlinux.com/blobstore/4118100ffb1aaf53046156f41280a4d3c7c2c7c9142461268c6e9165feedbe7d/kernel-5.10.234-225.910.amzn2.src.rpm"
+sha512 = "a0ccd495e1e2ab35a38e63d29d2ed974a67f7897b8b83b329c90fb728f51a8addd7f6e5c5e97c272cdc6f22f98ede4bdd8d2b4fd59098f0925759c858b577456"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.10/kernel-5.10.spec
+++ b/packages/kernel-5.10/kernel-5.10.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/f23a0c9ea605c78f33dd6ee85972cd11eb4353ae23abfe9b434756a645844cb4/kernel-5.10.234-225.895.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/4118100ffb1aaf53046156f41280a4d3c7c2c7c9142461268c6e9165feedbe7d/kernel-5.10.234-225.910.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm

--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/54de66dab22b2c48ec0f7771a6561caca6d72acca4765533d5d0936c9be05b18/kernel-5.15.178-120.178.amzn2.src.rpm"
-sha512 = "0ea90ec77bd08bc2944cf0069b5665e8f4351c2660f32a0e173bead0275ae383f55cdb1645e6a07a268273a9e07246d40fb023fa7680ebbbc41d161c8ec6749a"
+url = "https://cdn.amazonlinux.com/blobstore/f002883608d1229e9ae7bab86dfbf6d745fe1eeccc63c370765ce03a0f399877/kernel-5.15.178-120.180.amzn2.src.rpm"
+sha512 = "81c99fc6b88caf9fedff41070c055b923eae1d1b6b2b9e7d78e968b0220b4fe46d9ddb75a9fbe28dd4e154c38fa9f92ade8e2bf7057367d7e7ddc8cd192e8870"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/54de66dab22b2c48ec0f7771a6561caca6d72acca4765533d5d0936c9be05b18/kernel-5.15.178-120.178.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/f002883608d1229e9ae7bab86dfbf6d745fe1eeccc63c370765ce03a0f399877/kernel-5.15.178-120.180.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/ffe00924daa42edd797a396d01fb21af95701161e56f101e909ddd3f70c830ef/kernel-6.1.128-136.201.amzn2023.src.rpm"
-sha512 = "fab5bc1eb2c00bb5fece465614cc887fdf5c358237399b062bd2530a5580b56386dc830ded56247037618ae8990dcdef5303f2df27edce1da3e89deaeaf08ad7"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/1c0892d62277891964ac73e5be0dfd9a38ffd5173321e0aa91c73c3ff3362e67/kernel-6.1.129-138.220.amzn2023.src.rpm"
+sha512 = "0f2e8097d11beefe223178f27d2a5ef8cf59809d504c7f6fa09e7ce42d31bf52f7f20841615edab704af37f596aed7e6b07e861cd8cba6cb11318ca60a21a11d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.128
+Version: 6.1.129
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/ffe00924daa42edd797a396d01fb21af95701161e56f101e909ddd3f70c830ef/kernel-6.1.128-136.201.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/1c0892d62277891964ac73e5be0dfd9a38ffd5173321e0aa91c73c3ff3362e67/kernel-6.1.129-138.220.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm
@@ -175,8 +175,8 @@ Conflicts: %{_cross_os}image-feature(no-fips)
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar.xz {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
-tar -xof linux-%{version}.tar.xz; rm linux-%{version}.tar.xz
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
+tar -xof linux-%{version}.tar; rm linux-%{version}.tar
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.
@@ -474,7 +474,6 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/modules.dep.bin
 %{_cross_kmoddir}/modules.devname
 %{_cross_kmoddir}/modules.order
-%{_cross_kmoddir}/modules.softdep
 %{_cross_kmoddir}/modules.symbols
 %{_cross_kmoddir}/modules.symbols.bin
 %{_cross_kmoddir}/System.map
@@ -533,6 +532,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/crypto/anubis.ko.*
 %{_cross_kmoddir}/kernel/crypto/arc4.ko.*
 %{_cross_kmoddir}/kernel/crypto/asymmetric_keys/pkcs7_test_key.ko.*
+%{_cross_kmoddir}/kernel/crypto/asymmetric_keys/pkcs8_key_parser.ko.gz
 %{_cross_kmoddir}/kernel/crypto/async_tx/async_memcpy.ko.*
 %{_cross_kmoddir}/kernel/crypto/async_tx/async_pq.ko.*
 %{_cross_kmoddir}/kernel/crypto/async_tx/async_raid6_recov.ko.*
@@ -600,6 +600,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/drivers/acpi/acpi_pad.ko.*
 %{_cross_kmoddir}/kernel/drivers/acpi/video.ko.*
 %endif
+%{_cross_kmoddir}/kernel/drivers/amazon/media/v4l2-loopback/v4l2loopback.ko.gz
 %{_cross_kmoddir}/kernel/drivers/amazon/net/efa/efa.ko.*
 %{_cross_kmoddir}/kernel/drivers/amazon/net/ena/ena.ko.*
 %{_cross_kmoddir}/kernel/drivers/amazon/scsi/mpi3mr/mpi3mr.ko.gz
@@ -742,6 +743,9 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_kmoddir}/kernel/drivers/md/raid0.ko.*
 %{_cross_kmoddir}/kernel/drivers/md/raid10.ko.*
 %{_cross_kmoddir}/kernel/drivers/md/raid1.ko.*
+%{_cross_kmoddir}/kernel/drivers/media/mc/mc.ko.gz
+%{_cross_kmoddir}/kernel/drivers/media/v4l2-core/v4l2-dv-timings.ko.gz
+%{_cross_kmoddir}/kernel/drivers/media/v4l2-core/videodev.ko.gz
 %{_cross_kmoddir}/kernel/drivers/md/raid456.ko.*
 %{_cross_kmoddir}/kernel/drivers/mfd/lpc_ich.ko.*
 %{_cross_kmoddir}/kernel/drivers/mfd/lpc_sch.ko.*


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Update Kernel 5.10, 5.15 and 6.1 to the latest versions from Amazon Linux

Patch summary is as follows:
```
Summary for kernel-5.10
Patches that changed:
Patches that were dropped:
Patches that were added:
0895-ext4-fix-timer-use-after-free-on-failed-mount.patch
0896-KVM-arm64-timers-Convert-per-vcpu-virtual-offset-to-.patch
0897-KVM-arm64-Generalise-VM-features-into-a-set-of-flags.patch
0898-KVM-arm64-timers-Use-a-per-vcpu-per-timer-accumulato.patch
0899-arm64-Add-CNTPOFF_EL2-register-definition.patch
0900-arm64-Add-HAS_ECV_CNTPOFF-capability.patch
0901-KVM-arm64-timers-Use-CNTPOFF_EL2-to-offset-the-physi.patch
0902-KVM-arm64-timers-Allow-physical-offset-without-CNTPO.patch
0903-KVM-arm64-Expose-un-lock_all_vcpus-to-the-rest-of-KV.patch
0904-KVM-arm64-timers-Allow-userspace-to-set-the-global-c.patch
0905-KVM-arm64-timers-Allow-save-restoring-of-the-physica.patch
0906-KVM-arm64-timers-Fast-track-CNTPCT_EL0-trap-handling.patch
0907-KVM-arm64-Document-KVM_ARM_SET_CNT_OFFSETS-and-co.patch
0908-KVM-arm64-timers-Use-CNTHCTL_EL2-when-setting-non-CN.patch
0909-KVM-arm64-timers-Correctly-handle-TGE-flip-with-CNTP.patch

Summary for kernel-5.15
Patches that changed:
Patches that were dropped:
Patches that were added:
0178-block-add-a-free_disk-method.patch
0179-nbd-fix-uaf-in-nbd_open.patch

Summary for kernel-6.1
Patches that changed:
Patches that were dropped:
Patches that were added:
```

**Testing done:**

Check GH actions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
