### PR TITLE
chore: remove force upstream for neuron

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -21,7 +21,6 @@ force-upstream = true
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm"
 sha512 = "e94ea8244f41fd546fb2aa66a793488069a26724b59a4d05355011fca2643f0874a2971e617563c5c2c402952ed160c3b85548f6013c2c60fbc41c89b39133d8"
-force-upstream = true
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -21,7 +21,6 @@ force-upstream = true
 # Use latest-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm"
 sha512 = "e94ea8244f41fd546fb2aa66a793488069a26724b59a4d05355011fca2643f0874a2971e617563c5c2c402952ed160c3b85548f6013c2c60fbc41c89b39133d8"
-force-upstream = true
 
 [build-dependencies]
 microcode = { path = "../microcode" }


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Description of changes:**
Remove the `force-upstream = true` configuration for kernels 5.15 and 6.1


**Testing done:**
`make ARCH=x86_64 && make ARCH=aarch64`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
