### PR TITLE
Update kernels 6.1 and 6.12 to latest upstream

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/4bc5f6a434e2c9a9c70796d03f4a967ff73277f48acaf48629c30ca7807aa9a7/kernel-6.1.140-154.222.amzn2023.src.rpm"
-sha512 = "6be988d401ac6f8f5fea16053479888e9f0832f1cb39adbb6e57c507359e22c9bd8f1d13ef36a6432737bcca7aa682b1880a65c6d9628f958ebab1916a19af5c"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/1ab54821a628a0df1ec8643ea0c4c1a9a12f4ec5e6d8173e9a9d912417b02329/kernel-6.1.141-155.222.amzn2023.src.rpm"
+sha512 = "9b21faf5cad3b94aa88d51ee2e57358c30907917be73e426eaf22f5e0c42e242340d4e9cd19169832a53057be0539003f7b4d619c24811ba0956681959e78621"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/config-full-bottlerocket-aarch64
+++ b/packages/kernel-6.1/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.140 Kernel Configuration
+# Linux/arm64 6.1.141 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y
@@ -1106,7 +1106,6 @@ CONFIG_SKB_EXTENSIONS=y
 CONFIG_PACKET=y
 CONFIG_PACKET_DIAG=m
 CONFIG_UNIX=y
-CONFIG_UNIX_SCM=y
 CONFIG_AF_UNIX_OOB=y
 CONFIG_UNIX_DIAG=m
 CONFIG_TLS=m

--- a/packages/kernel-6.1/config-full-bottlerocket-x86_64
+++ b/packages/kernel-6.1/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.140 Kernel Configuration
+# Linux/x86 6.1.141 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y
@@ -1114,7 +1114,6 @@ CONFIG_SKB_EXTENSIONS=y
 CONFIG_PACKET=y
 CONFIG_PACKET_DIAG=m
 CONFIG_UNIX=y
-CONFIG_UNIX_SCM=y
 CONFIG_AF_UNIX_OOB=y
 CONFIG_UNIX_DIAG=m
 CONFIG_TLS=m

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.140
+Version: 6.1.141
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/4bc5f6a434e2c9a9c70796d03f4a967ff73277f48acaf48629c30ca7807aa9a7/kernel-6.1.140-154.222.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/1ab54821a628a0df1ec8643ea0c4c1a9a12f4ec5e6d8173e9a9d912417b02329/kernel-6.1.141-155.222.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/541f970e7b3ff886a4d94d8e285c83381eac315ed7baa2de40521886caaf2a0f/kernel6.12-6.12.30-34.92.amzn2023.src.rpm"
-sha512 = "09058cfd792700e0b9030dbb04185b9fb9c4798acaca8e0f224b55139cd478298101277c4a97d64e4fd1dc7f34688729a288ea15dff5cad1010b07e4c5e966f6"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/d7de2467b89a9bb41bfa57320fde107ec6f194836d75bc0bc370ee7391f2f4c8/kernel6.12-6.12.31-35.92.amzn2023.src.rpm"
+sha512 = "b332caad3f58a3cb5b3bc9339e56eb9c21a0ffbc0b6b7f91e9958a14ed59bbe6cbe634b098a2d5bfb0e1d421f49a3fd74d093a59ae86529e28c703dee652e2c2"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.12/config-full-bottlerocket-aarch64
+++ b/packages/kernel-6.12/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.12.30 Kernel Configuration
+# Linux/arm64 6.12.31 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-6.12/config-full-bottlerocket-x86_64
+++ b/packages/kernel-6.12/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.12.30 Kernel Configuration
+# Linux/x86 6.12.31 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -4,13 +4,13 @@
 %global kmajor 6.12
 
 Name: %{_cross_os}kernel-%{kmajor}
-Version: 6.12.30
+Version: 6.12.31
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/541f970e7b3ff886a4d94d8e285c83381eac315ed7baa2de40521886caaf2a0f/kernel6.12-6.12.30-34.92.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/d7de2467b89a9bb41bfa57320fde107ec6f194836d75bc0bc370ee7391f2f4c8/kernel6.12-6.12.31-35.92.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

- Update kernel-6.1 to 6.1.141
- Update kernel-6.12 to 6.12.31
- Config change in kernel-6.1 taken from upstream via this [commit](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=44aebf50fad29b)

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
