### PR TITLE
kernel-6.12: update to upstream 6.12.22

### DIFF
--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/e48aacb6891d5dc0f536065fa7b52d7b8e7bc0d809fe6f93043b7e8bb0e1fe3b/kernel6.12-6.12.20-23.97.amzn2023.src.rpm"
-sha512 = "18a717b3cb0fa6c19ca6e0567691b3349b92390f8ac6a83555efb7cf026782f20a98292fad10b40f50b2972c39a1d25bddf6c60f49bd98afdc9698e3107498bd"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/f9bc5c1b70c07858f2fb8cb02cfbaa0823c61d85ba51249217dc42c4a2afd8e0/kernel6.12-6.12.22-27.96.amzn2023.src.rpm"
+sha512 = "7c46e8a94113932bff4893cf6597d6f684197600d18c416c728a5c89cd3c50be3ada27196711ad5bed7afd23959bb5b0e7d931eda94c015aac50f8877f79d67d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -4,13 +4,13 @@
 %global kmajor 6.12
 
 Name: %{_cross_os}kernel-%{kmajor}
-Version: 6.12.20
+Version: 6.12.22
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: hhttps://cdn.amazonlinux.com/al2023/blobstore/e48aacb6891d5dc0f536065fa7b52d7b8e7bc0d809fe6f93043b7e8bb0e1fe3b/kernel6.12-6.12.20-23.97.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/f9bc5c1b70c07858f2fb8cb02cfbaa0823c61d85ba51249217dc42c4a2afd8e0/kernel6.12-6.12.22-27.96.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm


### PR DESCRIPTION
**Description of changes:**

Update to upstream kernel 6.12.22

No upstream configuration changes.
One dropped patch (adopted upstream).

**Testing done:**

Created AMI, booted.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
