### PR TITLE
Update NVIDIA drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v2.2.2 (2025-04-18)
+
+## OS Changes
+ * Update to drivers for kmod-5.15-nvidia and kmod-6.1-nvidia ([#108])
+
+[#108]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/108
+
 # v2.2.1 (2025-04-17)
 
 ## Build Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "2.2.1"
+release-version = "2.2.2"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"

--- a/packages/kmod-5.15-nvidia/Cargo.toml
+++ b/packages/kmod-5.15-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-x86_64-535.230.02.run"
-sha512 = "2154e28682fe1663dc64b18569c67839995d496a6c1b353fcdc17fc4520420c8d629d441312a6cedc054d6322a267d6f275d1daef210d2f24a179d931a4c99b8"
+url = "https://us.download.nvidia.com/tesla/535.247.01/NVIDIA-Linux-x86_64-535.247.01.run"
+sha512 = "f8e04e5f7cf8b7fdae9135cb5f0f2740d5eae0ef9a44a41dbf78996d3c2d4139bdbec99be14f73aa2d275d78658b4a91a274f20545e4325cef787548e3d073a6"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-aarch64-535.230.02.run"
-sha512 = "7954350fe91419fa85c25483e2572e63c14da3e6fef27ffd13b5a4fcc814cde32faf4cd289333d6a22db26c64658f3e2df0ff8a9ec17094e29a25d35517048e4"
+url = "https://us.download.nvidia.com/tesla/535.247.01/NVIDIA-Linux-aarch64-535.247.01.run"
+sha512 = "a0bd487238d41fd907c7e87d8ce10b4e19a367c8faafafc914fe6d741b348619e7427a5ff22dd2a475e4dd5cf3148965934b746bcc34b3f572bc01e8a6429bda"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.230.02-1.x86_64.rpm"
-sha512 = "18672058020ada0c7903308da5b9384f42aed742c79a358a0552feae263a27f77cf01612684deab98d77587b977a5dc29da1894c52780403d0816e46fd3cc64b"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.247.01-1.x86_64.rpm"
+sha512 = "ada6ac533dd8028a0002f3e981a69d4477ea10ddd6c5992c77cf34342311902841ba35c1d468f6b84c085404b3cb400f367f465234ad1204fe03df2fd05412c7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.230.02-1.aarch64.rpm"
-sha512 = "87b616aebe6a6e34fd4087fceffe352a843e2d5912483c6dfb36f22da9135ec030fd2cddfceb0e916b0d804df0722b9d990ad70a3c82cb4d2df65798a768c58d"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.247.01-1.aarch64.rpm"
+sha512 = "9be8b16314ecb948c3f013ea0e6cc6aa75193391ea9d6fe594ea2e2c89b042deaf16117a4dfa2723077cd8f71d819be7e4036f0035eb7e69f92ae1a3413f2b30"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 230
-%global tesla_patch 02
+%global tesla_minor 247
+%global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa

--- a/packages/kmod-6.1-nvidia/Cargo.toml
+++ b/packages/kmod-6.1-nvidia/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-x86_64-535.230.02.run"
-sha512 = "2154e28682fe1663dc64b18569c67839995d496a6c1b353fcdc17fc4520420c8d629d441312a6cedc054d6322a267d6f275d1daef210d2f24a179d931a4c99b8"
+url = "https://us.download.nvidia.com/tesla/535.247.01/NVIDIA-Linux-x86_64-535.247.01.run"
+sha512 = "f8e04e5f7cf8b7fdae9135cb5f0f2740d5eae0ef9a44a41dbf78996d3c2d4139bdbec99be14f73aa2d275d78658b4a91a274f20545e4325cef787548e3d073a6"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/535.230.02/NVIDIA-Linux-aarch64-535.230.02.run"
-sha512 = "7954350fe91419fa85c25483e2572e63c14da3e6fef27ffd13b5a4fcc814cde32faf4cd289333d6a22db26c64658f3e2df0ff8a9ec17094e29a25d35517048e4"
+url = "https://us.download.nvidia.com/tesla/535.247.01/NVIDIA-Linux-aarch64-535.247.01.run"
+sha512 = "a0bd487238d41fd907c7e87d8ce10b4e19a367c8faafafc914fe6d741b348619e7427a5ff22dd2a475e4dd5cf3148965934b746bcc34b3f572bc01e8a6429bda"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.230.02-1.x86_64.rpm"
-sha512 = "18672058020ada0c7903308da5b9384f42aed742c79a358a0552feae263a27f77cf01612684deab98d77587b977a5dc29da1894c52780403d0816e46fd3cc64b"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-535.247.01-1.x86_64.rpm"
+sha512 = "ada6ac533dd8028a0002f3e981a69d4477ea10ddd6c5992c77cf34342311902841ba35c1d468f6b84c085404b3cb400f367f465234ad1204fe03df2fd05412c7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.230.02-1.aarch64.rpm"
-sha512 = "87b616aebe6a6e34fd4087fceffe352a843e2d5912483c6dfb36f22da9135ec030fd2cddfceb0e916b0d804df0722b9d990ad70a3c82cb4d2df65798a768c58d"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-535.247.01-1.aarch64.rpm"
+sha512 = "9be8b16314ecb948c3f013ea0e6cc6aa75193391ea9d6fe594ea2e2c89b042deaf16117a4dfa2723077cd8f71d819be7e4036f0035eb7e69f92ae1a3413f2b30"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -1,6 +1,6 @@
 %global tesla_major 535
-%global tesla_minor 230
-%global tesla_patch 02
+%global tesla_minor 247
+%global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**
```
changelog: create version 2.2.2
5deda9e chore: package update kernel-6.1 kmod
70041ff chore: package update kernel-5.15 kmod
572ca64 chore: bump kit version to 2.2.2
```

**Testing done:**
Tests were run on both x86_64 and aarch64 architectures
<details>
<summary>Kernel 6.1 k8s-1.32-nvidia  test</summary>

```
----------------------------------------------------------------------------------------------------------------------------------
|   timestamp   |                                                    message                                                     |
|---------------|----------------------------------------------------------------------------------------------------------------|
| 1745097485774 | =========================================                                                                      |
| 1745097485774 |   Running sample UnifiedMemoryPerf                                                                             |
| 1745097485774 | =========================================                                                                      |
| 1745097485963 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097485963 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097485963 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097496533 | Running ........................................................                                               |
| 1745097496533 | Overall Time For matrixMultiplyPerf                                                                            |
| 1745097496533 | Printing Average of 20 measurements in (ms)                                                                    |
| 1745097496533 | Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs                                        |
| 1745097496533 | 4   0.166   0.199   0.324   0.013   0.028   0.024   0.030   0.022                                              |
| 1745097496533 | 16   0.182   0.221   0.447   0.025   0.041   0.034   0.043   0.045                                             |
| 1745097496533 | 64   0.256   0.282   0.815   0.087   0.091   0.083   0.080   0.067                                             |
| 1745097496533 | 256   0.576   0.589   1.359   0.494   0.288   0.271   0.249   0.246                                            |
| 1745097496533 | 1024   1.838   2.611   2.896   3.073   1.089   1.032   0.936   0.926                                           |
| 1745097496533 | 4096   6.820   7.573  10.792  22.150   4.232   4.158   4.053   4.041                                           |
| 1745097496533 | 16384  28.354  30.241  44.671 169.594  20.926  20.815  21.034  20.973                                          |
| 1745097496533 | NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled. |
| 1745097496674 | =========================================                                                                      |
| 1745097496674 |   Running sample deviceQuery                                                                                   |
| 1745097496674 | =========================================                                                                      |
| 1745097496762 | ./deviceQuery Starting...                                                                                      |
| 1745097496762 |  CUDA Device Query (Runtime API) version (CUDART static linking)                                               |
| 1745097496762 | Detected 1 CUDA Capable device(s)                                                                              |
| 1745097496762 | Device 0: "NVIDIA L4"                                                                                          |
| 1745097496762 |   CUDA Driver Version / Runtime Version          12.2 / 11.4                                                   |
| 1745097496762 |   CUDA Capability Major/Minor version number:    8.9                                                           |
| 1745097496762 |   Total amount of global memory:                 22491 MBytes (23583784960 bytes)                              |
| 1745097496762 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097496762 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097496762 |   (058) Multiprocessors, (128) CUDA Cores/MP:    7424 CUDA Cores                                               |
| 1745097496762 |   GPU Max Clock rate:                            2040 MHz (2.04 GHz)                                           |
| 1745097496762 |   Memory Clock rate:                             6251 Mhz                                                      |
| 1745097496762 |   Memory Bus Width:                              192-bit                                                       |
| 1745097496762 |   L2 Cache Size:                                 50331648 bytes                                                |
| 1745097496762 |   Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)     |
| 1745097496762 |   Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers                                       |
| 1745097496762 |   Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers                                |
| 1745097496762 |   Total amount of constant memory:               65536 bytes                                                   |
| 1745097496762 |   Total amount of shared memory per block:       49152 bytes                                                   |
| 1745097496762 |   Total shared memory per multiprocessor:        102400 bytes                                                  |
| 1745097496762 |   Total number of registers available per block: 65536                                                         |
| 1745097496762 |   Warp size:                                     32                                                            |
| 1745097496762 |   Maximum number of threads per multiprocessor:  1536                                                          |
| 1745097496762 |   Maximum number of threads per block:           1024                                                          |
| 1745097496762 |   Max dimension size of a thread block (x,y,z): (1024, 1024, 64)                                               |
| 1745097496762 |   Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)                                     |
| 1745097496762 |   Maximum memory pitch:                          2147483647 bytes                                              |
| 1745097496762 |   Texture alignment:                             512 bytes                                                     |
| 1745097496762 |   Concurrent copy and kernel execution:          Yes with 2 copy engine(s)                                     |
| 1745097496762 |   Run time limit on kernels:                     No                                                            |
| 1745097496762 |   Integrated GPU sharing Host Memory:            No                                                            |
| 1745097496762 |   Support host page-locked memory mapping:       Yes                                                           |
| 1745097496762 |   Alignment requirement for Surfaces:            Yes                                                           |
| 1745097496762 |   Device has ECC support:                        Enabled                                                       |
| 1745097496762 |   Device supports Unified Addressing (UVA):      Yes                                                           |
| 1745097496762 |   Device supports Managed Memory:                Yes                                                           |
| 1745097496762 |   Device supports Compute Preemption:            Yes                                                           |
| 1745097496762 |   Supports Cooperative Kernel Launch:            Yes                                                           |
| 1745097496762 |   Supports MultiDevice Co-op Kernel Launch:      Yes                                                           |
| 1745097496762 |   Device PCI Domain ID / Bus ID / location ID:   0 / 53 / 0                                                    |
| 1745097496762 |   Compute Mode:                                                                                                |
| 1745097496762 |      < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >                  |
| 1745097496762 | deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 11.4, NumDevs = 1        |
| 1745097496762 | Result = PASS                                                                                                  |
| 1745097496775 | =========================================                                                                      |
| 1745097496775 |   Running sample globalToShmemAsyncCopy                                                                        |
| 1745097496775 | =========================================                                                                      |
| 1745097497227 | [globalToShmemAsyncCopy] - Starting...                                                                         |
| 1745097497227 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097497227 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097497227 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097497227 | MatrixA(1280,1280), MatrixB(1280,1280)                                                                         |
| 1745097497227 | Running kernel = 0 - AsyncCopyMultiStageLargeChunk                                                             |
| 1745097497227 | Computing result using CUDA Kernel...                                                                          |
| 1745097497227 | done                                                                                                           |
| 1745097497227 | Performance= 1934.57 GFlop/s, Time= 2.168 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block         |
| 1745097497227 | Checking computed result for correctness: Result = PASS                                                        |
| 1745097497227 | NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled. |
| 1745097497297 | =========================================                                                                      |
| 1745097497297 |   Running sample immaTensorCoreGemm                                                                            |
| 1745097497297 | =========================================                                                                      |
| 1745097497862 | Initializing...                                                                                                |
| 1745097497862 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097497862 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097497862 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097497862 | M: 4096 (16 x 256)                                                                                             |
| 1745097497862 | N: 4096 (16 x 256)                                                                                             |
| 1745097497862 | K: 4096 (16 x 256)                                                                                             |
| 1745097497862 | Preparing data for GPU...                                                                                      |
| 1745097497862 | Required shared memory size: 64 Kb                                                                             |
| 1745097497862 | Computing... using high performance kernel compute_gemm_imma                                                   |
| 1745097497862 | Time: 1.390592 ms                                                                                              |
| 1745097497862 | TOPS: 98.83                                                                                                    |
| 1745097497933 | =========================================                                                                      |
| 1745097497933 |   Running sample reductionMultiBlockCG                                                                         |
| 1745097497933 | =========================================                                                                      |
| 1745097498807 | reductionMultiBlockCG Starting...                                                                              |
| 1745097498807 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097498807 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097498807 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097498807 | 33554432 elements                                                                                              |
| 1745097498807 | numThreads: 768                                                                                                |
| 1745097498807 | numBlocks: 58                                                                                                  |
| 1745097498807 | Launching SinglePass Multi Block Cooperative Groups kernel                                                     |
| 1745097498807 | Average time: 0.576550 ms                                                                                      |
| 1745097498807 | Bandwidth:    232.794527 GB/s                                                                                  |
| 1745097498807 | GPU result = 1.992401242256                                                                                    |
| 1745097498807 | CPU result = 1.992401361465                                                                                    |
| 1745097498876 | =========================================                                                                      |
| 1745097498876 |   Running sample shfl_scan                                                                                     |
| 1745097498876 | =========================================                                                                      |
| 1745097499066 | Starting shfl_scan                                                                                             |
| 1745097499066 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097499066 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097499066 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097499066 | > Detected Compute SM 8.9 hardware with 58 multi-processors                                                    |
| 1745097499066 | Starting shfl_scan                                                                                             |
| 1745097499066 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097499066 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097499066 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097499066 | > Detected Compute SM 8.9 hardware with 58 multi-processors                                                    |
| 1745097499066 | Computing Simple Sum test                                                                                      |
| 1745097499066 | ---------------------------------------------------                                                            |
| 1745097499066 | Initialize test data [1, 1, 1...]                                                                              |
| 1745097499066 | Scan summation for 65536 elements, 256 partial sums                                                            |
| 1745097499066 | Partial summing 256 elements with 1 blocks of size 256                                                         |
| 1745097499066 | Test Sum: 65536                                                                                                |
| 1745097499066 | Time (ms): 0.021472                                                                                            |
| 1745097499066 | 65536 elements scanned in 0.021472 ms -> 3052.161133 MegaElements/s                                            |
| 1745097499066 | CPU verify result diff (GPUvsCPU) = 0                                                                          |
| 1745097499066 | CPU sum (naive) took 0.018420 ms                                                                               |
| 1745097499066 | Computing Integral Image Test on size 1920 x 1080 synthetic data                                               |
| 1745097499066 | ---------------------------------------------------                                                            |
| 1745097499066 | Method: Fast  Time (GPU Timer): 0.011104 ms Diff = 0                                                           |
| 1745097499066 | Method: Vertical Scan  Time (GPU Timer): 0.050560 ms                                                           |
| 1745097499066 | CheckSum: 2073600, (expect 1920x1080=2073600)                                                                  |
| 1745097499134 | =========================================                                                                      |
| 1745097499134 |   Running sample simpleAWBarrier                                                                               |
| 1745097499134 | =========================================                                                                      |
| 1745097499365 | ./simpleAWBarrier starting...                                                                                  |
| 1745097499366 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097499366 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097499366 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097499366 | Launching normVecByDotProductAWBarrier kernel with numBlocks = 116 blockSize = 640                             |
| 1745097499378 | Result = PASSED                                                                                                |
| 1745097499394 | ./simpleAWBarrier completed, returned OK                                                                       |
| 1745097499464 | =========================================                                                                      |
| 1745097499465 |   Running sample simpleAtomicIntrinsics                                                                        |
| 1745097499465 | =========================================                                                                      |
| 1745097499617 | simpleAtomicIntrinsics starting...                                                                             |
| 1745097499618 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097499618 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097499618 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097499618 | Processing time: 99.556999 (ms)                                                                                |
| 1745097499618 | simpleAtomicIntrinsics completed, returned OK                                                                  |
| 1745097499684 | =========================================                                                                      |
| 1745097499684 |   Running sample simpleVoteIntrinsics                                                                          |
| 1745097499684 | =========================================                                                                      |
| 1745097499835 | [simpleVoteIntrinsics]                                                                                         |
| 1745097499835 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097499835 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097499835 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097499835 | > GPU device has 58 Multi-Processors, SM 8.9 compute capabilities                                              |
| 1745097499835 | [VOTE Kernel Test 1/3]                                                                                         |
| 1745097499835 |  Running <<Vote.Any>> kernel1 ...                                                                              |
| 1745097499835 |  OK                                                                                                            |
| 1745097499835 | [VOTE Kernel Test 2/3]                                                                                         |
| 1745097499835 |  Running <<Vote.All>> kernel2 ...                                                                              |
| 1745097499835 |  OK                                                                                                            |
| 1745097499835 | [VOTE Kernel Test 3/3]                                                                                         |
| 1745097499835 |  Running <<Vote.Any>> kernel3 ...                                                                              |
| 1745097499835 |  OK                                                                                                            |
| 1745097499835 |  Shutting down...                                                                                              |
| 1745097499907 | =========================================                                                                      |
| 1745097499907 |   Running sample vectorAdd                                                                                     |
| 1745097499907 | =========================================                                                                      |
| 1745097500088 | [Vector addition of 50000 elements]                                                                            |
| 1745097500088 | Copy input data from the host memory to the CUDA device                                                        |
| 1745097500088 | CUDA kernel launch with 196 blocks of 256 threads                                                              |
| 1745097500088 | Copy output data from the CUDA device to the host memory                                                       |
| 1745097500088 | Test PASSED                                                                                                    |
| 1745097500088 | Done                                                                                                           |
| 1745097500153 | =========================================                                                                      |
| 1745097500153 |   Running sample warpAggregatedAtomicsCG                                                                       |
| 1745097500153 | =========================================                                                                      |
| 1745097500560 | MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM                                             |
| 1745097500560 | MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere                                                |
| 1745097500560 | GPU Device 0: "Ampere" with compute capability 8.9                                                             |
| 1745097500560 | CPU max matches GPU max                                                                                        |
| 1745097500560 | Warp Aggregated Atomics PASSED                                                                                 |
----------------------------------------------------------------------------------------------------------------------------------
```
</details>

<details>
<summary> Kernels 5.15 and 6.1 ecs-1-nvidia test</summary>

```
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM
MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere
GPU Device 0: "Ampere" with compute capability 8.9

> GPU device has 58 Multi-Processors, SM 8.9 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

MapSMtoCores for SM 8.9 is undefined.  Default to use 128 Cores/SM
MapSMtoArchName for SM 8.9 is undefined.  Default to use Ampere
GPU Device 0: "Ampere" with compute capability 8.9

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```
</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.