### PR TITLE
kernel-5.15: update to 5.15.180

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/bcd19872c3df14f84fb665075ded3bb1aae7621cfa52966f0779fb497741a98b/kernel-5.15.179-122.186.amzn2.src.rpm"
-sha512 = "aecb771bdafe35bdb7fd0d46f54462079b6a51711b5e29a93c7a8352404953e1da8b373cf58f5cd20b318ce63f553f98c7b2dfc5a5f2846c0580b7061a489937"
+url = "https://cdn.amazonlinux.com/blobstore/3b6f33f4c20859f5c0ed89c10346530dbaebb54a0bf12be76101a17a52bac8e4/kernel-5.15.180-122.191.amzn2.src.rpm"
+sha512 = "704cd0fa555ad050f67c6251debcda1d4debefc67738e4583eecc498fd91338f9a6e48238c522d9e9c821089a7d5894b0560dda5bea96c7f5cdea3de60c3bbbc"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/config-full-bottlerocket-aarch64
+++ b/packages/kernel-5.15/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.179 Kernel Configuration
+# Linux/arm64 5.15.180 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-5.15/config-full-bottlerocket-x86_64
+++ b/packages/kernel-5.15/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.179 Kernel Configuration
+# Linux/x86 5.15.180 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y
@@ -1729,8 +1729,6 @@ CONFIG_ETHTOOL_NETLINK=y
 #
 # Device Drivers
 #
-CONFIG_HAVE_EISA=y
-# CONFIG_EISA is not set
 CONFIG_HAVE_PCI=y
 CONFIG_PCI=y
 CONFIG_PCI_DOMAINS=y

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.179
+Version: 5.15.180
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/bcd19872c3df14f84fb665075ded3bb1aae7621cfa52966f0779fb497741a98b/kernel-5.15.179-122.186.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/3b6f33f4c20859f5c0ed89c10346530dbaebb54a0bf12be76101a17a52bac8e4/kernel-5.15.180-122.191.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm
@@ -107,8 +107,8 @@ Summary: Header files for the Linux kernel for use by glibc
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
-tar -xof linux-%{version}.tar; rm linux-%{version}.tar
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar.xz {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
+tar -xof linux-%{version}.tar.xz; rm linux-%{version}.tar.xz
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.

--- a/packages/kernel-5.15/latest-kernel-full-config.sh
+++ b/packages/kernel-5.15/latest-kernel-full-config.sh
@@ -59,8 +59,8 @@ merge_kernel_configs() {
     cp "${rpm_file}" "${tmpdir}/"
     pushd "${tmpdir}" || bail "Could not move around"
 
-    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar {,.}config-x86_64 {,.}config-aarch64 {,./}"*.patch" {,./}kernel.spec
-    tar -xof linux-"${version}".tar; rm linux-"${version}".tar
+    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar.xz {,.}config-x86_64 {,.}config-aarch64 {,./}"*.patch" {,./}kernel.spec
+    tar -xof linux-"${version}".tar.xz; rm linux-"${version}".tar.xz
 
     # Find patch ordering based on the upstream SRPM and apply in that order
     readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Update Kernel 5.15 to `5.15.180`

Patch summary
```
Patches that were added:
0186-block-move-blk-throtl-fast-path-inline.patch
0187-blk-throttle-Set-BIO_THROTTLED-when-bio-has-been-thr.patch
0188-ipv6-mcast-extend-RCU-protection-in-igmp6_send.patch
0189-mm-call-the-security_mmap_file-LSM-hook-in-remap_fil.patch
0190-mm-split-critical-region-in-remap_file_pages-and-inv.patch
```

**Testing done:**

Check GH actions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
