### PR TITLE
advisories: add patched package with bottlerocket- prefix name

### DIFF
--- a/advisories/1.0.2/BRSA-2o0v4e7h24m6.toml
+++ b/advisories/1.0.2/BRSA-2o0v4e7h24m6.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.173"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.230"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.173"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2024-12-20T22:00:12Z

--- a/advisories/1.0.2/BRSA-3hsyse4yldh3.toml
+++ b/advisories/1.0.2/BRSA-3hsyse4yldh3.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.173"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.230"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.173"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2024-12-20T22:00:12Z

--- a/advisories/1.0.2/BRSA-8zxvcvs8fwd8.toml
+++ b/advisories/1.0.2/BRSA-8zxvcvs8fwd8.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.173"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.173"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2024-12-20T22:00:12Z

--- a/advisories/1.0.2/BRSA-9cmoeqsnaerg.toml
+++ b/advisories/1.0.2/BRSA-9cmoeqsnaerg.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.173"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.230"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.173"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2024-12-20T22:00:12Z

--- a/advisories/1.0.2/BRSA-wqgdhv3n6gvf.toml
+++ b/advisories/1.0.2/BRSA-wqgdhv3n6gvf.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.173"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.173"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2024-12-20T22:00:12Z

--- a/advisories/1.0.4/BRSA-4mz3mlhteng6.toml
+++ b/advisories/1.0.4/BRSA-4mz3mlhteng6.toml
@@ -20,6 +20,21 @@ package-name = "kmod-6.1-nvidia"
 patched-version = "1.0.0"
 patched-epoch = "1"
 
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.10-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.15-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-6.1-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
 [updateinfo]
 author = "giinglis"
 issue-date = 2025-01-16T21:50:12Z

--- a/advisories/1.0.4/BRSA-6jzsr8lqncrq.toml
+++ b/advisories/1.0.4/BRSA-6jzsr8lqncrq.toml
@@ -20,6 +20,21 @@ package-name = "kmod-6.1-nvidia"
 patched-version = "1.0.0"
 patched-epoch = "1"
 
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.10-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.15-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-6.1-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
 [updateinfo]
 author = "giinglis"
 issue-date = 2025-01-16T21:50:12Z

--- a/advisories/1.0.4/BRSA-bl2apnymyndl.toml
+++ b/advisories/1.0.4/BRSA-bl2apnymyndl.toml
@@ -20,6 +20,21 @@ package-name = "kmod-6.1-nvidia"
 patched-version = "1.0.0"
 patched-epoch = "1"
 
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.10-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.15-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-6.1-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
 [updateinfo]
 author = "giinglis"
 issue-date = 2025-01-16T21:50:12Z

--- a/advisories/1.0.4/BRSA-jd3wf9wpwu5l.toml
+++ b/advisories/1.0.4/BRSA-jd3wf9wpwu5l.toml
@@ -20,6 +20,21 @@ package-name = "kmod-6.1-nvidia"
 patched-version = "1.0.0"
 patched-epoch = "1"
 
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.10-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.15-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-6.1-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
 [updateinfo]
 author = "giinglis"
 issue-date = 2025-01-16T21:50:12Z

--- a/advisories/1.0.4/BRSA-tdebxkarxymw.toml
+++ b/advisories/1.0.4/BRSA-tdebxkarxymw.toml
@@ -20,6 +20,21 @@ package-name = "kmod-6.1-nvidia"
 patched-version = "1.0.0"
 patched-epoch = "1"
 
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.10-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-5.15-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
+[[advisory.products]]
+package-name = "bottlerocket-kmod-6.1-nvidia"
+patched-version = "1.0.0"
+patched-epoch = "1"
+
 [updateinfo]
 author = "giinglis"
 issue-date = 2025-01-16T21:50:12Z

