### PR TITLE
Update kernel-5.15 and kernel-6.1

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/f002883608d1229e9ae7bab86dfbf6d745fe1eeccc63c370765ce03a0f399877/kernel-5.15.178-120.180.amzn2.src.rpm"
-sha512 = "81c99fc6b88caf9fedff41070c055b923eae1d1b6b2b9e7d78e968b0220b4fe46d9ddb75a9fbe28dd4e154c38fa9f92ade8e2bf7057367d7e7ddc8cd192e8870"
+url = "https://cdn.amazonlinux.com/blobstore/812a458aa850ccd3aca708f86fb6b201ac0d192ac1e0a64d82fd3f4cf9003363/kernel-5.15.178-120.187.amzn2.src.rpm"
+sha512 = "251b4a4b4adf88b714b4e8070fd78034dac12632c82e05221e089d777b5b2b908dbc1a792a542d30a112737e56f70a43276745d3c0edcefc5603de35523231dd"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/f002883608d1229e9ae7bab86dfbf6d745fe1eeccc63c370765ce03a0f399877/kernel-5.15.178-120.180.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/812a458aa850ccd3aca708f86fb6b201ac0d192ac1e0a64d82fd3f4cf9003363/kernel-5.15.178-120.187.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/1c0892d62277891964ac73e5be0dfd9a38ffd5173321e0aa91c73c3ff3362e67/kernel-6.1.129-138.220.amzn2023.src.rpm"
-sha512 = "0f2e8097d11beefe223178f27d2a5ef8cf59809d504c7f6fa09e7ce42d31bf52f7f20841615edab704af37f596aed7e6b07e861cd8cba6cb11318ca60a21a11d"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/c088b296cf2426b9ad402c0ab6c728177aa81b8b45ab1687b7476ab665443250/kernel-6.1.130-139.222.amzn2023.src.rpm"
+sha512 = "8138e3d2c99f645bcf7f719d2304c0811ef0eea4557282053c1690f8f7fe4b8667b390c0464b5171b42d8521f0cc7c01bfc77d1db0a1b5c28cba06469164545a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.129
+Version: 6.1.130
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/1c0892d62277891964ac73e5be0dfd9a38ffd5173321e0aa91c73c3ff3362e67/kernel-6.1.129-138.220.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/c088b296cf2426b9ad402c0ab6c728177aa81b8b45ab1687b7476ab665443250/kernel-6.1.130-139.222.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm


### PR DESCRIPTION
**Description of changes:**

Update to the latest releases of kernels from Amazon Linux

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Patch Summary**

```
Summary for kernel-5.15
Patches that changed:
Patches that were dropped:
Patches that were added:
0180-sched-sch_cake-add-bounds-checks-to-host-bulk-flow-f.patch
0181-pfifo_tail_enqueue-Drop-new-packet-when-sch-limit-0.patch
0182-netem-Update-sch-q.qlen-before-qdisc_tree_reduce_bac.patch
0183-cifs-connect-individual-channel-servers-to-primary-c.patch
0184-cifs-track-individual-channel-status-using-chans_nee.patch
0185-smb-client-fix-UAF-in-smb2_reconnect_server.patch
0186-smb-client-fix-use-after-free-of-signing-key.patch

Summary for kernel-6.1
Patches that changed:
Patches that were dropped:
0218-block-bfq-split-sync-bfq_queues-on-a-per-actuator-ba.patch
0219-block-bfq-fix-bfqq-uaf-in-bfq_limit_depth.patch
Patches that were added:
0218-ftrace-Fix-modification-of-direct_function-hash-whil.patch
0219-ftrace-Use-asynchronous-grace-period-for-register_ft.patch
0220-uprobes-Fix-race-in-uprobe_free_utask.patch
0221-smb-client-fix-use-after-free-of-signing-key.patch
```

**Config Diff**

