### PR TITLE
Update kernel 5.15

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/3b6f33f4c20859f5c0ed89c10346530dbaebb54a0bf12be76101a17a52bac8e4/kernel-5.15.180-122.191.amzn2.src.rpm"
-sha512 = "704cd0fa555ad050f67c6251debcda1d4debefc67738e4583eecc498fd91338f9a6e48238c522d9e9c821089a7d5894b0560dda5bea96c7f5cdea3de60c3bbbc"
+url = "https://cdn.amazonlinux.com/blobstore/457e553c616457a4ba0f1899e03fca43c089f93cb83fd921514bf67fd541ce00/kernel-5.15.180-123.192.amzn2.src.rpm"
+sha512 = "881ebf0f018fe7bb189d6b124318eef6e6688f0bd31622b9047c1b80e561c1de9f490d43e72c5ee5efc2a01e8d40ef6102a88ee494bb900f6a1faa779a3983bc"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -7,7 +7,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/3b6f33f4c20859f5c0ed89c10346530dbaebb54a0bf12be76101a17a52bac8e4/kernel-5.15.180-122.191.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/457e553c616457a4ba0f1899e03fca43c089f93cb83fd921514bf67fd541ce00/kernel-5.15.180-123.192.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -107,8 +107,8 @@ Summary: Header files for the Linux kernel for use by glibc
 rpmkeys --import %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:0} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
-rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar.xz {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
-tar -xof linux-%{version}.tar.xz; rm linux-%{version}.tar.xz
+rpm2cpio %{S:0} | cpio -iu {,./}linux-%{version}.tar {,./}config-%{_cross_arch} {,./}"*.patch" {,./}kernel.spec
+tar -xof linux-%{version}.tar; rm linux-%{version}.tar
 # Count all the patches extracted from the SRPM
 patches_count=$(find -name "*.patch" | wc -l)
 # Find patch ordering based on the Source0 kernel.spec file from the SRPM.

--- a/packages/kernel-5.15/latest-kernel-full-config.sh
+++ b/packages/kernel-5.15/latest-kernel-full-config.sh
@@ -59,8 +59,8 @@ merge_kernel_configs() {
     cp "${rpm_file}" "${tmpdir}/"
     pushd "${tmpdir}" || bail "Could not move around"
 
-    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar.xz {,.}config-x86_64 {,.}config-aarch64 {,./}"*.patch" {,./}kernel.spec
-    tar -xof linux-"${version}".tar.xz; rm linux-"${version}".tar.xz
+    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar {,.}config-x86_64 {,.}config-aarch64 {,./}"*.patch" {,./}kernel.spec
+    tar -xof linux-"${version}".tar; rm linux-"${version}".tar
 
     # Find patch ordering based on the upstream SRPM and apply in that order
     readarray -t patches < <(grep -P "^Patch\d+" kernel.spec | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" kernel.spec)


### PR DESCRIPTION
**Description of changes:**

Update kernel 5.15 to latest upstream. The name of the kernel tar archive in the source RPM has changed, so make corresponding changes in kernel-5.15.spec and latest-kernel-full-config.sh.

There is one new patch, to code in the btrfs filesystem component. There are no configuration changes.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
