### PR TITLE
chore: prepare for v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v3.1.1 (2025-07-24)
+
+## OS Changes
+ * Update kernels 5.15, 6.1 and 6.12 to the latest upstream ([#199]) ([#201])
+
+[#199]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/199
+[#201]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/201
+
 # v3.1.0 (2025-06-11)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "3.1.0"
+release-version = "3.1.1"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Updates CHANGELOG.md and Twoliter.toml to prepare for kernel-kit v3.1.1

**Testing done:**

- CHANGELOG.md renders correctly
- verify [v3.1.0..develop](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v3.1.0...develop)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
