### PR TITLE
Add `ib_umad` as dependency to Fabric Manager

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/nvidia-fabricmanager.service
+++ b/packages/kmod-6.1-nvidia-r570/nvidia-fabricmanager.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=NVIDIA fabric manager service
+Wants=modprobe@ib_umad.service
+After=modprobe@ib_umad.service
 
 [Service]
 ExecStart=/usr/bin/nv-fabricmanager -c /etc/nvidia/fabricmanager.cfg

--- a/packages/kmod-6.12-nvidia-r570/nvidia-fabricmanager.service
+++ b/packages/kmod-6.12-nvidia-r570/nvidia-fabricmanager.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=NVIDIA fabric manager service
+Wants=modprobe@ib_umad.service
+After=modprobe@ib_umad.service
 
 [Service]
 ExecStart=/usr/bin/nv-fabricmanager -c /etc/nvidia/fabricmanager.cfg


### PR DESCRIPTION
**Description of changes:**
 Some instances need ib_umad loaded before Fabric Manager is started. This adds this dependency.


**Testing done:**
Booted a build and confirmed it loaded the module automatically:
```
lsmod | grep ib
ib_umad                49152  0
ib_core               536576  1 ib_umad

systemctl list-dependencies nvidia-fabricmanager.service
nvidia-fabricmanager.service
● ├─modprobe@ib_umad.service
● ├─system.slice
● └─sysinit.target
●   ├─dev-hugepages.mount
●   ├─dev-mqueue.mount
●   ├─kmod-static-nodes.service
●   ├─ldconfig.service
●   ├─proc-sys-fs-binfmt_misc.mount
●   ├─sys-fs-fuse-connections.mount
●   ├─sys-kernel-config.mount
●   ├─sys-kernel-debug.mount
●   ├─sys-kernel-tracing.mount
●   ├─systemd-journal-catalog-update.service
●   ├─systemd-journal-flush.service
●   ├─systemd-journald.service
●   ├─systemd-machine-id-commit.service
●   ├─systemd-modules-load.service
●   ├─systemd-network-generator.service
○   ├─systemd-pstore.service
●   ├─systemd-random-seed.service
○   ├─systemd-repart.service
●   ├─systemd-resolved.service
●   ├─systemd-sysctl.service
●   ├─systemd-sysusers.service
●   ├─systemd-tmpfiles-setup-dev.service
●   ├─systemd-tmpfiles-setup.service
●   ├─systemd-udev-trigger.service
●   ├─systemd-udevd.service
●   ├─local-fs.target
●   │ ├─has-boot-ever-succeeded.service
●   │ ├─mnt.mount
●   │ ├─opt.mount
●   │ ├─prepare-local-fs.service
●   │ ├─prepare-opt.service
●   │ ├─prepare-var-lib-containerd.service
●   │ ├─prepare-var-lib-kubelet.service
●   │ ├─prepare-var.service
○   │ ├─repart-data-fallback.service
○   │ ├─repart-data-preferred.service
●   │ ├─repart-local.service
●   │ ├─selinux-policy-files.service
●   │ ├─systemd-remount-fs.service
●   │ ├─tmp.mount
●   │ ├─var.mount
●   │ └─x86_64\x2dbottlerocket\x2dlinux\x2dgnu-sys\x2droot-usr-lib-modules.mount
●   └─swap.target

```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
