### PR TITLE
chore: prepare for v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# v3.1.1 (2025-07-24)
+ # v3.1.2 (2025-07-10)
+
+ ## OS Changes
+ * Update kernels from 5.15.185 to 5.15.186 ([#208])
+ * Update kernels from 6.1.141-155.222 to kernel-6.1.141-165.249 ([#208])
+ * Update kernels from 6.12.31-35.92 to 6.12.35-55.103 ([#208])
+
+[#208]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/208
+
+# v3.1.1 (2025-06-24)
 
 ## OS Changes
  * Update kernels 5.15, 6.1 and 6.12 to the latest upstream ([#199]) ([#201])

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "3.1.1"
+release-version = "3.1.2"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

Updates CHANGELOG.md and Twoliter.toml to prepare for kernel-kit v3.1.2

**Testing done:**

- CHANGELOG.md renders correctly
- verify [v3.1.1..develop](https://github.com/bottlerocket-os/bottlerocket-kernel-kit/compare/v3.1.1...develop)

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