```
diff --color ../current-latest/config-5.15-aarch64.config ../updated-configs/config-5.15-aarch64.config
5c5
< CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.02.8) 11.4.0"
---
> CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
7c7
< CONFIG_GCC_VERSION=110400
---
> CONFIG_GCC_VERSION=130300
10c10
< CONFIG_AS_VERSION=24100
---
> CONFIG_AS_VERSION=24301
12c12
< CONFIG_LD_VERSION=24100
---
> CONFIG_LD_VERSION=24301
21c21
< CONFIG_PAHOLE_VERSION=126
---
> CONFIG_PAHOLE_VERSION=129
425a426
> CONFIG_CC_HAVE_SHADOW_CALL_STACK=y
666,667c667,668
< CONFIG_CRYPTO_SHA256_ARM64=m
< CONFIG_CRYPTO_SHA512_ARM64=m
---
> CONFIG_CRYPTO_SHA256_ARM64=y
> CONFIG_CRYPTO_SHA512_ARM64=y
669,670c670,671
< CONFIG_CRYPTO_SHA2_ARM64_CE=m
< CONFIG_CRYPTO_SHA512_ARM64_CE=m
---
> CONFIG_CRYPTO_SHA2_ARM64_CE=y
> CONFIG_CRYPTO_SHA512_ARM64_CE=y
740a742
> CONFIG_ARCH_SUPPORTS_SHADOW_CALL_STACK=y
4729a4732,4734
> CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO=y
4733a4739,4740
> # CONFIG_INIT_STACK_ALL_PATTERN is not set
> # CONFIG_INIT_STACK_ALL_ZERO is not set
diff --color ../current-latest/config-5.15-x86_64.config ../updated-configs/config-5.15-x86_64.config
5c5
< CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.02.8) 11.4.0"
---
> CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
7c7
< CONFIG_GCC_VERSION=110400
---
> CONFIG_GCC_VERSION=130300
10c10
< CONFIG_AS_VERSION=24100
---
> CONFIG_AS_VERSION=24301
12c12
< CONFIG_LD_VERSION=24100
---
> CONFIG_LD_VERSION=24301
21c21
< CONFIG_PAHOLE_VERSION=126
---
> CONFIG_PAHOLE_VERSION=129
4652a4653,4655
> CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO=y
4656a4660,4661
> # CONFIG_INIT_STACK_ALL_PATTERN is not set
> # CONFIG_INIT_STACK_ALL_ZERO is not set
diff --color ../current-latest/config-6.1-aarch64.config ../updated-configs/config-6.1-aarch64.config
3c3
< # Linux/arm64 6.1.129 Kernel Configuration
---
> # Linux/arm64 6.1.130 Kernel Configuration
5c5
< CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.02.8) 11.4.0"
---
> CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
7c7
< CONFIG_GCC_VERSION=110400
---
> CONFIG_GCC_VERSION=130300
10c10
< CONFIG_AS_VERSION=24100
---
> CONFIG_AS_VERSION=24301
12c12
< CONFIG_LD_VERSION=24100
---
> CONFIG_LD_VERSION=24301
18d17
< CONFIG_GCC_ASM_GOTO_OUTPUT_WORKAROUND=y
21c20
< CONFIG_PAHOLE_VERSION=126
---
> CONFIG_PAHOLE_VERSION=129
424a424
> CONFIG_CC_HAVE_SHADOW_CALL_STACK=y
730a731,732
> CONFIG_ARCH_SUPPORTS_SHADOW_CALL_STACK=y
> # CONFIG_SHADOW_CALL_STACK is not set
5131a5134,5136
> CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO=y
5133,5135c5138,5139
< # CONFIG_GCC_PLUGIN_STRUCTLEAK_USER is not set
< # CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF is not set
< # CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL is not set
---
> # CONFIG_INIT_STACK_ALL_PATTERN is not set
> # CONFIG_INIT_STACK_ALL_ZERO is not set
5344,5347c5348,5351
< CONFIG_CRYPTO_SHA256_ARM64=m
< CONFIG_CRYPTO_SHA2_ARM64_CE=m
< CONFIG_CRYPTO_SHA512_ARM64=m
< CONFIG_CRYPTO_SHA512_ARM64_CE=m
---
> CONFIG_CRYPTO_SHA256_ARM64=y
> CONFIG_CRYPTO_SHA2_ARM64_CE=y
> CONFIG_CRYPTO_SHA512_ARM64=y
> CONFIG_CRYPTO_SHA512_ARM64_CE=y
5842a5847
> # CONFIG_KCOV is not set
diff --color ../current-latest/config-6.1-x86_64.config ../updated-configs/config-6.1-x86_64.config
3c3
< # Linux/x86 6.1.129 Kernel Configuration
---
> # Linux/x86 6.1.130 Kernel Configuration
5c5
< CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.02.8) 11.4.0"
---
> CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
7c7
< CONFIG_GCC_VERSION=110400
---
> CONFIG_GCC_VERSION=130300
10c10
< CONFIG_AS_VERSION=24100
---
> CONFIG_AS_VERSION=24301
12c12
< CONFIG_LD_VERSION=24100
---
> CONFIG_LD_VERSION=24301
18d17
< CONFIG_GCC_ASM_GOTO_OUTPUT_WORKAROUND=y
21c20
< CONFIG_PAHOLE_VERSION=126
---
> CONFIG_PAHOLE_VERSION=129
5072a5072,5074
> CONFIG_CC_HAS_AUTO_VAR_INIT_PATTERN=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO_BARE=y
> CONFIG_CC_HAS_AUTO_VAR_INIT_ZERO=y
5074,5076c5076,5077
< # CONFIG_GCC_PLUGIN_STRUCTLEAK_USER is not set
< # CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF is not set
< # CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL is not set
---
> # CONFIG_INIT_STACK_ALL_PATTERN is not set
> # CONFIG_INIT_STACK_ALL_ZERO is not set
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
