### PR TITLE
Cache COPYING file for NVIDIA kmods

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -16,6 +16,7 @@ runs:
           build/rpms
           build/state
           target
+          packages/kmod-*-nvidia/COPYING
         key: build-cache
     - run: cargo install cargo-make
       shell: bash

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -58,4 +58,5 @@ jobs:
             build/rpms
             build/state
             target
+            packages/kmod-*-nvidia/COPYING
           key: ${{ env.cache-key }}


### PR DESCRIPTION
**Description of changes:**

Previously, the COPYING file was fetched directly from GitHub as a raw file on each build, leading to occasional failures due to GitHub's rate limiting for unauthenticated requests.

Cache the file between builds to avoid hitting these rate limits during workflow re-executions.

**Testing done:**

:grin:

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
