### PR TITLE
Strip kmod symbols

### DIFF
--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -126,6 +126,11 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 # we don't set this flag the compilation fails
 make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
+# Strip symbols out of the .ko files
+for module in *.ko; do
+  %{_cross_target}-strip -g --strip-unneeded "${module}"
+done
+
 # end open driver build
 popd
 

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -148,6 +148,11 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 # compile the kernel, if we don't set this flag the compilation fails
 make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
+# Strip symbols out of the .ko files
+for module in *.ko; do
+  %{_cross_target}-strip -g --strip-unneeded "${module}"
+done
+
 # end open driver build
 popd
 
@@ -182,6 +187,11 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/grid
 # We set IGNORE_CC_MISMATCH even though we are using the same compiler used to
 # compile the kernel, if we don't set this flag the compilation fails
 make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 GRID_BUILD=1 GRID_BUILD_CSP=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
+
+# Strip symbols out of the .ko files
+for module in *.ko; do
+  %{_cross_target}-strip -g --strip-unneeded "${module}"
+done
 
 # End GRID build
 popd

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -126,6 +126,11 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 # we don't set this flag the compilation fails
 make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
+# Strip symbols out of the .ko files
+for module in *.ko; do
+  %{_cross_target}-strip -g --strip-unneeded "${module}"
+done
+
 # end open driver build
 popd
 

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -145,6 +145,11 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 # compile the kernel, if we don't set this flag the compilation fails
 make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
+# Strip symbols out of the .ko files
+for module in *.ko; do
+  %{_cross_target}-strip -g --strip-unneeded "${module}"
+done
+
 # end open driver build
 popd
 
@@ -179,6 +184,11 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/grid
 # We set IGNORE_CC_MISMATCH even though we are using the same compiler used to
 # compile the kernel, if we don't set this flag the compilation fails
 make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 GRID_BUILD=1 GRID_BUILD_CSP=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
+
+# Strip symbols out of the .ko files
+for module in *.ko; do
+  %{_cross_target}-strip -g --strip-unneeded "${module}"
+done
 
 # End GRID build
 popd


### PR DESCRIPTION
**Description of changes:**

Strip kernel module symbols for `open-gpu` and `grid`

**Testing done:**

 I confirmed the open gpu driver is loaded and the `.ko` files were stripped with the following combos:

**`aws-k8s-1.31-nvidia` and a `g6.2xlarge` instance**

<details>

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c0610-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.31-nvidia)",
    "variant_id": "aws-k8s-1.31-nvidia",
    "version_id": "1.39.0"
  }
}
bash-5.1# cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  570.133.20  Release Build  (dvs-builder@U22-I3-AF03-14-3)  Sun Apr 13 04:34:43 UTC 2025
GCC version:  gcc version 13.3.0 (Buildroot 2024.11.1)
bash-5.1# ls -lah /lib/modules/6.1.134/kernel/drivers/extra/video/nvidia/open-gpu/
total 22M
drwxr-xr-x. 2 root root  115 May  9 00:54 .
drwxr-xr-x. 5 root root   47 May  9 00:53 ..
-rwxr-xr-x. 1 root root 239K May  9 00:54 nvidia-drm.ko
-rwxr-xr-x. 1 root root 2.8M May  9 00:54 nvidia-modeset.ko
-rwxr-xr-x. 1 root root 5.5K May  9 00:54 nvidia-peermem.ko
-rwxr-xr-x. 1 root root 3.3M May  9 00:54 nvidia-uvm.ko
-rwxr-xr-x. 1 root root  15M May  9 00:54 nvidia.ko
bash-5.1#
```
</details>

**`aws-k8s-1.27-nvidia` and a `g6.2xlarge` instance**

<details>

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c0610-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.27-nvidia)",
    "variant_id": "aws-k8s-1.27-nvidia",
    "version_id": "1.39.0"
  }
}
bash-5.1# cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  535.247.01  Release Build  (dvs-builder@U22-A24-12-4)  Wed Mar 26 06:22:53 UTC 2025
GCC version:  gcc version 13.3.0 (Buildroot 2024.11.1)
bash-5.1# ls -lah /lib/modules/5.15.180/kernel/drivers/extra/video/nvidia/open-gpu/
total 16M
drwxr-xr-x. 2 root root 4.0K May  9 01:09 .
drwxr-xr-x. 4 root root 4.0K May  9 01:09 ..
-rwxr-xr-x. 1 root root 156K May  9 01:09 nvidia-drm.ko
-rwxr-xr-x. 1 root root 2.4M May  9 01:09 nvidia-modeset.ko
-rwxr-xr-x. 1 root root 5.3K May  9 01:09 nvidia-peermem.ko
-rwxr-xr-x. 1 root root 2.9M May  9 01:09 nvidia-uvm.ko
-rwxr-xr-x. 1 root root  11M May  9 01:09 nvidia.ko
bash-5.1#
```
</details>


