### PR TITLE
kernel: add default config files for xfsprogs

### DIFF
--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -50,6 +50,9 @@ Requires: %{_cross_os}microcode-licenses
 Requires: %{name}-modules = %{version}-%{release}
 Requires: %{name}-devel = %{version}-%{release}
 
+# Pull in default mkfs conf for xfsprogs.
+Requires: (%{name}-mkfs-xfs-conf if %{_cross_os}xfsprogs)
+
 # Pull in platform-dependent modules.
 %if "%{_cross_arch}" == "x86_64"
 Requires: (%{name}-modules-neuron if (%{_cross_os}variant-platform(aws) without %{_cross_os}variant-flavor(nvidia)))
@@ -83,6 +86,12 @@ Summary: Archived Linux kernel source for module building
 Summary: Modules for the Linux kernel
 
 %description modules
+%{summary}.
+
+%package mkfs-xfs-conf
+Summary: mkfs configurations for the XFS filesystem
+
+%description mkfs-xfs-conf
 %{summary}.
 
 %if "%{_cross_arch}" == "x86_64"
@@ -308,6 +317,10 @@ ln -sf %{_usrsrc}/kernels/%{version} %{buildroot}%{kernel_libdir}/source
 # Install a copy of System.map so that module dependencies can be regenerated.
 install -p -m 0600 System.map %{buildroot}%{kernel_libdir}
 
+# Add symlink for kernel 5.15 xfsprogs-mkfs defaults in the default path.
+mkdir -p %{buildroot}%{_cross_datadir}/xfsprogs/mkfs
+ln -s lts_5.15.conf %{buildroot}%{_cross_datadir}/xfsprogs/mkfs/default.conf
+
 %if "%{_cross_arch}" == "x86_64"
 # Add Neuron-related drop-ins to load the module when the hardware is present.
 mkdir -p %{buildroot}%{_cross_unitdir}/sysinit.target.d
@@ -322,6 +335,9 @@ install -p -m 0644 %{S:221} %{buildroot}%{_cross_unitdir}/modprobe@neuron.servic
 %{_cross_attribution_file}
 /boot/vmlinuz
 /boot/config
+
+%files mkfs-xfs-conf
+%{_cross_datadir}/xfsprogs/mkfs/default.conf
 
 %files modules
 %dir %{_cross_libdir}/modules

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -65,6 +65,9 @@ Requires: %{_cross_os}microcode-licenses
 Requires: %{name}-modules = %{version}-%{release}
 Requires: %{name}-devel = %{version}-%{release}
 
+# Pull in default mkfs conf for xfsprogs.
+Requires: (%{name}-mkfs-xfs-conf if %{_cross_os}xfsprogs)
+
 # Pull in platform-dependent boot config snippets.
 Requires: (%{name}-bootconfig-aws if %{_cross_os}variant-platform(aws))
 Requires: (%{name}-bootconfig-vmware if %{_cross_os}variant-platform(vmware))
@@ -132,6 +135,12 @@ Summary: Boot config snippet for the Linux kernel on bare metal
 Summary: Modules for the Linux kernel
 
 %description modules
+%{summary}.
+
+%package mkfs-xfs-conf
+Summary: mkfs configurations for the XFS filesystem
+
+%description mkfs-xfs-conf
 %{summary}.
 
 %package modules-metal
@@ -379,6 +388,10 @@ ln -sf %{_usrsrc}/kernels/%{version} %{buildroot}%{_cross_kmoddir}/source
 # Install a copy of System.map so that module dependencies can be regenerated.
 install -p -m 0600 System.map %{buildroot}%{_cross_kmoddir}
 
+# Add symlink for kernel 6.1 xfsprogs-mkfs defaults in the default path.
+mkdir -p %{buildroot}%{_cross_datadir}/xfsprogs/mkfs
+ln -s lts_6.1.conf %{buildroot}%{_cross_datadir}/xfsprogs/mkfs/default.conf
+
 # Ensure that each required FIPS module is loaded as a dependency of the
 # check-fips-module.service. The list of FIPS modules is different across
 # kernels but the check is consistent: it loads the "tcrypt" module after
@@ -418,6 +431,9 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 %{_cross_attribution_file}
 /boot/vmlinuz
 /boot/config
