### PR TITLE
Add additional Requires for kmods

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -66,7 +66,13 @@ Source505: load-grid-kernel-modules.service.in
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.1-archive
+Requires: %{_cross_os}kernel-6.1
 Requires: %{_cross_os}nvidia-migmanager
+Requires: %{name}-tesla
+Requires: %{name}-open-gpu
+%if "%{_cross_arch}" == "x86_64"
+Requires: %{name}-grid
+%endif
 
 %description
 %{summary}.
@@ -83,6 +89,7 @@ Summary: NVIDIA %{tesla_major} Open GPU driver
 Version: %{tesla_ver}
 License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
 
 %description open-gpu
 %{summary}.
@@ -93,6 +100,7 @@ Summary: NVIDIA %{tesla_major} GRID driver
 Version: %{tesla_ver}
 License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
 
 %description grid
 %{summary}.
@@ -106,10 +114,6 @@ Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 Requires: %{name}-fabricmanager
 Provides: %{name}-tesla(fabricmanager)
-Requires: %{name}-open-gpu
-%if "%{_cross_arch}" == "x86_64"
-Requires: %{name}-grid
-%endif
 
 %description tesla
 %{summary}

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -58,7 +58,10 @@ Source308: load-open-gpu-kernel-modules.service.in
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.1-archive
+Requires: %{_cross_os}kernel-6.1
 Requires: %{_cross_os}nvidia-migmanager
+Requires: %{name}-tesla
+Requires: %{name}-open-gpu-%{tesla_major}
 
 %description
 %{summary}.
@@ -75,6 +78,7 @@ Summary: NVIDIA %{tesla_major} Open GPU driver
 Version: %{tesla_ver}
 License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
 
 %description open-gpu-%{tesla_major}
 %{summary}.
@@ -87,7 +91,6 @@ Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 Requires: %{name}-fabricmanager
 Provides: %{name}-tesla(fabricmanager)
-Requires: %{name}-open-gpu-%{tesla_major}
 
 %description tesla-%{tesla_major}
 %{summary}

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -69,7 +69,13 @@ Source505: load-grid-kernel-modules.service.in
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.12-devel
+Requires: %{_cross_os}kernel-6.12
 Requires: %{_cross_os}nvidia-migmanager
+Requires: %{name}-tesla
+Requires: %{name}-open-gpu
+%if "%{_cross_arch}" == "x86_64"
+Requires: %{name}-grid
+%endif
 
 %description
 %{summary}.
@@ -86,6 +92,7 @@ Summary: NVIDIA %{tesla_major} Open GPU driver
 Version: %{tesla_ver}
 License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
 
 %description open-gpu
 %{summary}.
@@ -96,6 +103,7 @@ Summary: NVIDIA %{tesla_major} GRID driver
 Version: %{tesla_ver}
 License: MIT AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
 
 %description grid
 %{summary}.
@@ -109,10 +117,6 @@ Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 Requires: %{name}-fabricmanager
 Provides: %{name}-tesla(fabricmanager)
-Requires: %{name}-open-gpu
-%if "%{_cross_arch}" == "x86_64"
-Requires: %{name}-grid
-%endif
 
 %description tesla
 %{summary}


### PR DESCRIPTION

**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/132

**Description of changes:**

This adds the ability to specify `kmod-6.1-nvidia-r570` or `kmod-6.1-nvidia-r570-tesla` in a variant definition. It also will prevent installing a mismatched kernel and kmod in a variant by requiring the kernel the kmod is built against.

**Testing done:**
Built a variant with `kmod-6.12-nvidia-r570` instead of `kmod-6.12-nvidia-r570-tesla` and validated the drivers loaded properly.

Tried building a variant with mismatched kernel and kmod and saw the build fail, its not the most straightforward conflict but gets the job done:
```
...
  3.341 Verifying packages...
  7.471 Preparing packages...
  7.669         file /boot/boot-config.d/05-aws.conf conflicts between attempted installs of bottlerocket-kernel-6.1-bootconfig-aws-6.1.134-1.1746121535.0f6fbaf3.br1.x86_64 and bottlerocket-kernel-6.12-bootconfig-aws-6.12.23-1.1746121535.0f6fbaf3.br1.x86_64
  7.669         file /boot/config conflicts between attempted installs of bottlerocket-kernel-6.1-6.1.134-1.1746121535.0f6fbaf3.br1.x86_64 and bottlerocket-kernel-6.12-6.12.23-1.1746121535.0f6fbaf3.br1.x86_64
  7.669         file /boot/vmlinuz conflicts between attempted installs of bottlerocket-kernel-6.1-6.1.134-1.1746121535.0f6fbaf3.br1.x86_64 and bottlerocket-kernel-6.12-6.12.23-1.1746121535.0f6fbaf3.br1.x86_64
  ------
...
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
