### PR TITLE
tools: run bulk of full-config in container

### DIFF
--- a/tools/inner-full-config.sh
+++ b/tools/inner-full-config.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+bail() {
+    if [[ $# -gt 0 ]]; then
+        >&2 echo "Error: $*"
+    fi
+    exit 1
+}
+
+pushd /work || bail "Unable to enter /work (bind mount to tmp dir)"
+
+version="$(rpm --query --nosignature --queryformat '%{VERSION}' kernel-source.rpm)"
+majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
+if [ "${majorminor}" == "6.12" ]; then
+    # kernel 6.12 has a patch file that is not applied to the kernel sources, so
+    # only pick up the 1000-series kernel patches for our purposes here.
+    readarray -t br_patches < <(find /kernel-package -maxdepth 1 -name "10*.patch")
+    spec_file="kernel6.12.spec"
+    microcode_file="config-microcode-6-12"
+else
+    readarray -t br_patches < <(find /kernel-package -maxdepth 1 -name "*.patch")
+    spec_file="kernel.spec"
+    microcode_file="config-microcode"
+fi
+
+kernel_path=/kernel-package
+
+rpm2cpio kernel-source.rpm | cpio -iu {,./}linux-"${version}".tar{,.xz} {,./}config-x86_64 {,./}config-aarch64 {,./}"*.patch" {,./}"${spec_file}"
+
+# Upstream source is either xz compressed tarball or plain tarball
+if [ -f "./linux-${version}.tar" ]; then
+    tar -xof linux-"${version}".tar; rm linux-"${version}".tar
+else
+    tar -xof linux-"${version}".tar.xz; rm linux-"${version}".tar.xz
+fi
+
+# Find upstream patch ordering based on the upstream SRPM so we can apply in that order
+readarray -t patches < <(grep -P "^Patch\d+" "${spec_file}" | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" "${spec_file}")
+
+# Enter the source directory extracted from the tarball and patch
+pushd "linux-${version}" || bail "Could not move into linux-${version}"
+
+# Patches from the upstream
+for patch in "${patches[@]}"; do
+    patch -p1 <"../$patch"
+done
+
+# Patches from bottlerocket
+for patch in "${br_patches[@]}"; do
+    echo "Applying bottlerocket patch ${patch}"
+    patch -p1 <"$patch"
+done
+
+popd || bail "Could not move around - 'popd' back to /work failed. Lets stop before we break anything further."
+
+for arch in "x86_64" "aarch64"; do
+
+    export CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu-
+    export KCONFIG_CONFIG=bottlerocket_${arch}_defconfig
+
+    br_cfg="${kernel_path}/config-bottlerocket"
+    microcode_cfg="/package/packages/microcode/${microcode_file}"
+
+    pushd "linux-${version}" || bail "Could not move into linux-${version}"
+
+    if [ "${arch}" = "aarch64" ]; then
+        karch="arm64"
+        script_args=("../config-${arch}" "${br_cfg}")
+    elif [ "${arch}" = "x86_64" ]; then
+        karch="x86"
+        script_args=("../config-${arch}" "${microcode_cfg}" "${br_cfg}")
+    fi
+
+    ARCH=${karch} ./scripts/kconfig/merge_config.sh "${script_args[@]}"
+    mv -f "bottlerocket_${arch}_defconfig" "${kernel_path}/config-full-bottlerocket-${arch}" || bail "Failed to create config-full-bottlerocket-${arch}"
+    popd || bail "Could not move around - 'popd' failed in merge_config loop. Lets stop before we break anything further."
+done

--- a/tools/latest-kernel-full-config.sh
+++ b/tools/latest-kernel-full-config.sh
@@ -76,89 +76,18 @@ merge_kernel_configs() {
     sdk_image=$2
     kernel_path=$PWD
 
-    version="$(rpm --query --nosignature --queryformat '%{VERSION}' "${rpm_file}")"
-    majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
-    if [ "${majorminor}" == "6.12" ]; then
-        # kernel 6.12 has a patch file that is not applied to the kernel sources, so
-        # only pick up the 1000-series kernel patches for our purposes here.
-        readarray -t br_patches < <(find "${kernel_path}" -maxdepth 1 -name "10*.patch")
-        spec_file="kernel6.12.spec"
-        microcode_file="config-microcode-6-12"
-    else
-        readarray -t br_patches < <(find "${kernel_path}" -maxdepth 1 -name "*.patch")
-        spec_file="kernel.spec"
-        microcode_file="config-microcode"
-    fi
 
     tmpdir=$(mktemp -d)
-    cp "${rpm_file}" "${tmpdir}/"
-    pushd "${tmpdir}" || bail "Could not move around"
+    cp "${rpm_file}" "${tmpdir}/kernel-source.rpm"
 
-    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar{,.xz} {,./}config-x86_64 {,./}config-aarch64 {,./}"*.patch" {,./}"${spec_file}"
-    # Upstream source is either xz compressed tarball or plain tarball
-    if [ -f "./linux-${version}.tar" ]; then
-        tar -xof linux-"${version}".tar; rm linux-"${version}".tar
-    else
-        tar -xof linux-"${version}".tar.xz; rm linux-"${version}".tar.xz
-    fi
-
-    # Find patch ordering based on the upstream SRPM and apply in that order
-    readarray -t patches < <(grep -P "^Patch\d+" "${spec_file}" | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" "${spec_file}")
-
-    pushd "linux-${version}" || bail "Could not move into linux-${version}"
-
-    # Patches from the upstream
-    for patch in "${patches[@]}"; do
-        patch -p1 <"../$patch"
-    done
-
-    # Patches from bottlerocket
-    for patch in "${br_patches[@]}"; do
-        echo "Applying ${patch}"
-        patch -p1 <"$patch"
-    done
-
-    popd || bail "Could not move around - 'popd' failed. Lets stop before we break anything further."
-
-    for arch in "x86_64" "aarch64"; do
-
-        br_cfg="${kernel_path}/config-bottlerocket"
-        microcode_cfg="${kernel_path}/../microcode/${microcode_file}"
-        al_cfg="${PWD}/config-${arch}"
-        linux_src="${PWD}/linux-${version}"
-
-        pushd "linux-${version}" || bail "Could not move into linux-${version}"
-
-        if [ "${arch}" = "aarch64" ]; then
-            karch="arm64"
-            script_args=("../config-${arch}" "../config-bottlerocket")
-        elif [ "${arch}" = "x86_64" ]; then
-            karch="x86"
-            script_args=("../config-${arch}" "../config-microcode" "../config-bottlerocket")
-        fi
-
-        # mount config files and start the sdk docker container
-        docker run --rm \
-            -v "${br_cfg}":/config-bottlerocket \
-            -v "${microcode_cfg}":/config-microcode \
-            -v "${al_cfg}":/config-${arch} \
-            -v "${linux_src}":/linux-"${version}" \
-            -e ARCH="${karch}" \
-            -e CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu- \
-            -e KCONFIG_CONFIG=bottlerocket_${arch}_defconfig \
-            -w /linux-"${version}" \
-            -u "$(id -u)":1000 \
-            --name "${arch}-kernel-${version}-config-merger" \
-            "${sdk_image}" \
-            ./scripts/kconfig/merge_config.sh \
-            "${script_args[@]}"
-
-        mv -f "bottlerocket_${arch}_defconfig" "${kernel_path}/config-full-bottlerocket-${arch}"
-        popd || bail "Could not move around - 'popd' failed. Lets stop before we break anything further."
-    done
-
-    popd || bail "Could not move around - 'popd' failed. Lets stop before we break anything further."
-
+    docker run --rm \
+        -v "${kernel_path}/":/kernel-package \
+        -v "${tmpdir}":/work \
+        -v "${kernel_path}/../../":/package \
+        -u "$(id -u)":1000 \
+        --name "kernel-${version}-inner-full" \
+        "${sdk_image}" \
+        "/package/tools/inner-full-config.sh"
 }
 
 ################################################################################


### PR DESCRIPTION
Move all of the work to patch, merge, and generate configurations into an sdk container. The previous script only ran the merge-config.sh script in the container.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #174

**Description of changes:**

Move the work to extract, patch, and merge kernel configuations into a new inner-full-config script, and execute that script in an SDK container. As seen in issue #173, running this logic on a build machine can break for many reasons. Running inside the SDK world gives the script a stable environment.

**Testing done:**

Generated configurations for all three kernels. Verified that the resulting files were in fact rebuilt, but were identical to the files checked in to GitHub.

Both scripts are shellcheck clean.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