+
+%files mkfs-xfs-conf
+%{_cross_datadir}/xfsprogs/mkfs/default.conf
 
 %files headers
 %dir %{_cross_includedir}/asm

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -82,6 +82,9 @@ Conflicts: %{_cross_os}image-feature(external-kmod-development)
 # Pull in expected modules.
 Requires: %{name}-modules = %{version}-%{release}
 
+# Pull in default mkfs conf for xfsprogs.
+Requires: (%{name}-mkfs-xfs-conf if %{_cross_os}xfsprogs)
+
 # Pull in platform-dependent boot config snippets.
 Requires: (%{name}-bootconfig-aws if %{_cross_os}variant-platform(aws))
 Requires: (%{name}-bootconfig-vmware if %{_cross_os}variant-platform(vmware))
@@ -122,6 +125,12 @@ Summary: Boot config snippet for the Linux kernel on VMware
 Summary: Modules for the Linux kernel
 
 %description modules
+%{summary}.
+
+%package mkfs-xfs-conf
+Summary: mkfs configurations for the XFS filesystem
+
+%description mkfs-xfs-conf
 %{summary}.
 
 %if "%{_cross_arch}" == "x86_64"
@@ -370,6 +379,10 @@ mkdir -p %{buildroot}%{_cross_unitdir}/"${LOWERPATH}.mount.d"
 sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:210} \
   > %{buildroot}%{_cross_unitdir}/"${LOWERPATH}.mount.d"/no-squashfs.conf
 
+# Add symlink for kernel 6.12 xfsprogs-mkfs defaults in the default path.
+mkdir -p %{buildroot}%{_cross_datadir}/xfsprogs/mkfs
+ln -s lts_6.12.conf %{buildroot}%{_cross_datadir}/xfsprogs/mkfs/default.conf
+
 %if "%{_cross_arch}" == "x86_64"
 # Add Neuron-related drop-ins to load the module when the hardware is present.
 mkdir -p %{buildroot}%{_cross_unitdir}/sysinit.target.d
