### PR TITLE
Update kernel-5.15 and kernel-6.1

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/2f27c27e414456f2b7bf405a7a4711e426006430692829026dd1d2cd2d7a20e4/kernel-5.15.179-121.185.amzn2.src.rpm"
-sha512 = "ce7addd1403d66a741425b1e4c1baae43b4196228dd8fdfdc07ce4d12e524d6e25d6e3175a580e7bf26c27a5d5f405ae8d916d5f349b0e2c00124e25defe72d2"
+url = "https://cdn.amazonlinux.com/blobstore/bcd19872c3df14f84fb665075ded3bb1aae7621cfa52966f0779fb497741a98b/kernel-5.15.179-122.186.amzn2.src.rpm"
+sha512 = "aecb771bdafe35bdb7fd0d46f54462079b6a51711b5e29a93c7a8352404953e1da8b373cf58f5cd20b318ce63f553f98c7b2dfc5a5f2846c0580b7061a489937"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/2f27c27e414456f2b7bf405a7a4711e426006430692829026dd1d2cd2d7a20e4/kernel-5.15.179-121.185.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/bcd19872c3df14f84fb665075ded3bb1aae7621cfa52966f0779fb497741a98b/kernel-5.15.179-122.186.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/7d46bc64f4afbf05a15c34f96a30cf311ca494c3cfea17df5209bffba880c7cc/kernel-6.1.131-143.221.amzn2023.src.rpm"
-sha512 = "fc07b5caf2202297fcb0f6f4f8d29e0d2f8ba74ddc1aa5af3648edd2990151486d42a4345ebfcd3fd0f663be2caefeb967bd13c195b9e4ac7c6c19d71fdaf734"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/394b901027fbaf478c06ece468a137528f62fd67f82ee31b99b969c48a73cd0c/kernel-6.1.132-147.221.amzn2023.src.rpm"
+sha512 = "d33d909c90494efbff70db25c0f2566fea4c0bd80330330fa8524275dbd8e527ce098cbf1b71fc8bf78525f21e4ac9b1213d9b22f0e17086da67393ba1c9daa0"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/config-full-bottlerocket-aarch64
+++ b/packages/kernel-6.1/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.131 Kernel Configuration
+# Linux/arm64 6.1.132 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-6.1/config-full-bottlerocket-x86_64
+++ b/packages/kernel-6.1/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.131 Kernel Configuration
+# Linux/x86 6.1.132 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.131
+Version: 6.1.132
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/7d46bc64f4afbf05a15c34f96a30cf311ca494c3cfea17df5209bffba880c7cc/kernel-6.1.131-143.221.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/394b901027fbaf478c06ece468a137528f62fd67f82ee31b99b969c48a73cd0c/kernel-6.1.132-147.221.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm
@@ -174,8 +174,8 @@ Conflicts: %{_cross_os}image-feature(no-fips)
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
-tar -xof linux-%{version}.tar; rm linux-%{version}.tar
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar.xz {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
+tar -xof linux-%{version}.tar.xz; rm linux-%{version}.tar.xz
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.

--- a/packages/kernel-6.1/latest-kernel-full-config.sh
+++ b/packages/kernel-6.1/latest-kernel-full-config.sh
@@ -59,8 +59,8 @@ merge_kernel_configs() {
     cp "${rpm_file}" "${tmpdir}/"
     pushd "${tmpdir}" || bail "Could not move around"
 
-    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar {,.}config-x86_64 {,.}config-aarch64 {,./}"*.patch" {,./}kernel.spec
-    tar -xof linux-"${version}".tar; rm linux-"${version}".tar
+    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar.xz {,.}config-x86_64 {,.}config-aarch64 {,./}"*.patch" {,./}kernel.spec
+    tar -xof linux-"${version}".tar.xz; rm linux-"${version}".tar.xz
 
     # Find patch ordering based on the upstream SRPM and apply in that order
     readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
Update to the latest releases of kernels from Amazon Linux

**Patch summary**
```
Patch summary for 5.15
Patches that changed:
Patches that were dropped:
Patches that were added:
0185-udp-Fix-memory-accounting-leak.patch
```

```
Patch summary for 6.1
Patches that changed:
Patches that were dropped:
Patches that were added:
```

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