--- a/advisories/1.0.6/BRSA-0cdwee6kyi5l.toml
+++ b/advisories/1.0.6/BRSA-0cdwee6kyi5l.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-5mkvmc9uo73q.toml
+++ b/advisories/1.0.6/BRSA-5mkvmc9uo73q.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-bjyw3iarh4yj.toml
+++ b/advisories/1.0.6/BRSA-bjyw3iarh4yj.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-fqw9j1texulu.toml
+++ b/advisories/1.0.6/BRSA-fqw9j1texulu.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-go81hdaecudw.toml
+++ b/advisories/1.0.6/BRSA-go81hdaecudw.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.176"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-hcqmzlzhekbz.toml
+++ b/advisories/1.0.6/BRSA-hcqmzlzhekbz.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-iveoc870vzy4.toml
+++ b/advisories/1.0.6/BRSA-iveoc870vzy4.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-j2ezr5hfrkna.toml
+++ b/advisories/1.0.6/BRSA-j2ezr5hfrkna.toml
@@ -20,6 +20,21 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-jljmqnfh0kut.toml
+++ b/advisories/1.0.6/BRSA-jljmqnfh0kut.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-ohkotsnpdiwj.toml
+++ b/advisories/1.0.6/BRSA-ohkotsnpdiwj.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-orz5gql64c0j.toml
+++ b/advisories/1.0.6/BRSA-orz5gql64c0j.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-qgj8wydlhu8h.toml
+++ b/advisories/1.0.6/BRSA-qgj8wydlhu8h.toml
@@ -15,6 +15,16 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-sexhwkyu28vm.toml
+++ b/advisories/1.0.6/BRSA-sexhwkyu28vm.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-sez1uahew4g8.toml
+++ b/advisories/1.0.6/BRSA-sez1uahew4g8.toml
@@ -20,6 +20,21 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-sobubucso2f0.toml
+++ b/advisories/1.0.6/BRSA-sobubucso2f0.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-urupeozhxjhn.toml
+++ b/advisories/1.0.6/BRSA-urupeozhxjhn.toml
@@ -15,6 +15,16 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.6/BRSA-xllgj5w5lj5x.toml
+++ b/advisories/1.0.6/BRSA-xllgj5w5lj5x.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.124"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.124"
+patched-epoch = "0"
+
 [updateinfo]
 author = "ceradev"
 issue-date = 2025-01-25T00:00:23Z

--- a/advisories/1.0.7/BRSA-edhp8onrudst.toml
+++ b/advisories/1.0.7/BRSA-edhp8onrudst.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.176"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
 [updateinfo]
 author = "agarrcia"
 issue-date = 2025-02-04T18:59:20Z

--- a/advisories/1.0.7/BRSA-hyiqpdbm9eve.toml
+++ b/advisories/1.0.7/BRSA-hyiqpdbm9eve.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.176"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
 [updateinfo]
 author = "agarrcia"
 issue-date = 2025-02-04T18:59:20Z

--- a/advisories/1.0.7/BRSA-ivzwmzklr5el.toml
+++ b/advisories/1.0.7/BRSA-ivzwmzklr5el.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.176"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
 [updateinfo]
 author = "agarrcia"
 issue-date = 2025-02-04T18:59:20Z

--- a/advisories/1.0.7/BRSA-nwdrgeullswh.toml
+++ b/advisories/1.0.7/BRSA-nwdrgeullswh.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.176"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.176"
+patched-epoch = "0"
+
 [updateinfo]
 author = "agarrcia"
 issue-date = 2025-02-04T18:59:20Z

--- a/advisories/1.0.7/BRSA-ycnjrulkhn9g.toml
+++ b/advisories/1.0.7/BRSA-ycnjrulkhn9g.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.10"
 patched-version = "5.10.233"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.233"
+patched-epoch = "0"
+
 [updateinfo]
 author = "agarrcia"
 issue-date = 2025-02-04T18:59:20Z

--- a/advisories/1.1.0/BRSA-2f10j6kirmuy.toml
+++ b/advisories/1.1.0/BRSA-2f10j6kirmuy.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.127"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.127"
+patched-epoch = "0"
+
 [updateinfo]
 author = "jweiw"
 issue-date = 2025-02-06T19:04:10Z

--- a/advisories/1.1.0/BRSA-e5hrldy6v5cz.toml
+++ b/advisories/1.1.0/BRSA-e5hrldy6v5cz.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.127"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.127"
+patched-epoch = "0"
+
 [updateinfo]
 author = "jweiw"
 issue-date = 2025-02-06T19:04:10Z

--- a/advisories/1.1.0/BRSA-rlv29svjr8ae.toml
+++ b/advisories/1.1.0/BRSA-rlv29svjr8ae.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.127"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.127"
+patched-epoch = "0"
+
 [updateinfo]
 author = "jweiw"
 issue-date = 2025-02-06T19:04:10Z