@@ -393,6 +406,9 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %dir %{_cross_datadir}/bottlerocket/kernel-devel
 %{_cross_datadir}/bottlerocket/kernel-devel/*
 %{_cross_unitdir}/*kernel*devel*.mount.d/no-squashfs.conf
+
+%files mkfs-xfs-conf
+%{_cross_datadir}/xfsprogs/mkfs/default.conf
 
 %files headers
 %dir %{_cross_includedir}/asm


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes: https://github.com/bottlerocket-os/bottlerocket/issues/4281

**Description of changes:**
Related to https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/521
- Adds symlink from kernel wise defaults to the default config path

**Testing done:**
Test-1 - Testing basic functionality in AMIs with different kernels
```
[root@admin]# sheltie
bash-5.1# apiclient ephemeral-storage init -t xfs
bash-5.1# apiclient ephemeral-storage bind --dirs /var/lib/kubelet
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
# V5 features that were the mkfs defaults when the upstream Linux 5.15 LTS
# kernel was released at the end of 2021.

[metadata]
bigtime=1
crc=1
finobt=1
inobtcount=1
reflink=1
rmapbt=0

[inode]
sparse=1
nrext64=0
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.26)",
    "variant_id": "aws-k8s-1.26",
    "version_id": "1.39.0"
  }
}
bash-5.1# dmesg
[    0.000000] Linux version 5.15.180 (builder@buildkitsandbox) (x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0, GNU ld (GNU Binutils) 2.43.1) #1 SMP Fri May 16 23:40:01 UTC 2025
..........
[   55.100512] md127: detected capacity change from 0 to 9765096448
[   65.473766] XFS (md127): Mounting V5 Filesystem
[   65.550594] XFS (md127): Ending clean mount
```

```
[ssm-user@control]$ apiclient ephemeral-storage init -t xfs
[ssm-user@control]$ apiclient ephemeral-storage bind --dirs /var/lib/kubelet
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.28)",
    "variant_id": "aws-k8s-1.28",
    "version_id": "1.39.0"
  }
}
....

bash-5.1# dmesg
[    0.000000] Linux version 6.1.134 (builder@buildkitsandbox) (x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0, GNU ld (GNU Binutils) 2.43.1) #1 SMP PREEMPT_DYNAMIC Thu May 29 05:00:58 UTC 2025
..........
[   87.912051] XFS (nvme2n1): Mounting V5 Filesystem
[   87.919911] XFS (nvme2n1): Ending clean mount
bash-5.1# lsblk
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
loop0          7:0    0  368K  1 loop /x86_64-bottlerocket-linux-gnu/sys-root/usr/share/licenses
loop1          7:1    0 12.6M  1 loop /var/lib/kernel-devel/.overlay/lower
nvme0n1      259:0    0    2G  0 disk
|-nvme0n1p1  259:3    0    4M  0 part
|-nvme0n1p2  259:4    0    5M  0 part
|-nvme0n1p3  259:5    0   40M  0 part /boot
|-nvme0n1p4  259:6    0  920M  0 part
|-nvme0n1p5  259:7    0   10M  0 part
|-nvme0n1p6  259:8    0   25M  0 part
|-nvme0n1p7  259:9    0    5M  0 part
|-nvme0n1p8  259:10   0   40M  0 part
|-nvme0n1p9  259:11   0  920M  0 part
|-nvme0n1p10 259:12   0   10M  0 part
|-nvme0n1p11 259:13   0   25M  0 part
|-nvme0n1p12 259:14   0   41M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:15   0    1M  0 part
nvme2n1      259:1    0  2.3T  0 disk /var/lib/kubelet
                                      /mnt/.ephemeral
nvme1n1      259:2    0   20G  0 disk
`-nvme1n1p1  259:17   0   20G  0 part /var
                                      /opt
                                      /mnt
                                      /local
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
# V5 features that were the mkfs defaults when the upstream Linux 6.1 LTS
# kernel was released at the end of 2022.

[metadata]
bigtime=1
crc=1
finobt=1
inobtcount=1
metadir=0
reflink=1
rmapbt=0
autofsck=0

[inode]
sparse=1
nrext64=0
exchange=0

[naming]
parent=0
```
```
[ssm-user@control]$ apiclient ephemeral-storage init -t xfs
[ssm-user@control]$ apiclient ephemeral-storage bind --dirs /var/lib/kubelet
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.39.0"
  }
}
.....
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
# V5 features that were the mkfs defaults when the upstream Linux 6.12 LTS
# kernel was released at the end of 2024.

[metadata]
bigtime=1
crc=1
finobt=1
inobtcount=1
metadir=0
reflink=1
rmapbt=1
autofsck=0

[inode]
sparse=1
nrext64=1
exchange=0

[naming]
parent=0
bash-5.1# dmesg
[    0.000000] Linux version 6.12.25 (builder@buildkitsandbox) (x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0, GNU ld (GNU Binutils) 2.43.1) #1 SMP PREEMPT_DYNAMIC Thu May 29 05:00:34 UTC 2025
......
[   34.864084] XFS (nvme2n1): Mounting V5 Filesystem 3a0430c7-5c59-4ffa-8105-e31d659cf03a
[   34.872310] XFS (nvme2n1): Ending clean mount
bash-5.1# lsblk
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
nvme2n1      259:0    0  2.3T  0 disk /var/lib/kubelet
                                      /mnt/.ephemeral
nvme1n1      259:1    0   20G  0 disk
`-nvme1n1p1  259:17   0   20G  0 part /var
                                      /opt
                                      /mnt
                                      /local
nvme0n1      259:2    0    2G  0 disk
|-nvme0n1p1  259:3    0    4M  0 part
|-nvme0n1p2  259:4    0    5M  0 part
|-nvme0n1p3  259:5    0   40M  0 part /boot
|-nvme0n1p4  259:6    0  920M  0 part
|-nvme0n1p5  259:7    0   10M  0 part
|-nvme0n1p6  259:8    0   25M  0 part
|-nvme0n1p7  259:9    0    5M  0 part
|-nvme0n1p8  259:10   0   40M  0 part
|-nvme0n1p9  259:11   0  920M  0 part
|-nvme0n1p10 259:12   0   10M  0 part
|-nvme0n1p11 259:13   0   25M  0 part
|-nvme0n1p12 259:14   0   41M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:15   0    1M  0 part
```

Test-2 - AMI: bottlerocket-aws-k8s-1.26-x86_64-v1.39.0-0968c061-dirty
This shows that a customer can manually specify configuration file that overrides the defaults. The 2nd command shows that the original behaviour is preserved, where an attempt on overriding one of the configuration (which is not part of the default) would fail.
```
[root@admin]# sheltie
bash-5.1# mkfs.xfs -c options=/usr/share/xfsprogs/mkfs/lts_5.15.conf /dev/nvme2n1
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
Parameters parsed from config file /usr/share/xfsprogs/mkfs/lts_5.15.conf successfully
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
         =                       exchange=0   metadir=0
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1, parent=0
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
         =                       rgcount=0    rgsize=0 extents
Discarding blocks...Done.
bash-5.1# mkfs.xfs -c options=/usr/share/xfsprogs/mkfs/lts_5.15.conf -i nrext64=0 /dev/nvme2n1
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
-i nrext64 option respecified
Usage: mkfs.xfs
/* blocksize */         [-b size=num]
/* config file */       [-c options=xxx]
/* metadata */          [-m crc=0|1,finobt=0|1,uuid=xxx,rmapbt=0|1,reflink=0|1,
                            inobtcount=0|1,bigtime=0|1,autofsck=xxx,
                            metadir=0|1]
