### PR TITLE
Update driver 570.148.08

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r570/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.133.20/NVIDIA-Linux-x86_64-570.133.20.run"
-sha512 = "c6f443791b14e71273929e6e97660cceeb46e9fbd10a3df624236a2433a99b0c905f89ada7c490f2a6009ff37a715c8585a4e82df75adf0afed5236da39ae5b6"
+url = "https://us.download.nvidia.com/tesla/570.148.08/NVIDIA-Linux-x86_64-570.148.08.run"
+sha512 = "706ba13cdc5ba83c2d207ea5a9950271b5f7809cd30c413636fbc3faff917a20dc183d11f68f5a1ebf06cbe7e40a281fe7bb99871fa6c3eee7de82ee54a7cd8b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.133.20/NVIDIA-Linux-aarch64-570.133.20.run"
-sha512 = "a8e338f551e0086e0de899ccf7f7d8b440eabd8842f347ff778170d54f926a10346d79cedd562fa826cb515def92eef60d84064d41571fefe7eb00fc8d2e727b"
+url = "https://us.download.nvidia.com/tesla/570.148.08/NVIDIA-Linux-aarch64-570.148.08.run"
+sha512 = "1c52945d52518b8b379305e2388042e19bef7a054c3271ef65a18fecca739740cdb7c7587c1d104b817986f8ba6ef43668ecb8e261b7fcc1d092a1f2fd04f470"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.133.20-1.x86_64.rpm"
-sha512 = "4fda6996671f7dc0264dcd4228510366a32eb5a7be1bdc99c248bb3bec41637e1ec41d6c90fea2b52a28ee92b56dc0a0b6e1d81c63731611cff1392fff058737"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.148.08-1.x86_64.rpm"
+sha512 = "51ca08f51f71136894122452bb959ec4d6c1d53271cb33c276487b8f2c74435a1d14417cd844b12c5fe0ccf84b6acc07e17d7ad89b1f71b6cd0da5701cbfad8e"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.133.20-1.aarch64.rpm"
-sha512 = "e4b6de518ee47bb86c7dcdedc90d2147c9c55605b41dc6782e6e2e7976ea7b06c60dc881b5ef8eef272e021f54353bacb4ef92f488715205742d62f5c64306da"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.148.08-1.aarch64.rpm"
+sha512 = "c6425cb53bb7915f5912e49c2b4182fe9875eb60759c15e130ae6d323dc168ad860451e2d69932aba8febb350bc7c0ff6d82df625aa0b63d8601e9fa7cc31b2d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -1,6 +1,6 @@
 %global tesla_major 570
-%global tesla_minor 133
-%global tesla_patch 20
+%global tesla_minor 148
+%global tesla_patch 08
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa
@@ -667,11 +667,11 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.18
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.19
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.0
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.0
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-gpucomp.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1

--- a/packages/kmod-6.12-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r570/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.133.20/NVIDIA-Linux-x86_64-570.133.20.run"
-sha512 = "c6f443791b14e71273929e6e97660cceeb46e9fbd10a3df624236a2433a99b0c905f89ada7c490f2a6009ff37a715c8585a4e82df75adf0afed5236da39ae5b6"
+url = "https://us.download.nvidia.com/tesla/570.148.08/NVIDIA-Linux-x86_64-570.148.08.run"
+sha512 = "706ba13cdc5ba83c2d207ea5a9950271b5f7809cd30c413636fbc3faff917a20dc183d11f68f5a1ebf06cbe7e40a281fe7bb99871fa6c3eee7de82ee54a7cd8b"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.133.20/NVIDIA-Linux-aarch64-570.133.20.run"
-sha512 = "a8e338f551e0086e0de899ccf7f7d8b440eabd8842f347ff778170d54f926a10346d79cedd562fa826cb515def92eef60d84064d41571fefe7eb00fc8d2e727b"
+url = "https://us.download.nvidia.com/tesla/570.148.08/NVIDIA-Linux-aarch64-570.148.08.run"
+sha512 = "1c52945d52518b8b379305e2388042e19bef7a054c3271ef65a18fecca739740cdb7c7587c1d104b817986f8ba6ef43668ecb8e261b7fcc1d092a1f2fd04f470"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.133.20-1.x86_64.rpm"
-sha512 = "4fda6996671f7dc0264dcd4228510366a32eb5a7be1bdc99c248bb3bec41637e1ec41d6c90fea2b52a28ee92b56dc0a0b6e1d81c63731611cff1392fff058737"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.148.08-1.x86_64.rpm"
+sha512 = "51ca08f51f71136894122452bb959ec4d6c1d53271cb33c276487b8f2c74435a1d14417cd844b12c5fe0ccf84b6acc07e17d7ad89b1f71b6cd0da5701cbfad8e"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.133.20-1.aarch64.rpm"
-sha512 = "e4b6de518ee47bb86c7dcdedc90d2147c9c55605b41dc6782e6e2e7976ea7b06c60dc881b5ef8eef272e021f54353bacb4ef92f488715205742d62f5c64306da"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.148.08-1.aarch64.rpm"
+sha512 = "c6425cb53bb7915f5912e49c2b4182fe9875eb60759c15e130ae6d323dc168ad860451e2d69932aba8febb350bc7c0ff6d82df625aa0b63d8601e9fa7cc31b2d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -1,6 +1,6 @@
 %global tesla_major 570
