### PR TITLE
drop zstd module from GRUB

### DIFF
--- a/packages/grub/grub.spec
+++ b/packages/grub/grub.spec
@@ -192,7 +192,7 @@ sed -e "s,__VERSION__,%{version},g" %{S:4} > sbat.csv
 popd
 
 %install
-MODS=(configfile echo ext2 gptprio linux normal part_gpt reboot sleep zstd search)
+MODS=(configfile echo ext2 gptprio linux normal part_gpt reboot sleep search)
 
 # These modules are needed for signature verification, which is currently only
 # done for the EFI build of GRUB.


### PR DESCRIPTION
**Issue number:**
Related: #93

**Description of changes:**
zstd was added years ago in e6763c4 ("grub: add zstd module"), but aarch64 kernels have never been shipped in the compressed format. The feature was in tension with Secure Boot and specifically a desire to avoid exposing GRUB's decompression logic to unverified inputs.

Newer kernels such as 6.12 support the zboot format where kernels can self-decompress on aarch64, so we no longer need the GRUB feature. Disable it to save 100-200 KiB from the GRUB image.


**Testing done:**
Built GRUB. Verified that x86_64 and aarch64 VMs booted and that the GRUB image was smaller.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
