### PR TITLE
kernel-5.15: update to 5.15.182

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/457e553c616457a4ba0f1899e03fca43c089f93cb83fd921514bf67fd541ce00/kernel-5.15.180-123.192.amzn2.src.rpm"
-sha512 = "881ebf0f018fe7bb189d6b124318eef6e6688f0bd31622b9047c1b80e561c1de9f490d43e72c5ee5efc2a01e8d40ef6102a88ee494bb900f6a1faa779a3983bc"
+url = "https://cdn.amazonlinux.com/blobstore/73ddac272f5e3ae99bb724b93d40930b1d31f928c7b3e7baddd39eb0fcedbdb5/kernel-5.15.182-123.190.amzn2.src.rpm"
+sha512 = "e867cc2143c4b4e0d63bfa9932b3431dd64400cd096f188cd44f7d015417d1372b42b4e188de38be0fe78dcca46be6eb7ac1d44fac2095094b3918af57703b26"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/config-full-bottlerocket-aarch64
+++ b/packages/kernel-5.15/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.180 Kernel Configuration
+# Linux/arm64 5.15.182 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-5.15/config-full-bottlerocket-x86_64
+++ b/packages/kernel-5.15/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.180 Kernel Configuration
+# Linux/x86 5.15.182 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.180
+Version: 5.15.182
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/457e553c616457a4ba0f1899e03fca43c089f93cb83fd921514bf67fd541ce00/kernel-5.15.180-123.192.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/73ddac272f5e3ae99bb724b93d40930b1d31f928c7b3e7baddd39eb0fcedbdb5/kernel-5.15.182-123.190.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Description of changes:**
Update to upstream kernel-5.15 to 5.15.182

Patch summary
```
Summary for kernel-5.15
Patches that changed:
0104-mptcp-add-MPTCP_INFO-getsockopt.patch -> 0104-mptcp-add-MPTCP_INFO-getsockopt.patch
0118-mptcp-getsockopt-add-support-for-IP_TOS.patch -> 0118-mptcp-getsockopt-add-support-for-IP_TOS.patch
0173-arm64-proton-pack-Move-the-loop-and-firmware-enable-.patch -> 0171-arm64-proton-pack-Move-the-loop-and-firmware-enable-.patch
0174-arm64-proton-pack-Add-Spectre-BSE-mitigation-for-Cor.patch -> 0172-arm64-proton-pack-Add-Spectre-BSE-mitigation-for-Cor.patch
0175-arm64-proton-pack-Prefer-WA1-for-BHB-on-Cortex-A72-r.patch -> 0173-arm64-proton-pack-Prefer-WA1-for-BHB-on-Cortex-A72-r.patch
Patches that were dropped:
0165-net-make-sock_inuse_add-available.patch
0172-net-defer-final-struct-net-free-in-netns-dismantle.patch
0177-ext4-fix-timer-use-after-free-on-failed-mount.patch
0186-block-move-blk-throtl-fast-path-inline.patch
0187-blk-throttle-Set-BIO_THROTTLED-when-bio-has-been-thr.patch
Patches that were added:
0187-nvme-tcp-fix-potential-memory-corruption-in-nvme_tcp.patch
0188-blk-throttle-Set-BIO_THROTTLED-when-bio-has-been-thr.patch
0189-ACPI-PPTT-Fix-processor-subtable-walk.patch
```


**Testing done:**
`make ARCH=aarch64 && make ARCH=x86_64`


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