**`aws-k8s-1.33-nvidia` and a `g6.2xlarge` instance**

<details>

```bash
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c0610-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.33-nvidia)",
    "variant_id": "aws-k8s-1.33-nvidia",
    "version_id": "1.39.0"
  }
}
bash-5.1# cat /proc/driver/nvidia/version
NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  570.133.20  Release Build  (dvs-builder@U22-I3-AF03-14-3)  Sun Apr 13 04:34:43 UTC 2025
GCC version:  gcc version 13.3.0 (Buildroot 2024.11.1)
bash-5.1# ls -lah /lib/modules/6.12/kernel/drivers/extra/video/nvidia/open-gpu/
total 23M
drwxr-xr-x. 2 root root  115 May  9 01:15 .
drwxr-xr-x. 5 root root   47 May  9 01:15 ..
-rwxr-xr-x. 1 root root 285K May  9 01:15 nvidia-drm.ko
-rwxr-xr-x. 1 root root 2.9M May  9 01:15 nvidia-modeset.ko
-rwxr-xr-x. 1 root root 6.6K May  9 01:15 nvidia-peermem.ko
-rwxr-xr-x. 1 root root 4.0M May  9 01:15 nvidia-uvm.ko
-rwxr-xr-x. 1 root root  15M May  9 01:15 nvidia.ko
bash-5.1#
```

</details>

**smoke test**

**aws-k8s-1.31-nvidia (6.1 kernel)**

<details>