-%global tesla_minor 133
-%global tesla_patch 20
+%global tesla_minor 148
+%global tesla_patch 08
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global fm_arch sbsa
@@ -665,11 +665,11 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.18
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.19
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.0
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.0
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-gpucomp.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #165 

**Description of changes:**
bump the driver version to 570.148.08

**Testing done:**
`PACKAGE=kmod-6_1-nvidia-r570 make twoliter build-packag`
`PACKAGE=kmod-6_12-nvidia-r570 make twoliter build-packag`
- running smoke test on `g5g.2xlarge` instance
```
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "807acc8b-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.32-nvidia)",
    "variant_id": "aws-k8s-1.32-nvidia",
    "version_id": "1.40.0"
  }
}
```

```
╭─in ~/k8s
╰$ kubectl logs nvidia-smoke-test

=========================================
  Running sample UnifiedMemoryPerf
=========================================

GPU Device 0: "Turing" with compute capability 7.5

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.172   0.179   0.320   0.023   0.040   0.031   0.042   0.030
16        0.197   0.215   0.495   0.049   0.062   0.056   0.067   0.065
64        0.352   0.400   0.744   0.142   0.154   0.144   0.152   0.139
256       0.921   0.881   1.357   0.719   0.555   0.529   0.511   0.497
1024      3.261   2.965   3.722   4.622   2.250   2.172   2.077   2.062
4096     12.431  11.014  14.616  32.882   9.442   9.323   9.268   9.237
16384    56.227  52.973  66.800 265.571  47.589  47.486  47.604  47.632

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA T4G"
  CUDA Driver Version / Runtime Version          12.8 / 12.8
  CUDA Capability Major/Minor version number:    7.5
  Total amount of global memory:                 14914 MBytes (15638134784 bytes)
  (040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
  GPU Max Clock rate:                            1590 MHz (1.59 GHz)
  Memory Clock rate:                             5001 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        65536 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1024
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 31
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.8, CUDA Runtime Version = 12.8, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 887.06 GFlop/s, Time= 4.728 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Turing" with compute capability 7.5

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 5.264576 ms
TOPS: 26.11

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Turing" with compute capability 7.5

33554432 elements
numThreads: 1024
numBlocks: 40

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 1.025989 ms
Bandwidth:    130.817849 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.319008
65536 elements scanned in 0.319008 ms -> 205.436859 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.269530 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.055296 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.148224 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5

Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5

Processing time: 1.152000 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5

> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Turing" with compute capability 7.5

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```
- running smoke test on `g5g.2xlarge`
```
{
  "os": {
    "arch": "aarch64",
    "build_id": "807acc8b-dirty",
    "pretty_name": "Bottlerocket OS 1.40.0 (aws-k8s-1.33-nvidia)",
    "variant_id": "aws-k8s-1.33-nvidia",
    "version_id": "1.40.0"
  }
}
```

