### PR TITLE
Kernel-5.15: update to 5.15.179

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/812a458aa850ccd3aca708f86fb6b201ac0d192ac1e0a64d82fd3f4cf9003363/kernel-5.15.178-120.187.amzn2.src.rpm"
-sha512 = "251b4a4b4adf88b714b4e8070fd78034dac12632c82e05221e089d777b5b2b908dbc1a792a542d30a112737e56f70a43276745d3c0edcefc5603de35523231dd"
+url = "https://cdn.amazonlinux.com/blobstore/2f27c27e414456f2b7bf405a7a4711e426006430692829026dd1d2cd2d7a20e4/kernel-5.15.179-121.185.amzn2.src.rpm"
+sha512 = "ce7addd1403d66a741425b1e4c1baae43b4196228dd8fdfdc07ce4d12e524d6e25d6e3175a580e7bf26c27a5d5f405ae8d916d5f349b0e2c00124e25defe72d2"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.178
+Version: 5.15.179
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/812a458aa850ccd3aca708f86fb6b201ac0d192ac1e0a64d82fd3f4cf9003363/kernel-5.15.178-120.187.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/2f27c27e414456f2b7bf405a7a4711e426006430692829026dd1d2cd2d7a20e4/kernel-5.15.179-121.185.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.19.64.0.noarch.rpm


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 5.15.179-121.185.amzn2.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Update to the latest releases of kernels from Amazon Linux

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Patch Summary:**

```
Summary for kernel-5.15
Patches that changed:
Patches that were dropped:
0180-sched-sch_cake-add-bounds-checks-to-host-bulk-flow-f.patch
0181-pfifo_tail_enqueue-Drop-new-packet-when-sch-limit-0.patch
0182-netem-Update-sch-q.qlen-before-qdisc_tree_reduce_bac.patch
Patches that were added:
0184-KVM-x86-Acquire-kvm-srcu-when-handling-KVM_SET_VCPU_.patch
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.