### PR TITLE
Add IMEX for 6.12 NVIDIA R570 driver

### DIFF
--- a/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
+++ b/packages/kmod-5.15-nvidia/kmod-5.15-nvidia.spec
@@ -3,9 +3,9 @@
 %global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
-%global fm_arch sbsa
+%global nvidia_arch sbsa
 %else
-%global fm_arch %{_cross_arch}
+%global nvidia_arch %{_cross_arch}
 %endif
 
 # With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
@@ -103,8 +103,8 @@ popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-mkdir fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
-rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} .
@@ -332,7 +332,7 @@ install -p -m 0644 supported-gpus/open-gpu-supported-devices.json %{buildroot}%{
 popd
 
 # Begin NVIDIA fabric manager binaries and topologies
-pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+pushd fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 install -p -m 0755 usr/bin/nv-fabricmanager %{buildroot}%{_cross_bindir}
 install -p -m 0755 usr/bin/nvswitch-audit %{buildroot}%{_cross_bindir}
 ln -rs %{buildroot}%{_cross_bindir}/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
@@ -358,7 +358,7 @@ popd
 
 %files tesla-%{tesla_major}
 %license NVidiaEULAforAWS.pdf
-%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
+%license fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
 %dir %{_cross_datadir}/nvidia/tesla
 %dir %{_cross_libexecdir}/nvidia/tesla/bin
 %dir %{_cross_libdir}/nvidia/tesla

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -3,9 +3,9 @@
 %global tesla_patch 08
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
-%global fm_arch sbsa
+%global nvidia_arch sbsa
 %else
-%global fm_arch %{_cross_arch}
+%global nvidia_arch %{_cross_arch}
 %endif
 
 # With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
@@ -132,8 +132,8 @@ popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-mkdir fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
-rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} %{S:3} .
@@ -432,7 +432,7 @@ install -p -m 0644 supported-gpus/open-gpu-supported-devices.json %{buildroot}%{
 popd
 
 # Begin NVIDIA fabric manager binaries and topologies
-pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+pushd fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 install -p -m 0755 usr/bin/nv-fabricmanager %{buildroot}%{_cross_bindir}
 install -p -m 0755 usr/bin/nvswitch-audit %{buildroot}%{_cross_bindir}
 ln -rs %{buildroot}%{_cross_bindir}/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
@@ -458,7 +458,7 @@ popd
 
 %files tesla
 %license NVidiaEULAforAWS.pdf
-%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
+%license fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
 %dir %{_cross_datadir}/egl
 %dir %{_cross_datadir}/egl/egl_external_platform.d
 %dir %{_cross_datadir}/glvnd

--- a/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
+++ b/packages/kmod-6.1-nvidia/kmod-6.1-nvidia.spec
@@ -3,9 +3,9 @@
 %global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
-%global fm_arch sbsa
+%global nvidia_arch sbsa
 %else
-%global fm_arch %{_cross_arch}
+%global nvidia_arch %{_cross_arch}
 %endif
 
 # With the split of the firmware binary from firmware/gsp.bin to firmware/gsp_ga10x.bin
@@ -106,8 +106,8 @@ popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-mkdir fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
-rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} .
@@ -346,7 +346,7 @@ install -p -m 0644 supported-gpus/open-gpu-supported-devices.json %{buildroot}%{
 popd
 
 # Begin NVIDIA fabric manager binaries and topologies
-pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+pushd fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 install -p -m 0755 usr/bin/nv-fabricmanager %{buildroot}%{_cross_bindir}
 install -p -m 0755 usr/bin/nvswitch-audit %{buildroot}%{_cross_bindir}
 ln -rs %{buildroot}%{_cross_bindir}/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
@@ -372,7 +372,7 @@ popd
 
 %files tesla-%{tesla_major}
 %license NVidiaEULAforAWS.pdf
-%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
+%license fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
 %dir %{_cross_datadir}/egl
 %dir %{_cross_datadir}/egl/egl_external_platform.d
 %dir %{_cross_datadir}/glvnd

--- a/packages/kmod-6.12-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r570/Cargo.toml
@@ -37,6 +37,16 @@ sha512 = "c6425cb53bb7915f5912e49c2b4182fe9875eb60759c15e130ae6d323dc168ad860451
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-570-570.148.08-1.x86_64.rpm"
+sha512 = "846e3f2c6dab2bf097771ec01720cf98ccd30f0dcbad09826d708e29f896982642bad866c38fc116c02f6f0a3feea3eaef69034380dc303dbb50aeee079ed01a"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-570-570.148.08-1.aarch64.rpm"
+sha512 = "13c1ac2f8650a909ea826fbd41c4ba3378a6c83aa6d38996c2a5509aa49f70a90c023ccaa1e1cad6ecd6808e721cc4effcf02f4cc21f0f2a0fc4043a105ba1bd"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
 url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/570/COPYING"
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -39,6 +39,10 @@ Source3: COPYING
 Source10: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
 Source11: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
 
+# IMEX for GB200
+Source20: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-%{tesla_ver}-1.x86_64.rpm
+Source21: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-%{tesla_ver}-1.aarch64.rpm
+
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in
 Source202: nvidia-dependencies-modules-load.conf
@@ -85,8 +89,16 @@ Requires: %{name}-grid
 Summary: NVIDIA fabricmanager config and service files
 Requires: %{name}-tesla(fabricmanager)
 Requires: %{_cross_os}nvlsm
+Requires: %{name}-imex
 
 %description fabricmanager
+%{summary}.
+
+%package imex
+Summary: NVIDIA IMEX config and service files
+Requires: %{name}
+
+%description imex
 %{summary}.
 
 %package open-gpu
@@ -140,6 +152,11 @@ rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm |
 
 # Add the license.
 install -p -m 0644 %{S:2} %{S:3} .
+
+# Extract imex from the rpm via cpio rather than `%%setup` since the
+# correct source is architecture-dependent.
+mkdir imex-%{nvidia_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-imex-%{tesla_major}-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D imex-%{nvidia_arch}-%{tesla_ver}-archive
 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
@@ -442,6 +459,13 @@ done
 
 popd
 
+# Begin IMEX binaries and configuration files
+pushd imex-%{nvidia_arch}-%{tesla_ver}-archive
+install -p -m 0755 usr/bin/nvidia-imex %{buildroot}%{_cross_bindir}
+install -p -m 0755 usr/bin/nvidia-imex-ctl %{buildroot}%{_cross_bindir}
+
+popd
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -708,3 +732,7 @@ popd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.env
 %{_cross_unitdir}/nvidia-fabricmanager.service
+
+%files imex
+%{_cross_bindir}/nvidia-imex
+%{_cross_bindir}/nvidia-imex-ctl

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -3,9 +3,9 @@
 %global tesla_patch 08
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
-%global fm_arch sbsa
+%global nvidia_arch sbsa
 %else
-%global fm_arch %{_cross_arch}
+%global nvidia_arch %{_cross_arch}
 %endif
 
 %global kernel_major 6.12
@@ -135,8 +135,8 @@ popd
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-mkdir fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
-rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
+rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} %{S:3} .
@@ -429,7 +429,7 @@ install -p -m 0644 supported-gpus/open-gpu-supported-devices.json %{buildroot}%{
 popd
 
 # Begin NVIDIA fabric manager binaries and topologies
-pushd fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive
+pushd fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 install -p -m 0755 usr/bin/nv-fabricmanager %{buildroot}%{_cross_bindir}
 install -p -m 0755 usr/bin/nvswitch-audit %{buildroot}%{_cross_bindir}
 ln -rs %{buildroot}%{_cross_bindir}/nv-fabricmanager %{buildroot}%{_cross_libexecdir}/nvidia/tesla/bin/nv-fabricmanager
@@ -455,7 +455,7 @@ popd
 
 %files tesla
 %license NVidiaEULAforAWS.pdf
-%license fabricmanager-linux-%{fm_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
+%license fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive/usr/share/doc/nvidia-fabricmanager/third-party-notices.txt
 %dir %{_cross_datadir}/egl
 %dir %{_cross_datadir}/egl/egl_external_platform.d
 %dir %{_cross_datadir}/glvnd

--- a/packages/nvlsm/nvlsm.spec
+++ b/packages/nvlsm/nvlsm.spec
@@ -5,9 +5,9 @@
 # Both `lib/libgrpc_mgr.so` and `sbin/nvlsm` have RPATHs set to `opt/nvidia/nvlsm` which causes the RPATH check to fail.
 %global __brp_check_rpaths %{nil}
 %if "%{?_cross_arch}" == "aarch64"
-%global fm_arch sbsa
+%global nvidia_arch sbsa
 %else
-%global fm_arch %{_cross_arch}
+%global nvidia_arch %{_cross_arch}
 %endif
 
 Name: %{_cross_os}nvlsm
@@ -35,14 +35,14 @@ Source204: nvlsm-ld.so.conf.in
 %prep
 # Extract Subnet Manager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
-mkdir nvlsm-linux-%{fm_arch}-%{nvlsm_ver}-archive
-rpm2cpio %{_sourcedir}/nvlsm-%{nvlsm_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D nvlsm-linux-%{fm_arch}-%{nvlsm_ver}-archive
+mkdir nvlsm-linux-%{nvidia_arch}-%{nvlsm_ver}-archive
+rpm2cpio %{_sourcedir}/nvlsm-%{nvlsm_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D nvlsm-linux-%{nvidia_arch}-%{nvlsm_ver}-archive
 
 # Add the license.
 install -p -m 0644 %{S:2} .
 
 %install
-pushd nvlsm-linux-%{fm_arch}-%{nvlsm_ver}-archive
+pushd nvlsm-linux-%{nvidia_arch}-%{nvlsm_ver}-archive
 
 # Install binary
 install -d %{buildroot}%{_cross_bindir}
@@ -73,7 +73,7 @@ install -m 0644 nvlsm.conf %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/
 %files
 %{_cross_attribution_file}
 %license NVidiaEULAforAWS.pdf
-%license nvlsm-linux-%{fm_arch}-%{nvlsm_ver}-archive/usr/share/nvidia/nvlsm/third-party-notices.txt
+%license nvlsm-linux-%{nvidia_arch}-%{nvlsm_ver}-archive/usr/share/nvidia/nvlsm/third-party-notices.txt
 
 %{_cross_bindir}/nvlsm
 


### PR DESCRIPTION
**Description of changes:**
This adds IMEX as a subpackage that provides support for GB200 devices which require the IMEX process to coordinate efficient communication between devices in ComputeDomains. The DRA device plugin will use these binaries when creating channels but GB200 hardware is required. This DRA DaemonSet provides [its own configuration file](https://github.com/NVIDIA/k8s-dra-driver-gpu/blob/4f10463592f4c877b0c252966d1b0ee14f3774a1/templates/compute-domain-daemon-config.tmpl.cfg) so only the binaries are provided. We do not provide a systemd service file either because the intention is to let the DRA driver manage this.

**Testing done:**
Built an `aws-k8s-1.33-nvidia` with this kit and confirmed the binaries run. 
```
bash-5.1# nvidia-imex --version
IMEX version is: 570.148.08
bash-5.1# nvidia-imex-ctl
Unable to open configuration file at /etc/nvidia-imex/config.cfg
Usage: nvidia-imex-ctl [-i <IP> <PORT>|-u <unix domain socket path>|-c <nvidia-imex config.cfg path>] <-n|-N|-q|-s|-d|-m> [-t <timeout>]
Where:
       -i <IP> <PORT>: Connect to the IMEX daemon's control service at the specified ip address and port.
       -u <unix domain socket path>: Connect to the IMEX daemon's control service at the specified unix domain socket path.
       -c <nvidia-imex config path>: Path to nvidia-imex configuration file.  Default value is /etc/nvidia-imex/config.cfg
NOTE:  If none of -i, -u, -c are provided, -c is assumed with default value.
       -n: Continuously monitor the entire IMEX domain status.  Requires config file (default or via -c)
       -N: Gets the full status of the entire IMEX domain.  Requires config file (default or via -c)
       -q: Query the status of the IMEX daemon once and return.
       -s: Subscribe to the status of the IMEX daemon.  Can be used with -t to terminate after a certain amount of time.
       -d: Dump performance metrics of the IMEX daemon once and return.
       -m: Subscribe to performance metrics of the IMEX daemon.  Can be used with -t to terminate after a certain amount of time.
       -t: Timeout (in milliseconds) for the -s command to terminate.  Unspecified means it will run until IMEX terminates.
       -r: Terminate status subscription when IMEX daemon returns READY status.
       -a: Only used with -q and -c.  Query status of all nodes configured, based on the config file in -c (or default.
       -j: Output of the -n/-N command will be in JSON, rather than formatted.
NOTE: only one of -i, -u, or -c can be specified.  If none are specified, -c is assumed with the default nvidia-imex config file location.
      also, only one command can be executed.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