--- a/advisories/1.1.0/BRSA-ttblrg1ppfau.toml
+++ b/advisories/1.1.0/BRSA-ttblrg1ppfau.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.127"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.127"
+patched-epoch = "0"
+
 [updateinfo]
 author = "jweiw"
 issue-date = 2025-02-06T19:04:10Z

--- a/advisories/1.1.3/BRSA-bfjfsvvpma5s.toml
+++ b/advisories/1.1.3/BRSA-bfjfsvvpma5s.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.128"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.128"
+patched-epoch = "0"
+
 [updateinfo]
 author = "mharrimn"
 issue-date = 2025-02-25T18:22:32Z

--- a/advisories/1.1.3/BRSA-htlt44c8iy6u.toml
+++ b/advisories/1.1.3/BRSA-htlt44c8iy6u.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.128"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.128"
+patched-epoch = "0"
+
 [updateinfo]
 author = "mharrimn"
 issue-date = 2025-02-25T18:22:32Z

--- a/advisories/1.1.3/BRSA-xtatgdj47wpo.toml
+++ b/advisories/1.1.3/BRSA-xtatgdj47wpo.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.128"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.128"
+patched-epoch = "0"
+
 [updateinfo]
 author = "mharrimn"
 issue-date = 2025-02-25T18:22:32Z

--- a/advisories/1.1.3/BRSA-zrbn8hjbhfyp.toml
+++ b/advisories/1.1.3/BRSA-zrbn8hjbhfyp.toml
@@ -10,6 +10,11 @@ package-name = "kernel-6.1"
 patched-version = "6.1.128"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-6.1"
+patched-version = "6.1.128"
+patched-epoch = "0"
+
 [updateinfo]
 author = "mharrimn"
 issue-date = 2025-02-25T18:22:32Z

--- a/advisories/1.1.4/BRSA-5qpiqmz2r4pt.toml
+++ b/advisories/1.1.4/BRSA-5qpiqmz2r4pt.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.234"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-8nnvoayqfr6v.toml
+++ b/advisories/1.1.4/BRSA-8nnvoayqfr6v.toml
@@ -15,6 +15,16 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.234"
+patched-epoch = "0"
+
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-8qgbwwnsfixn.toml
+++ b/advisories/1.1.4/BRSA-8qgbwwnsfixn.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-avmvecbpessm.toml
+++ b/advisories/1.1.4/BRSA-avmvecbpessm.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-ddgp75otjxny.toml
+++ b/advisories/1.1.4/BRSA-ddgp75otjxny.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-derrphdxrfap.toml
+++ b/advisories/1.1.4/BRSA-derrphdxrfap.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.10"
 patched-version = "5.10.234"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.10"
+patched-version = "5.10.234"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-ijbmwcz2xa6c.toml
+++ b/advisories/1.1.4/BRSA-ijbmwcz2xa6c.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-vtcpmegulzri.toml
+++ b/advisories/1.1.4/BRSA-vtcpmegulzri.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-wfttuzfrmqnh.toml
+++ b/advisories/1.1.4/BRSA-wfttuzfrmqnh.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z

--- a/advisories/1.1.4/BRSA-xb0edk7sb5a7.toml
+++ b/advisories/1.1.4/BRSA-xb0edk7sb5a7.toml
@@ -10,6 +10,11 @@ package-name = "kernel-5.15"
 patched-version = "5.15.178"
 patched-epoch = "0"
 
+[[advisory.products]]
+package-name = "bottlerocket-kernel-5.15"
+patched-version = "5.15.178"
+patched-epoch = "0"
+
 [updateinfo]
 author = "rpkelly"
 issue-date = 2025-02-26T00:51:03Z


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

n/a

**Description of changes:**

In any Bottlerocket variant built with the combination of twoliter version < 0.6.0 and the bottlerocket-kernel-kit (any version), application inventory for the variant will not strip the bottlerocket- prefix from the name of packages sourced from the kernel-kit.

Remediate this by adding bottlerocket- prefixed package names to advisories applicable to kernel-kit < 1.2.0. kernel-kit v1.2.0 built with [twoliter v0.7.3](https://github.com/bottlerocket-os/twoliter/releases/tag/v0.7.3), which included a kit metadata version bump to signal a breaking change.

**Testing done:**

Built Bottlerocket updateinfo.xml with these changes and verified packages with prefix are included.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
