### PR TITLE
kmod-6.12-nvidia-r570: install nvoptix.bin from the drivers

### DIFF
--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -278,6 +278,7 @@ install -m 755 nvidia-cuda-mps-control %{buildroot}%{_cross_bindir}
 install -m 755 nvidia-cuda-mps-server %{buildroot}%{_cross_bindir}
 install -m 755 nvidia-persistenced %{buildroot}%{_cross_bindir}
 install -m 4755 nvidia-modprobe %{buildroot}%{_cross_bindir}
+install -m 755 nvoptix.bin %{buildroot}%{_cross_datadir}/nvidia/
 ln -rs %{buildroot}%{_cross_bindir}/nvidia-smi %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-smi
 ln -rs %{buildroot}%{_cross_bindir}/nvidia-debugdump %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-debugdump
 ln -rs %{buildroot}%{_cross_bindir}/nvidia-cuda-mps-control %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
@@ -477,6 +478,7 @@ popd
 %{_cross_libdir}/nvidia/tesla/libnvidia-fbc.so.1
 %{_cross_libdir}/nvidia/tesla/libnvoptix.so.%{tesla_ver}
 %{_cross_libdir}/nvidia/tesla/libnvoptix.so.1
+%{_cross_datadir}/nvidia/nvoptix.bin
 
 # Graphics GLVND libs
 %{_cross_libdir}/nvidia/tesla/libnvidia-glvkspirv.so.%{tesla_ver}


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #127

**Description of changes:**

In order to be able to use the Nvidia OptiX denoiser, the `nvoptix.bin` binary should be copied from the drivers at build time so that [`nvidia-container-toolkit` can mount it](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/internal/discover/graphics.go#L63) inside containers requesting the required graphics capabilities. Help regarding the proper installation location would be highly appreciated as this is my first contribution to Bottlerocket.

**Testing done:**

An AMI with the given changes was built and tested against our EKS clusters for the past 3 weeks. I am definitely willing to run more tests if needed.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
