### PR TITLE
chore: cleanup Cargo.lock and Changelog from kernel-5.10 removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## OS Changes
  * Update kernel-5.15 to version 5.15.178-120.187 ([#81])
  * Update kernel-6.1 to version 6.1.130-139.222 ([#81])
- * Drop kernel-5.10 and kmod-5.10-nvidia ([#80])
+ * Remove kernel-5.10 and kmod-5.10-nvidia ([#80])
 
 ## Build Changes
  * Update twoliter to 0.8.1 ([#77])

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,10 +7,8 @@ name = "bottlerocket-kernel-kit"
 version = "0.1.0"
 dependencies = [
  "grub",
- "kernel-5_10",
  "kernel-5_15",
  "kernel-6_1",
- "kmod-5_10-nvidia",
  "kmod-5_15-nvidia",
  "kmod-6_1-nvidia",
  "libkcapi",
@@ -25,13 +23,6 @@ name = "grub"
 version = "0.1.0"
 
 [[package]]
-name = "kernel-5_10"
-version = "0.1.0"
-dependencies = [
- "microcode",
-]
-
-[[package]]
 name = "kernel-5_15"
 version = "0.1.0"
 dependencies = [
@@ -43,13 +34,6 @@ name = "kernel-6_1"
 version = "0.1.0"
 dependencies = [
  "microcode",
-]
-
-[[package]]
-name = "kmod-5_10-nvidia"
-version = "0.1.0"
-dependencies = [
- "kernel-5_10",
 ]
 
 [[package]]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Adjust Cargo.lock to reflect removal of `kernel-5.10` and `kmod-5.10-nvidia`. Also take feedback from @arnaldo2792 in #82 

**Testing done:**

`make`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
