### PR TITLE
tweaks for the 6.12 kernel config

### DIFF
--- a/packages/kernel-6.12/config-bottlerocket
+++ b/packages/kernel-6.12/config-bottlerocket
@@ -147,6 +147,12 @@ CONFIG_FW_LOADER_COMPRESS=y
 # CONFIG_FW_LOADER_COMPRESS_XZ is not set
 CONFIG_FW_LOADER_COMPRESS_ZSTD=y
 
+# Prefer LZ4 for zram compression
+CONFIG_ZRAM_BACKEND_LZ4=y
+CONFIG_ZRAM_DEF_COMP_LZ4=y
+# CONFIG_ZRAM_BACKEND_LZO is not set
+# CONFIG_ZRAM_DEF_COMP_LZO is not set
+
 # Add virtio drivers for development setups running as guests in qemu
 CONFIG_VIRTIO_CONSOLE=m
 CONFIG_HW_RANDOM_VIRTIO=m

--- a/packages/kernel-6.12/config-bottlerocket
+++ b/packages/kernel-6.12/config-bottlerocket
@@ -167,6 +167,9 @@ CONFIG_BOOT_CONFIG=y
 # Enables support for checkpoint/restore
 CONFIG_CHECKPOINT_RESTORE=y
 
+# Enable cgroup v1 cpusets controller
+CONFIG_CPUSETS_V1=y
+
 # Disable user-mode helper for bpfilter, since it relies on a more complete set
 # of userspace libraries for the target than we want to depend on at kernel
 # build time.

--- a/packages/kernel-6.12/config-bottlerocket
+++ b/packages/kernel-6.12/config-bottlerocket
@@ -1,8 +1,7 @@
 # Because Bottlerocket does not have an initramfs, modules required to mount
 # the root filesystem must be set to y.
 
-# The root filesystem is ext4 or erofs
-CONFIG_EXT4_FS=y
+# The root filesystem is erofs
 CONFIG_EROFS_FS=y
 
 # compress arm64 kernels

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -858,6 +858,7 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %{_cross_kmoddir}/kernel/fs/configfs/configfs.%{_ko}
 %{_cross_kmoddir}/kernel/fs/efivarfs/efivarfs.%{_ko}
 %{_cross_kmoddir}/kernel/fs/exfat/exfat.%{_ko}
+%{_cross_kmoddir}/kernel/fs/ext4/ext4.%{_ko}
 %{_cross_kmoddir}/kernel/fs/fat/fat.%{_ko}
 %{_cross_kmoddir}/kernel/fs/fat/msdos.%{_ko}
 %{_cross_kmoddir}/kernel/fs/fat/vfat.%{_ko}
@@ -865,6 +866,7 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %{_cross_kmoddir}/kernel/fs/fuse/fuse.%{_ko}
 %{_cross_kmoddir}/kernel/fs/fuse/virtiofs.%{_ko}
 %{_cross_kmoddir}/kernel/fs/isofs/isofs.%{_ko}
+%{_cross_kmoddir}/kernel/fs/jbd2/jbd2.%{_ko}
 %{_cross_kmoddir}/kernel/fs/lockd/lockd.%{_ko}
 %{_cross_kmoddir}/kernel/fs/lustre/fid/fid.%{_ko}
 %{_cross_kmoddir}/kernel/fs/lustre/fld/fld.%{_ko}
@@ -877,6 +879,7 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %{_cross_kmoddir}/kernel/fs/lustre/obdecho/obdecho.%{_ko}
 %{_cross_kmoddir}/kernel/fs/lustre/osc/osc.%{_ko}
 %{_cross_kmoddir}/kernel/fs/lustre/ptlrpc/ptlrpc.%{_ko}
+%{_cross_kmoddir}/kernel/fs/mbcache.%{_ko}
 %{_cross_kmoddir}/kernel/fs/netfs/netfs.%{_ko}
 %{_cross_kmoddir}/kernel/fs/nfs/blocklayout/blocklayoutdriver.%{_ko}
 %{_cross_kmoddir}/kernel/fs/nfs_common/grace.%{_ko}
@@ -955,6 +958,7 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %if "%{_cross_arch}" == "x86_64"
 %{_cross_kmoddir}/kernel/lib/crc8.%{_ko}
 %endif
+%{_cross_kmoddir}/kernel/lib/crc16.%{_ko}
 %{_cross_kmoddir}/kernel/lib/crc-itu-t.%{_ko}
 %{_cross_kmoddir}/kernel/lib/crypto/libarc4.%{_ko}
 %{_cross_kmoddir}/kernel/lib/crypto/libchacha20poly1305.%{_ko}


### PR DESCRIPTION
**Issue number:**
N/A

**Description of changes:**
A handful of tweaks for the 6.12 kernel config:
* Enable cpusets for cgroup v1.
* Prefer LZ4 over LZO for zram
* Drop ext4 from the set of built-in drivers




**Testing done:**
`lsmod` shows `ext4` is loaded as a module:
```
# lsmod | grep ext4
ext4                 1175552  4
crc16                  12288  1 ext4
mbcache                16384  1 ext4
jbd2                  204800  1 ext4
```

`zramctl` shows that the lz4 algorithm is used:
```
# zramctl
NAME       ALGORITHM DISKSIZE DATA COMPR TOTAL STREAMS MOUNTPOINT
/dev/zram0 lz4             1G   4K   44B    4K       4 [SWAP]
```

`kubelet` is running when cgroup v1 is used:
```
# findmnt /sys/fs/cgroup -o fstype -n
tmpfs

# systemctl -t service --state=running | grep kubelet
  kubelet.service                 loaded active running Kubele
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
