### PR TITLE
switch kmod-6.12-nvidia-r570 to kernel-6.12-devel

### DIFF
--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -346,10 +346,13 @@ for fipsmod in $(cat %{_sourcedir}/fipsmodules-%{_cross_arch}) ; do
   (( i+=1 ))
 done
 
-# Create the mount point and drop-in for the runtime kernel-devel directory.
-# This will be empty, but is retained for compatibility with the "release"
-# package, which expects to set up a writable mount under /usr/src/kernels.
-install -d %{buildroot}%{_cross_datadir}/bottlerocket/kernel-devel/%{version}
+# Create the mount point for the runtime kernel-devel directory, and populate
+# with the linker script that driverdog needs.
+install -d %{buildroot}%{_cross_datadir}/bottlerocket/kernel-devel/%{version}/scripts
+install -p -m 0644 scripts/module.lds \
+  %{buildroot}%{_cross_datadir}/bottlerocket/kernel-devel/%{version}/scripts
+
+# Add a drop-in for compatibility with the release package's mount unit.
 LOWERPATH=$(systemd-escape --path %{_cross_sharedstatedir}/kernel-devel/.overlay/lower)
 mkdir -p %{buildroot}%{_cross_unitdir}/"${LOWERPATH}.mount.d"
 sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:210} \
@@ -375,7 +378,8 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 /boot/vmlinuz
 /boot/config
 %dir %{_cross_usrsrc}/kernels
-%{_cross_datadir}/bottlerocket/kernel-devel
+%dir %{_cross_datadir}/bottlerocket/kernel-devel
+%{_cross_datadir}/bottlerocket/kernel-devel/*
 %{_cross_unitdir}/*kernel*devel*.mount.d/no-squashfs.conf
 
 %files headers

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -273,9 +273,6 @@ sed -i \
   -e 's,$(CONFIG_SYSTEM_TRUSTED_KEYRING),n,g' \
   scripts/Makefile
 
-# Restrict permissions on System.map.
-chmod 600 System.map
-
 (
   find * \
     -type f \

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -409,6 +409,9 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %{_cross_includedir}/xen/*
 
 %files devel
+# Allow downstream package builds to modify these files, since they need to
+# rebuild tools for the current host architecture.
+%defattr(664, root, builder, 775)
 %{_cross_usrsrc}/kernels/%{kmajor}
 %{_cross_ksrcdir}
 %{_cross_kmoddir}/source

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -8,6 +8,9 @@
 %global fm_arch %{_cross_arch}
 %endif
 
+%global kernel_major 6.12
+%global kernel_sources %{_cross_usrsrc}/kernels/%{kernel_major}
+
 # With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
 # and firmware/gsp_tu10x.bin the file format changed from executable to relocatable.
 # The __spec_install_post macro will by default try to strip all binary files.
@@ -57,7 +60,7 @@ Source308: load-open-gpu-kernel-modules.service.in
 
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
-BuildRequires: %{_cross_os}kernel-6.12-archive
+BuildRequires: %{_cross_os}kernel-6.12-devel
 Requires: %{_cross_os}nvidia-migmanager
 
 %description
@@ -108,12 +111,6 @@ rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm |
 
 # Add the license.
 install -p -m 0644 %{S:2} %{S:3} .
-
-%global kernel_sources %{_builddir}/kernel-devel
-tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
-
-%define _kernel_version %(ls %{kernel_sources}/include/config/kernel.release)
-%global _cross_kmoddir %{_cross_libdir}/modules/%{_kernel_version}
 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
@@ -179,9 +176,8 @@ install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/{drivers,ld.so.c
 install -d %{buildroot}%{_cross_sysusersdir}
 install -d %{buildroot}%{_cross_bindir}
 
-KERNEL_VERSION=$(cat %{kernel_sources}/include/config/kernel.release)
 sed \
-  -e "s|__KERNEL_VERSION__|${KERNEL_VERSION}|" \
+  -e "s|__KERNEL_VERSION__|%{kernel_major}|" \
   -e "s|__PREFIX__|%{_cross_prefix}|" %{S:200} > nvidia.conf
 install -p -m 0644 nvidia.conf %{buildroot}%{_cross_tmpfilesdir}
 


### PR DESCRIPTION
**Issue number:**
Fixes fallout from the mid-air collision between #95 and #99. 

**Description of changes:**
Switch the 570 kmod to use files from `kernel-6.12-devel` instead of the now-absent `kernel-6.12-archive`.


**Testing done:**
Built locally. Also tested a `g5g.8xlarge` launch and confirmed that the Tesla kmod could be linked and loaded.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
