### PR TITLE
kernel-6.12: add advisories for kernel-6.12.22 and 6.12.23

### DIFF
--- a/advisories/2.3.0/BRSA-dvk8feip6pjw.toml
+++ b/advisories/2.3.0/BRSA-dvk8feip6pjw.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-dvk8feip6pjw"
+title = "kernel CVE-2025-21926"
+cve = "CVE-2025-21926"
+severity = "moderate"
+description = "In the Linux kernel, the following vulnerability has been resolved: net: gso: fix ownership in __udp_gso_segment"
+
+[[advisory.products]]
+package-name = "kernel-6.12"
+patched-version = "6.12.22"
+patched-epoch = "0"
+
+[updateinfo]
+author = "dhwanise"
+issue-date = 2025-04-28T23:26:21Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.0"

--- a/advisories/2.3.0/BRSA-zo9om0fo2ba6.toml
+++ b/advisories/2.3.0/BRSA-zo9om0fo2ba6.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-zo9om0fo2ba6"
+title = "kernel CVE-2025-21893"
+cve = "CVE-2025-21893"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: keys: Fix UAF in key_put()"
+
+[[advisory.products]]
+package-name = "kernel-6.12"
+patched-version = "6.12.22"
+patched-epoch = "0"
+
+[updateinfo]
+author = "dhwanise"
+issue-date = 2025-04-28T23:26:21Z
+arches = ["aarch64", "x86_64"]
+version = "2.3.0"

--- a/advisories/2.3.3/BRSA-tbne3lsrxho1.toml
+++ b/advisories/2.3.3/BRSA-tbne3lsrxho1.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-tbne3lsrxho1"
+title = "kernel CVE-2025-21751"
+cve = "CVE-2025-21751"
+severity = "high"
+description = "In the Linux kernel, the following vulnerability has been resolved: net/mlx5: HWS, change error flow on matcher disconnect"
+
+[[advisory.products]]
+package-name = "kernel-6.12"
+patched-version = "6.12.23"
+patched-epoch = "0"
+
+[updateinfo]
+author = "dhwanise"
+issue-date = 2025-05-01T20:55:52Z
+arches = ["x86_64", "aarch64"]
+version = "2.3.3"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Add advisories for kernel-6.12 versions 6.12.22 and 6.12.23


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
