### PR TITLE
2.2.0 release: Revert "chore: update Bottlerocket SDK to 0.61.0"

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -3,7 +3,7 @@ kit = []
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.61.0"
+version = "0.60.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.61.0"
-digest = "Ufe4lJz1PL3MBGZq6aVmdTIL/qF4EkSeQjU3o4sLHdU="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.60.0"
+digest = "aVbABC86XWBbfyems1C3lrEhEvL1XmNt1hcwF0oAzSs="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -6,5 +6,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.61.0"
+version = "0.60.0"
 vendor = "bottlerocket"


### PR DESCRIPTION


<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

This reverts commit 9db11bf0a3d013f8641ea9580290e2a42249ec94. We do not want to include this commit in the upcoming v2.2.0 release of the kernel-kit.

Note that this PR is targeting the `2.2.x` branch.

**Testing done:**

Build.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
