### PR TITLE
advisories: add BRSAs for grub CVEs patched in v4.0.0

### DIFF
--- a/advisories/4.0.0/BRSA-hyvdvzwmmufq.toml
+++ b/advisories/4.0.0/BRSA-hyvdvzwmmufq.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-hyvdvzwmmufq"
+title = "grub CVE-2024-45775"
+cve = "CVE-2024-45775"
+severity = "moderate"
+description = "A flaw was found in GRUB's extended command dispatcher. The `grub_extcmd_dispatcher()` function fails to check for memory allocation failures, leading to null pointer processing and potential crashes."
+
+[[advisory.products]]
+package-name = "grub"
+patched-version = "2.0.6"
+patched-epoch = "1"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2025-08-04T22:34:58Z
+arches = ["x86_64", "aarch64"]
+version = "4.0.0"

--- a/advisories/4.0.0/BRSA-k4mfj9sytcg7.toml
+++ b/advisories/4.0.0/BRSA-k4mfj9sytcg7.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "BRSA-k4mfj9sytcg7"
+title = "grub CVE-2025-0622"
+cve = "CVE-2025-0622"
+severity = "moderate"
+description = "A flaw was found in GRUB where variable hooks are not properly removed during module unload in PGP, normal, and gettext modules, potentially leading to use-after-free conditions."
+
+[[advisory.products]]
+package-name = "grub"
+patched-version = "2.0.6"
+patched-epoch = "1"
+
+[updateinfo]
+author = "giinglis"
+issue-date = 2025-08-04T22:34:58Z
+arches = ["aarch64", "x86_64"]
+version = "4.0.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Related: #228 


**Description of changes:**

Add advisories for `grub` updates that landed in recent kernel kit release.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