/* quota */             [-m uquota|uqnoenforce,gquota|gqnoenforce,
                            pquota|pqnoenforce]
/* data subvol */       [-d agcount=n,agsize=n,file,name=xxx,size=num,
                            (sunit=value,swidth=value|su=num,sw=num|noalign),
                            sectsize=num,concurrency=num]
/* force overwrite */   [-f]
/* inode size */        [-i perblock=n|size=num,maxpct=n,attr=0|1|2,
                            projid32bit=0|1,sparse=0|1,nrext64=0|1,
                            exchange=0|1]
/* no discard */        [-K]
/* log subvol */        [-l agnum=n,internal,size=num,logdev=xxx,version=n
                            sunit=value|su=num,sectsize=num,lazy-count=0|1,
                            concurrency=num]
/* label */             [-L label (maximum 12 characters)]
/* naming */            [-n size=num,version=2|ci,ftype=0|1,parent=0|1]]
/* no-op info only */   [-N]
/* prototype file */    [-p fname]
/* quiet */             [-q]
/* realtime subvol */   [-r extsize=num,size=num,rtdev=xxx,rgcount=n,rgsize=n,
                            concurrency=num]
/* sectorsize */        [-s size=num]
/* version */           [-V]
                        devicename
<devicename> is required unless -d name=xxx is given.
<num> is xxx (bytes), xxxs (sectors), xxxb (fs blocks), xxxk (xxx KiB),
      xxxm (xxx MiB), xxxg (xxx GiB), xxxt (xxx TiB) or xxxp (xxx PiB).