```
GPU Device 0: "Ada" with compute capability 8.9

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB	 UMhint	UMhntAs	 UMeasy	  0Copy	MemCopy	CpAsync	CpHpglk	CpPglAs
4	  0.239	  0.277	  0.349	  0.014	  0.030	  0.025	  0.030	  0.023
16	  0.253	  0.307	  0.565	  0.027	  0.042	  0.036	  0.045	  0.046
64	  0.309	  0.329	  0.896	  0.100	  0.098	  0.094	  0.088	  0.076
256	  0.651	  0.571	  1.462	  0.499	  0.318	  0.292	  0.262	  0.256
1024	  2.104	  1.823	  3.303	  3.100	  1.200	  1.146	  0.994	  1.000
4096	  7.693	  6.646	 12.508	 22.719	  5.294	  5.265	  5.032	  5.021
16384	 32.778	 29.781	 54.031	169.347	 32.799	 32.957	 24.471	 24.226

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
//samples/deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA L4"
  CUDA Driver Version / Runtime Version          12.8 / 12.8
  CUDA Capability Major/Minor version number:    8.9
  Total amount of global memory:                 22574 MBytes (23670685696 bytes)
  (058) Multiprocessors, (128) CUDA Cores/MP:    7424 CUDA Cores
  GPU Max Clock rate:                            2040 MHz (2.04 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              192-bit
  L2 Cache Size:                                 50331648 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 49 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.8, CUDA Runtime Version = 12.8, NumDevs = 1
Result = PASS
[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ada" with compute capability 8.9

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 2007.12 GFlop/s, Time= 2.090 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
Initializing...
GPU Device 0: "Ada" with compute capability 8.9

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 1.637376 ms
TOPS: 83.94
reductionMultiBlockCG Starting...

GPU Device 0: "Ada" with compute capability 8.9

33554432 elements
numThreads: 768
numBlocks: 58

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.577490 ms
Bandwidth:    232.415638 GB/s

GPU result = 1.992401242256
CPU result = 1.992401361465
Starting shfl_scan
GPU Device 0: "Ada" with compute capability 8.9

> Detected Compute SM 8.9 hardware with 58 multi-processors
Starting shfl_scan
GPU Device 0: "Ada" with compute capability 8.9

> Detected Compute SM 8.9 hardware with 58 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.372512
65536 elements scanned in 0.372512 ms -> 175.929901 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.117010 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.061408 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.080320 ms
CheckSum: 2073600, (expect 1920x1080=2073600)
//samples/simpleAWBarrier starting...
GPU Device 0: "Ada" with compute capability 8.9

Launching normVecByDotProductAWBarrier kernel with numBlocks = 116 blockSize = 768
Result = PASSED
//samples/simpleAWBarrier completed, returned OK
simpleAtomicIntrinsics starting...
GPU Device 0: "Ada" with compute capability 8.9

Processing time: 1.380000 (ms)
simpleAtomicIntrinsics completed, returned OK
[simpleVoteIntrinsics]
GPU Device 0: "Ada" with compute capability 8.9

> GPU device has 58 Multi-Processors, SM 8.9 compute capabilities

[VOTE Kernel Test 1/3]
	Running <<Vote.Any>> kernel1 ...
	OK

[VOTE Kernel Test 2/3]
	Running <<Vote.All>> kernel2 ...
	OK

[VOTE Kernel Test 3/3]
	Running <<Vote.Any>> kernel3 ...
	OK
	Shutting down...
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
GPU Device 0: "Ada" with compute capability 8.9

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

</details>

**aws-k8s-1.33-nvidia (6.12)**

<details>

```
GPU Device 0: "Ada" with compute capability 8.9

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB	 UMhint	UMhntAs	 UMeasy	  0Copy	MemCopy	CpAsync	CpHpglk	CpPglAs
4	  0.212	  0.241	  0.362	  0.013	  0.028	  0.025	  0.030	  0.023
16	  0.224	  0.272	  0.567	  0.027	  0.041	  0.036	  0.045	  0.044
64	  0.302	  0.369	  0.875	  0.093	  0.093	  0.084	  0.084	  0.077
256	  0.667	  0.669	  1.482	  0.513	  0.304	  0.286	  0.266	  0.259
1024	  2.001	  1.907	  3.202	  3.145	  1.165	  1.107	  1.009	  1.000
4096	  7.137	  6.247	 12.505	 22.419	  4.778	  4.708	  4.585	  4.589
16384	 31.769	 31.334	 55.677	173.183	 31.668	 30.641	 28.283	 28.454

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
//samples/deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA L4"
  CUDA Driver Version / Runtime Version          12.8 / 12.8
  CUDA Capability Major/Minor version number:    8.9
  Total amount of global memory:                 22574 MBytes (23670685696 bytes)
  (058) Multiprocessors, (128) CUDA Cores/MP:    7424 CUDA Cores
  GPU Max Clock rate:                            2040 MHz (2.04 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              192-bit
  L2 Cache Size:                                 50331648 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 49 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.8, CUDA Runtime Version = 12.8, NumDevs = 1
Result = PASS
[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ada" with compute capability 8.9

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 1955.69 GFlop/s, Time= 2.145 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
Initializing...
GPU Device 0: "Ada" with compute capability 8.9

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 1.652736 ms
TOPS: 83.16
reductionMultiBlockCG Starting...

GPU Device 0: "Ada" with compute capability 8.9

33554432 elements
numThreads: 768
numBlocks: 58

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.576650 ms
Bandwidth:    232.754199 GB/s

GPU result = 1.992401242256
CPU result = 1.992401361465
Starting shfl_scan
GPU Device 0: "Ada" with compute capability 8.9

> Detected Compute SM 8.9 hardware with 58 multi-processors
Starting shfl_scan
GPU Device 0: "Ada" with compute capability 8.9

> Detected Compute SM 8.9 hardware with 58 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.284736
65536 elements scanned in 0.284736 ms -> 230.164062 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.117320 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.031744 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.069856 ms
CheckSum: 2073600, (expect 1920x1080=2073600)
//samples/simpleAWBarrier starting...
GPU Device 0: "Ada" with compute capability 8.9

Launching normVecByDotProductAWBarrier kernel with numBlocks = 116 blockSize = 768
Result = PASSED
//samples/simpleAWBarrier completed, returned OK
simpleAtomicIntrinsics starting...
GPU Device 0: "Ada" with compute capability 8.9

Processing time: 1.450000 (ms)
simpleAtomicIntrinsics completed, returned OK
[simpleVoteIntrinsics]
GPU Device 0: "Ada" with compute capability 8.9

> GPU device has 58 Multi-Processors, SM 8.9 compute capabilities

[VOTE Kernel Test 1/3]
	Running <<Vote.Any>> kernel1 ...
	OK

[VOTE Kernel Test 2/3]
	Running <<Vote.All>> kernel2 ...
	OK

[VOTE Kernel Test 3/3]
	Running <<Vote.Any>> kernel3 ...
	OK
	Shutting down...
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
GPU Device 0: "Ada" with compute capability 8.9

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

</details>

**aws-k8s-1.27-nvidia (5.15)**

<details>

```
GPU Device 0: "Ada" with compute capability 8.9

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB	 UMhint	UMhntAs	 UMeasy	  0Copy	MemCopy	CpAsync	CpHpglk	CpPglAs
4	  0.237	  0.173	  0.344	  0.013	  0.029	  0.025	  0.031	  0.023
16	  0.196	  0.235	  0.555	  0.027	  0.045	  0.035	  0.046	  0.047
64	  0.277	  0.314	  0.886	  0.092	  0.099	  0.084	  0.085	  0.076
256	  0.588	  0.575	  1.397	  0.510	  0.305	  0.282	  0.271	  0.260
1024	  1.902	  1.738	  3.007	  3.109	  1.149	  1.092	  1.001	  0.994
4096	  6.751	  6.174	 10.975	 22.265	  4.661	  4.618	  4.507	  4.485
16384	 29.737	 27.953	 48.043	168.618	 33.529	 32.986	 23.587	 23.626

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
//samples/deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA L4"
  CUDA Driver Version / Runtime Version          12.2 / 12.8
  CUDA Capability Major/Minor version number:    8.9
  Total amount of global memory:                 22491 MBytes (23583784960 bytes)
  (058) Multiprocessors, (128) CUDA Cores/MP:    7424 CUDA Cores
  GPU Max Clock rate:                            2040 MHz (2.04 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              192-bit
  L2 Cache Size:                                 50331648 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 49 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.2, CUDA Runtime Version = 12.8, NumDevs = 1
Result = PASS
[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Ada" with compute capability 8.9

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 1986.63 GFlop/s, Time= 2.111 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.
Initializing...
GPU Device 0: "Ada" with compute capability 8.9

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 1.569792 ms
TOPS: 87.55
reductionMultiBlockCG Starting...

GPU Device 0: "Ada" with compute capability 8.9

33554432 elements
numThreads: 768
numBlocks: 58

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 0.576670 ms
Bandwidth:    232.746091 GB/s

GPU result = 1.992401242256
CPU result = 1.992401361465
Starting shfl_scan
GPU Device 0: "Ada" with compute capability 8.9

> Detected Compute SM 8.9 hardware with 58 multi-processors
Starting shfl_scan
GPU Device 0: "Ada" with compute capability 8.9

> Detected Compute SM 8.9 hardware with 58 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.238656
65536 elements scanned in 0.238656 ms -> 274.604462 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.116940 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.023552 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.071232 ms
CheckSum: 2073600, (expect 1920x1080=2073600)
//samples/simpleAWBarrier starting...
GPU Device 0: "Ada" with compute capability 8.9

Launching normVecByDotProductAWBarrier kernel with numBlocks = 116 blockSize = 768
Result = PASSED
//samples/simpleAWBarrier completed, returned OK
simpleAtomicIntrinsics starting...
GPU Device 0: "Ada" with compute capability 8.9

Processing time: 1.237000 (ms)
simpleAtomicIntrinsics completed, returned OK
[simpleVoteIntrinsics]
GPU Device 0: "Ada" with compute capability 8.9

> GPU device has 58 Multi-Processors, SM 8.9 compute capabilities

[VOTE Kernel Test 1/3]
	Running <<Vote.Any>> kernel1 ...
	OK

[VOTE Kernel Test 2/3]
	Running <<Vote.All>> kernel2 ...
	OK

[VOTE Kernel Test 3/3]
	Running <<Vote.Any>> kernel3 ...
	OK
	Shutting down...
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
GPU Device 0: "Ada" with compute capability 8.9

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

</details>

Also, we got a 73 MBs back:

```
# This is k8s 1.31
/dev/root        1.8G  1.6G  109M  94% /
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
