### PR TITLE
kernel-5.15: update to 5.15.185

### DIFF
--- a/packages/kernel-5.15/Cargo.toml
+++ b/packages/kernel-5.15/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/blobstore/769fc12891f0fb43f6e4d578cc269386eec708a8555a3660d203c1aa8dab89f3/kernel-5.15.184-125.190.amzn2.src.rpm"
-sha512 = "53441e5e1a1744ad36f3d229860fa90bb528873aed85565f1880528cf8f1873742e514ee955a61b2ba39c78c587051e40fa5ac40431c1db15815bc3f706beb3b"
+url = "https://cdn.amazonlinux.com/blobstore/952ee51ccb5639c808ac166c933216a6891813dff7908fbf9abaaadb57d58e20/kernel-5.15.185-126.190.amzn2.src.rpm"
+sha512 = "74e36b415bf8fbf26f94ee3f222a90b88d451840ef8d5332e5d6c1f8721a418e9d2ee84a05cb5d08eda2087d4f4739a2526ad03568c28a40858e8522a5375ed8"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-5.15/config-full-bottlerocket-aarch64
+++ b/packages/kernel-5.15/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 5.15.184 Kernel Configuration
+# Linux/arm64 5.15.185 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-5.15/config-full-bottlerocket-x86_64
+++ b/packages/kernel-5.15/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 5.15.184 Kernel Configuration
+# Linux/x86 5.15.185 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-5.15/kernel-5.15.spec
+++ b/packages/kernel-5.15/kernel-5.15.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-5.15
-Version: 5.15.184
+Version: 5.15.185
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/blobstore/769fc12891f0fb43f6e4d578cc269386eec708a8555a3660d203c1aa8dab89f3/kernel-5.15.184-125.190.amzn2.src.rpm
+Source0: https://cdn.amazonlinux.com/blobstore/952ee51ccb5639c808ac166c933216a6891813dff7908fbf9abaaadb57d58e20/kernel-5.15.185-126.190.amzn2.src.rpm
 Source1: gpgkey-99E617FE5DB527C0D8BD5F8E11CF1F95C87F5B1A.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.20.28.0.noarch.rpm


### PR DESCRIPTION
Rebase to Amazon Linux upstream version 5.15.185-126.190.amzn2.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

Update kernel-5.15 to version 5.15.185-126.190 (latest upstream)

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
