### PR TITLE
kmod-6.12-nvidia-r570: add common module file for linking

### DIFF
--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -126,7 +126,7 @@ Requires: %{name}
 %package tesla
 Summary: NVIDIA %{tesla_major} Tesla driver
 Version: %{tesla_ver}
-License: LicenseRef-NVIDIA-AWS-EULA
+License: LicenseRef-NVIDIA-AWS-EULA AND GPL-2.0-only
 Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
 Requires: %{name}-fabricmanager
@@ -326,6 +326,9 @@ install -p -m 0644 \
 install kernel/nvidia.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
 install kernel/nvidia/nv-interface.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
 install kernel/nvidia/nv-kernel.o_binary %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d/nv-kernel.o
+
+# module-common object
+install kernel/.module-common.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d/.module-common.o
 
 # uvm
 install kernel/nvidia-uvm.mod.o %{buildroot}%{_cross_datadir}/nvidia/tesla/module-objects.d
@@ -553,6 +556,7 @@ popd
 %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia.mod.o
 %{_cross_datadir}/nvidia/tesla/module-objects.d/nv-interface.o
 %{_cross_datadir}/nvidia/tesla/module-objects.d/nv-kernel.o
+%{_cross_datadir}/nvidia/tesla/module-objects.d/.module-common.o
 
 # uvm
 %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-uvm.mod.o

--- a/packages/kmod-6.12-nvidia-r570/nvidia-tesla-build-config.toml.in
+++ b/packages/kmod-6.12-nvidia-r570/nvidia-tesla-build-config.toml.in
@@ -6,13 +6,13 @@ objects-source = "__NVIDIA_MODULES__"
 link-objects = ["nv-interface.o", "nv-kernel.o"]
 
 [nvidia-tesla.kernel-modules."nvidia.ko"]
-link-objects = ["nvidia.o", "nvidia.mod.o"]
+link-objects = ["nvidia.o", "nvidia.mod.o", ".module-common.o"]
 
 [nvidia-tesla.object-files."nvidia-modeset.o"]
 link-objects = ["nv-modeset-interface.o", "nv-modeset-kernel.o"]
 
 [nvidia-tesla.kernel-modules."nvidia-modeset.ko"]
-link-objects = ["nvidia-modeset.o", "nvidia-modeset.mod.o"]
+link-objects = ["nvidia-modeset.o", "nvidia-modeset.mod.o", ".module-common.o"]
 
 [nvidia-tesla.kernel-modules."nvidia-uvm.ko"]
-link-objects = ["nvidia-uvm.o", "nvidia-uvm.mod.o"]
+link-objects = ["nvidia-uvm.o", "nvidia-uvm.mod.o", ".module-common.o"]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #176 

**Description of changes:**

- Add module-common.o to nvidia driver spec
- This change is necessary due to this [commit](https://github.com/gregkh/linux/commit/fdf94e4403ece60b29ef9e2da95e2fcefe50817f) changing the linking of constants in upstream. 

**Testing done:**

- Built a custom AMI with kernel-kit v4.0.1 and bottlerocket v1.44.0
- Deployed a pod with the latest `aws-k8s-nvidia` variant for `aarch64` and `x86_64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