<value> is xxx (512 byte blocks).
```
Test-3: In this test we run older version of xfsprogs which doesn't have the defaults for 6.12 kernel. (We do create the symlink in this case but the symlink doesn't point to anything)
```
[root@admin]# sheltie
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.39.0"
  }
}
bash-5.1# apiclient ephemeral-storage init -t xfs
bash-5.1# apiclient ephemeral-storage bind --dirs /var/lib/kubelet
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
cat: /usr/share/xfsprogs/mkfs/default.conf: No such file or directory
bash-5.1# dmesg
[    0.000000] Linux version 6.12.25 (builder@buildkitsandbox) (x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0, GNU ld (GNU Binutils) 2.43.1) #1 SMP PREEMPT_DYNAMIC Fri May 30 23:08:57 UTC 2025
...
[  418.666702] XFS (nvme2n1): Mounting V5 Filesystem 29fb3e8d-da56-4171-81a3-5a8e91dab4f8
[  418.674485] XFS (nvme2n1): Ending clean mount
bash-5.1# cd /usr/share/xfsprogs/mkfs
bash-5.1# ls
dax_x86_64.conf  default.conf  lts_4.19.conf  lts_5.10.conf  lts_5.15.conf  lts_5.4.conf  lts_6.1.conf  lts_6.6.conf
bash-5.1# lsblk
NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
nvme1n1      259:0    0   20G  0 disk
`-nvme1n1p1  259:17   0   20G  0 part /var
                                      /opt
                                      /mnt
                                      /local
nvme0n1      259:1    0   20G  0 disk
|-nvme0n1p1  259:3    0    4M  0 part
|-nvme0n1p2  259:4    0    5M  0 part
|-nvme0n1p3  259:5    0   40M  0 part /boot
|-nvme0n1p4  259:6    0  920M  0 part
|-nvme0n1p5  259:7    0   10M  0 part
|-nvme0n1p6  259:8    0   25M  0 part
|-nvme0n1p7  259:9    0    5M  0 part
|-nvme0n1p8  259:10   0   40M  0 part
|-nvme0n1p9  259:11   0  920M  0 part
|-nvme0n1p10 259:12   0   10M  0 part
|-nvme0n1p11 259:13   0   25M  0 part
|-nvme0n1p12 259:14   0   41M  0 part /var/lib/bottlerocket
`-nvme0n1p13 259:15   0    1M  0 part
nvme2n1      259:2    0  2.3T  0 disk /var/lib/kubelet
                                      /mnt/.ephemeral
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
cat: /usr/share/xfsprogs/mkfs/default.conf: No such file or directory
bash-5.1# ls /usr/share/xfsprogs/mkfs
dax_x86_64.conf  default.conf  lts_4.19.conf  lts_5.10.conf  lts_5.15.conf  lts_5.4.conf  lts_6.1.conf  lts_6.6.conf
```
Test-4: Checking differences in parameter values for 6.12 kernel (before package update) vs 6.1 kernel
You will notice that `nrext64` values are different (It's hardcoded to `true` in the code). I have displayed the defaults file so we can match the values. In 6.12 case, since the default file isn't symlinked to anything, we get the error message `cat: /usr/share/xfsprogs/mkfs/default.conf: No such file or directory` despite `ls` showing that the file is present.
```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.33)",
    "variant_id": "aws-k8s-1.33",
    "version_id": "1.39.0"
  }
}
bash-5.1# mkfs.xfs -N -f /dev/nvme2n1
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=1
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=1
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
cat: /usr/share/xfsprogs/mkfs/default.conf: No such file or directory
bash-5.1# ls /usr/share/xfsprogs/mkfs
dax_x86_64.conf  default.conf  lts_4.19.conf  lts_5.10.conf  lts_5.15.conf  lts_5.4.conf  lts_6.1.conf  lts_6.6.conf
```

```
bash-5.1# apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "0968c061-dirty",
    "pretty_name": "Bottlerocket OS 1.39.0 (aws-k8s-1.32)",
    "variant_id": "aws-k8s-1.32",
    "version_id": "1.39.0"
  }
}
bash-5.1# mkfs.xfs -N -f /dev/nvme2n1
Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=0
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
bash-5.1# cat /usr/share/xfsprogs/mkfs/default.conf
# V5 features that were the mkfs defaults when the upstream Linux 6.1 LTS
# kernel was released at the end of 2022.

[metadata]
bigtime=1
crc=1
finobt=1
inobtcount=1
reflink=1
rmapbt=0

[inode]
sparse=1
nrext64=0
```
Test-5: Comparing outputs of `mkfs.xfs -N -f /dev/nvme2n1`
```
xxxxxxxxxxx scratch-pad % git diff --no-index --word-diff xfsprogs-6.1-old.txt xfsprogs-6.1.txt
diff --git a/xfsprogs-6.1-old.txt b/xfsprogs-6.1.txt
index bff2117..e3eb73f 100644
--- a/xfsprogs-6.1-old.txt
+++ b/xfsprogs-6.1.txt
@@ -1,11 +1,14 @@
bash-5.1# mkfs.xfs -N -f /dev/nvme2n1
{+Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully+}
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, [-rmapbt=1-]{+rmapbt=0+}
         =                       reflink=1    bigtime=1 inobtcount=1 [-nrext64=1-]{+nrext64=0+}
{+         =                       exchange=0   metadir=0+}
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, [-ftype=1-]{+ftype=1, parent=0+}
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
         {+=                       rgcount=0    rgsize=0 extents+}
xxxxxxxxxxx scratch-pad % git diff --no-index --word-diff xfsprogs-6.12-old.txt xfsprogs-6.12.txt
diff --git a/xfsprogs-6.12-old.txt b/xfsprogs-6.12.txt
index bff2117..326f847 100644
--- a/xfsprogs-6.12-old.txt
+++ b/xfsprogs-6.12.txt
@@ -1,11 +1,14 @@
bash-5.1# mkfs.xfs -N -f /dev/nvme2n1
{+Parameters parsed from config file /usr/share/xfsprogs/mkfs/default.conf successfully+}
meta-data=/dev/nvme2n1           isize=512    agcount=4, agsize=152587890 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=1
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=1
         {+=                       exchange=0   metadir=0+}
data     =                       bsize=4096   blocks=610351560, imaxpct=5
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, [-ftype=1-]{+ftype=1, parent=0+}
log      =internal log           bsize=4096   blocks=298023, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
         {+=                       rgcount=0    rgsize=0 extents+}
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
