### PR TITLE
update generate kernel config scripts to fix globbing

### DIFF
--- a/packages/kernel-5.15/latest-kernel-full-config.sh
+++ b/packages/kernel-5.15/latest-kernel-full-config.sh
@@ -53,7 +53,7 @@ merge_kernel_configs() {
     kernel_path=$PWD
 
     version="$(rpm --query --nosignature --queryformat '%{VERSION}' "${rpm_file}")"
-    readarray -t br_patches < <(find "${kernel_path}" -name "*.patch")
+    readarray -t br_patches < <(find "${kernel_path}" -maxdepth 1  -name "*.patch")
 
     tmpdir=$(mktemp -d)
     cp "${rpm_file}" "${tmpdir}/"

--- a/packages/kernel-6.1/latest-kernel-full-config.sh
+++ b/packages/kernel-6.1/latest-kernel-full-config.sh
@@ -53,7 +53,7 @@ merge_kernel_configs() {
     kernel_path=$PWD
 
     version="$(rpm --query --nosignature --queryformat '%{VERSION}' "${rpm_file}")"
-    readarray -t br_patches < <(find "${kernel_path}" -name "*.patch")
+    readarray -t br_patches < <(find "${kernel_path}" -maxdepth 1 -name "*.patch")
 
     tmpdir=$(mktemp -d)
     cp "${rpm_file}" "${tmpdir}/"


### PR DESCRIPTION
update generate kernel config script to glob BR patches only from current directory not recursively

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #

**Description of changes:**

Fix globbing of bottlerocket patches read to only read from current directory

**Testing done:**

Check GH actions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
