### PR TITLE
Include libnvidia-gpucomp.so

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -584,6 +584,7 @@ popd
 %{_cross_libdir}/nvidia/tesla/libnvidia-allocator.so.1
 %{_cross_libdir}/nvidia/tesla/libOpenCL.so.1.0.0
 %{_cross_libdir}/nvidia/tesla/libOpenCL.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-gpucomp.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"
 %{_cross_libdir}/nvidia/tesla/libnvidia-pkcs11.so.%{tesla_ver}
 %{_cross_libdir}/nvidia/tesla/libnvidia-pkcs11-openssl3.so.%{tesla_ver}
@@ -672,7 +673,6 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-gpucomp.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -581,6 +581,7 @@ popd
 %{_cross_libdir}/nvidia/tesla/libnvidia-allocator.so.1
 %{_cross_libdir}/nvidia/tesla/libOpenCL.so.1.0.0
 %{_cross_libdir}/nvidia/tesla/libOpenCL.so.1
+%{_cross_libdir}/nvidia/tesla/libnvidia-gpucomp.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"
 %{_cross_libdir}/nvidia/tesla/libnvidia-pkcs11.so.%{tesla_ver}
 %{_cross_libdir}/nvidia/tesla/libnvidia-pkcs11-openssl3.so.%{tesla_ver}
@@ -670,7 +671,6 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-gpucomp.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}


### PR DESCRIPTION
libnvidia-container includes shared compiler library libnvidia-gpucomp.so since 1.14.0~rc.2 refer to https://github.com/NVIDIA/libnvidia-container/blob/main/CHANGELOG.md#1140rc2

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #180 

**Description of changes:**

Remove lib file libnvidia-gpucomp.so from exclude list of rpm .spec file

**Testing done:**

I built a new kernel-kit image and checked rpm files bottlerocket-kmod-6.12-nvidia-r570-tesla-570.133.20 and bottlerocket-kmod-6.1-nvidia-r570-tesla-570.133.20, file /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/nvidia/tesla/libnvidia-gpucomp.so.570.133.20 is included.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