```

╭─jweiw@ip-172-31-49-136 in ~/k8s
╰$ kubectl logs nvidia-smoke-test

=========================================
  Running sample UnifiedMemoryPerf

Running ........................................................

Overall Time For matrixMultiplyPerf

Printing Average of 20 measurements in (ms)
Size_KB  UMhint UMhntAs  UMeasy   0Copy MemCopy CpAsync CpHpglk CpPglAs
4         0.223   0.243   0.325   0.024   0.039   0.032   0.046   0.031
16        0.248   0.265   0.499   0.051   0.065   0.057   0.071   0.066
64        0.370   0.367   0.777   0.146   0.159   0.148   0.156   0.148
256       0.976   0.882   1.515   0.721   0.571   0.545   0.530   0.512
1024      3.536   3.045   3.964   4.675   2.362   2.289   2.070   2.061
4096     12.841  11.084  15.243  32.506   9.305   9.266   9.060   9.057
16384    56.389  52.802  69.771 303.940  47.531  47.392  47.278  47.262

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample deviceQuery
=========================================

./deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA T4G"
  CUDA Driver Version / Runtime Version          12.8 / 12.8
  CUDA Capability Major/Minor version number:    7.5
  Total amount of global memory:                 14914 MBytes (15638134784 bytes)
  (040) Multiprocessors, (064) CUDA Cores/MP:    2560 CUDA Cores
  GPU Max Clock rate:                            1590 MHz (1.59 GHz)
  Memory Clock rate:                             5001 Mhz
  Memory Bus Width:                              256-bit
  L2 Cache Size:                                 4194304 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        65536 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1024
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 3 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                Yes
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 0 / 31
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.8, CUDA Runtime Version = 12.8, NumDevs = 1
Result = PASS

=========================================
  Running sample globalToShmemAsyncCopy
=========================================

[globalToShmemAsyncCopy] - Starting...
GPU Device 0: "Turing" with compute capability 7.5

MatrixA(1280,1280), MatrixB(1280,1280)
Running kernel = 0 - AsyncCopyMultiStageLargeChunk
Computing result using CUDA Kernel...
done
Performance= 872.19 GFlop/s, Time= 4.809 msec, Size= 4194304000 Ops, WorkgroupSize= 256 threads/block
Checking computed result for correctness: Result = PASS

NOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.

=========================================
  Running sample immaTensorCoreGemm
=========================================

Initializing...
GPU Device 0: "Turing" with compute capability 7.5

M: 4096 (16 x 256)
N: 4096 (16 x 256)
K: 4096 (16 x 256)
Preparing data for GPU...
Required shared memory size: 64 Kb
Computing... using high performance kernel compute_gemm_imma
Time: 5.268448 ms
TOPS: 26.09

=========================================
  Running sample reductionMultiBlockCG
=========================================

reductionMultiBlockCG Starting...

GPU Device 0: "Turing" with compute capability 7.5

33554432 elements
numThreads: 1024
numBlocks: 40

Launching SinglePass Multi Block Cooperative Groups kernel
Average time: 1.005779 ms
Bandwidth:    133.446489 GB/s

GPU result = 1.992401361465
CPU result = 1.992401361465

=========================================
  Running sample shfl_scan
=========================================

Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Starting shfl_scan
GPU Device 0: "Turing" with compute capability 7.5

> Detected Compute SM 7.5 hardware with 40 multi-processors
Computing Simple Sum test
---------------------------------------------------
Initialize test data [1, 1, 1...]
Scan summation for 65536 elements, 256 partial sums
Partial summing 256 elements with 1 blocks of size 256
Test Sum: 65536
Time (ms): 0.318368
65536 elements scanned in 0.318368 ms -> 205.849838 MegaElements/s
CPU verify result diff (GPUvsCPU) = 0
CPU sum (naive) took 0.254570 ms

Computing Integral Image Test on size 1920 x 1080 synthetic data
---------------------------------------------------
Method: Fast  Time (GPU Timer): 0.053984 ms Diff = 0
Method: Vertical Scan  Time (GPU Timer): 0.161152 ms
CheckSum: 2073600, (expect 1920x1080=2073600)

=========================================
  Running sample simpleAWBarrier
=========================================

./simpleAWBarrier starting...
GPU Device 0: "Turing" with compute capability 7.5

Launching normVecByDotProductAWBarrier kernel with numBlocks = 40 blockSize = 1024
Result = PASSED
./simpleAWBarrier completed, returned OK

=========================================
  Running sample simpleAtomicIntrinsics
=========================================

simpleAtomicIntrinsics starting...
GPU Device 0: "Turing" with compute capability 7.5

Processing time: 1.220000 (ms)
simpleAtomicIntrinsics completed, returned OK

=========================================
  Running sample simpleVoteIntrinsics
=========================================

[simpleVoteIntrinsics]
GPU Device 0: "Turing" with compute capability 7.5

> GPU device has 40 Multi-Processors, SM 7.5 compute capabilities

[VOTE Kernel Test 1/3]
        Running <<Vote.Any>> kernel1 ...
        OK

[VOTE Kernel Test 2/3]
        Running <<Vote.All>> kernel2 ...
        OK

[VOTE Kernel Test 3/3]
        Running <<Vote.Any>> kernel3 ...
        OK
        Shutting down...

=========================================
  Running sample vectorAdd
=========================================

[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done

=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Turing" with compute capability 7.5

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```
**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
