### PR TITLE
tools: map 1000 uid into container to let it uses latest-kernel-full-config.sh

### DIFF
--- a/tools/latest-kernel-full-config.sh
+++ b/tools/latest-kernel-full-config.sh
@@ -147,6 +147,7 @@ merge_kernel_configs() {
             -e CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu- \
             -e KCONFIG_CONFIG=bottlerocket_${arch}_defconfig \
             -w /linux-"${version}" \
+            -u "$(id -u)":1000 \
             --name "${arch}-kernel-${version}-config-merger" \
             "${sdk_image}" \
             ./scripts/kconfig/merge_config.sh \


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #173

**Description of changes:**
Currently when running the latest-kernel-full-config.sh script with UID other than 1000 will get error show below.
```
./.tmp.config.XXXXXXXXXX': Permission denied
```
set `-u "$(id -u)":1000`  to specify the user and group ID for processes in the container.

**Testing done:**
run `./tools/latest-kernel-full-config.sh -r packages/kernel-5.15/kernel-5.15.182-123.190.amzn2.src.rpm`
I can see `config-full-bottlerocket-aarch64` and `config-full-bottlerocket-x86_64` generate succefully
```
╰$ la
total 383M
-rw-r--r--. 1 jweiw jweiw  1.7K May 29 21:04 1001-Makefile-add-prepare-target-for-external-modules.patch
-rw-r--r--. 1 jweiw jweiw  2.2K May 29 21:04 1002-Revert-kbuild-hide-tools-build-targets-from-external.patch
-rw-r--r--. 1 jweiw jweiw  1.9K May 29 21:04 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
-rw-r--r--. 1 jweiw jweiw  1.7K May 29 21:04 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
-rw-r--r--. 1 jweiw jweiw  1.8K May 29 21:04 6001-lustre-fix-Werror-enum-int-mismatch.patch
-rw-r--r--. 1 jweiw jweiw   986 May 30 19:03 Cargo.toml
-rw-r--r--. 1 jweiw jweiw  6.0K May 29 21:04 config-bottlerocket
-rw-r--r--. 1 jweiw fedora 137K May 30 19:21 config-full-bottlerocket-aarch64
-rw-r--r--. 1 jweiw fedora 139K May 30 19:21 config-full-bottlerocket-x86_64
-rw-r--r--. 1 jweiw jweiw     6 May 29 21:04 .gitignore
-rw-r--r--. 1 jweiw jweiw   981 May 29 21:04 gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
-rw-r--r--. 1 jweiw jweiw  1.6K May 29 21:04 gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
-rw-r--r--. 1 jweiw jweiw  191M May  9 20:57 kernel-5.15.180-123.192.amzn2.src.rpm
-rw-r--r--. 1 jweiw jweiw  191M May 23 19:45 kernel-5.15.182-123.190.amzn2.src.rpm
-rw-r--r--. 1 jweiw jweiw   13K May 30 19:03 kernel-5.15.spec
-rwxr-xr-x. 1 jweiw jweiw   212 May 29 21:04 latest-kernel-srpm-url.sh
-rwxr-xr-x. 1 jweiw jweiw   372 May 29 21:04 latest-neuron-srpm-url.sh
-rw-r--r--. 1 jweiw jweiw   190 May 29 21:04 modprobe@neuron.service.drop-in.conf
-rw-r--r--. 1 jweiw jweiw    37 May 29 21:04 neuron-sysinit.target.drop-in.conf
drwxr-xr-x. 1 jweiw jweiw    82 May 29 21:26 patch_changes
-rw-r--r--. 1 jweiw jweiw  1.3K May 29 21:04 README.md
```
```
╰$ timedatectl
               Local time: Fri 2025-05-30 19:25:50 UTC
           Universal time: Fri 2025-05-30 19:25:50 UTC
                 RTC time: Fri 2025-05-30 19:25:50
                Time zone: UTC (UTC, +0000)
System clock synchronized: yes
              NTP service: active
          RTC in local TZ: no
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
