### PR TITLE
kernel 6.12: update to 6.12.23

### DIFF
--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/f9bc5c1b70c07858f2fb8cb02cfbaa0823c61d85ba51249217dc42c4a2afd8e0/kernel6.12-6.12.22-27.96.amzn2023.src.rpm"
-sha512 = "7c46e8a94113932bff4893cf6597d6f684197600d18c416c728a5c89cd3c50be3ada27196711ad5bed7afd23959bb5b0e7d931eda94c015aac50f8877f79d67d"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/f183a3597b33df4ee0a4eaa32de802eac8a2bd7fac833682475310601b5f3eb9/kernel6.12-6.12.23-29.97.amzn2023.src.rpm"
+sha512 = "a2ea33f903f8fb166de3af10d57eed63cbad41110d1feeafa7f9212e0bb19d87dc0e5bbac56b42769cf33765ae4fe6ab7994394a82647b5785eb2960b3c36ab9"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -4,13 +4,13 @@
 %global kmajor 6.12
 
 Name: %{_cross_os}kernel-%{kmajor}
-Version: 6.12.22
+Version: 6.12.23
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/f9bc5c1b70c07858f2fb8cb02cfbaa0823c61d85ba51249217dc42c4a2afd8e0/kernel6.12-6.12.22-27.96.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/f183a3597b33df4ee0a4eaa32de802eac8a2bd7fac833682475310601b5f3eb9/kernel6.12-6.12.23-29.97.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm

--- a/tools/collect-kernel-config
+++ b/tools/collect-kernel-config
@@ -38,7 +38,7 @@ readonly output_dir
 mkdir -p ${output_dir}
 echo "Created ${output_dir}"
 
-for kernel in 5.15 6.1; do
+for kernel in 5.15 6.1 6.12; do
     for arch in x86_64 aarch64; do
 	rpm2cpio ./build/rpms/kernel-${kernel}/bottlerocket-kernel-${kernel}-${kernel}*.${arch}.rpm | cpio --extract --to-stdout ./boot/config > ${output_dir}/config-${kernel}-${arch}.config
     done


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Update to upstream kernel 6.12.23

Patch summary
```
Patches that changed:
Patches that were dropped:
Patches that were added:
0096-net-mlx5-HWS-change-error-flow-on-matcher-disconnect.patch
```

Config diff
```
diff ../current-latest/config-6.12-aarch64.config ../updated-configs/config-6.12-aarch64.config
3c3
< # Linux/arm64 6.12.22 Kernel Configuration
---
> # Linux/arm64 6.12.23 Kernel Configuration
22a23
> CONFIG_LD_CAN_USE_KEEP_IN_OVERLAY=y
diff ../current-latest/config-6.12-x86_64.config ../updated-configs/config-6.12-x86_64.config
3c3
< # Linux/x86 6.12.22 Kernel Configuration
---
> # Linux/x86 6.12.23 Kernel Configuration
22a23
> CONFIG_LD_CAN_USE_KEEP_IN_OVERLAY=y
1891,1892d1891
< CONFIG_HAVE_EISA=y
< # CONFIG_EISA is not set

```

**Testing done:**

Check GH actions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
