### PR TITLE
Update kernels 6.1 and 6.12

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/1448230a64777613fa4c0f0798411bad58d1ab86b851ff38cdac0880ef155856/kernel-6.1.134-150.224.amzn2023.src.rpm"
-sha512 = "8246ddc620827ac002a9caed90e067a4502f38956167294f199af205ea8487b2845e3bae9be86b815777521e3ba693261c0b2bb523e1a4dda81c74341ebadcb8"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/08216c7c9bf70c353575bb560b0d11595f9ce9e453b5af450b72683af63811c5/kernel-6.1.134-152.225.amzn2023.src.rpm"
+sha512 = "02ffebcff5c732fd7c338755f1f5585c9ce4f392b5ffa13e297b5f828c0d27098b704f46409a38063fbd480360f57da9ed97c0c0e4aa426324cbe21d91309f61"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/1448230a64777613fa4c0f0798411bad58d1ab86b851ff38cdac0880ef155856/kernel-6.1.134-150.224.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/08216c7c9bf70c353575bb560b0d11595f9ce9e453b5af450b72683af63811c5/kernel-6.1.134-152.225.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/f183a3597b33df4ee0a4eaa32de802eac8a2bd7fac833682475310601b5f3eb9/kernel6.12-6.12.23-29.97.amzn2023.src.rpm"
-sha512 = "a2ea33f903f8fb166de3af10d57eed63cbad41110d1feeafa7f9212e0bb19d87dc0e5bbac56b42769cf33765ae4fe6ab7994394a82647b5785eb2960b3c36ab9"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/affe4afff48d5589bf6dd4b04c59a853822b8d36c785d3d9006fb18f7b35b6c3/kernel6.12-6.12.25-32.101.amzn2023.src.rpm"
+sha512 = "c1ac9f080412834485e9244d8b8342c05c175d09956ba9202e264452dc9b6e04c2913584f2658ed1570e6f6169a89e5dcc52813a52635f5de0774933c9f7adc0"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -4,13 +4,13 @@
 %global kmajor 6.12
 
 Name: %{_cross_os}kernel-%{kmajor}
-Version: 6.12.23
+Version: 6.12.25
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/f183a3597b33df4ee0a4eaa32de802eac8a2bd7fac833682475310601b5f3eb9/kernel6.12-6.12.23-29.97.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/affe4afff48d5589bf6dd4b04c59a853822b8d36c785d3d9006fb18f7b35b6c3/kernel6.12-6.12.25-32.101.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm
@@ -1361,6 +1361,9 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %{_cross_kmoddir}/kernel/net/xfrm/xfrm_user.%{_ko}
 %{_cross_kmoddir}/kernel/security/keys/encrypted-keys/encrypted-keys.%{_ko}
 %{_cross_kmoddir}/kernel/security/keys/trusted-keys/trusted.%{_ko}
+%if "%{_cross_arch}" == "x86_64"
+%{_cross_kmoddir}/kernel/virt/lib/irqbypass.ko
+%endif
 
 %if "%{_cross_arch}" == "x86_64"
 %files modules-neuron


### PR DESCRIPTION
**Description of changes:**

Update kernels 6.1 and 6.12 to latest upstream versions.

Patches:
```
Summary for kernel-6.1
Patches that changed:
Patches that were dropped:
Patches that were added:
0224-AL2023-6.1-Update-lustrefsx-to-2.15.6-fsx18-commit.patch
Summary for kernel-6.12
Patches that changed:
0074-unwind-build-kernel-with-sframe-info.patch -> 0074-unwind-build-kernel-with-sframe-info.patch
Patches that were dropped:
Patches that were added:
0097-AL2023-6.12-Update-lustrefsx-to-2.15.6-fsx18-commit.patch
0098-asm-generic-introduce-text-patching.h.patch
0099-arm64-patching-Rename-aarch64_insn_copy-to-text_poke.patch
0100-arm64-module-Use-text-poke-API-for-late-relocations.patch
```
These are an update to the FSx Lustre drivers, an update to kernel build in 6.12, and updates to live patching in 6.12. Bottlerocket does not use live patching.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
