### PR TITLE
tools: add additional version checks to changelog validation

### DIFF
--- a/tools/validate-changelog.sh
+++ b/tools/validate-changelog.sh
@@ -4,9 +4,23 @@
 # this should be sufficient to validate the CHANGELOG for our CI, provided that
 # every new tag has a corresponding CHANGELOG update, as we always parse the
 # CHANGELOG between two headers with a tagged version.
-if diff <(grep -ne '^# ' CHANGELOG.md) <(grep -ne '^# v[0-9]\+\.[0-9]\+\.[0-9]\+' CHANGELOG.md); then
-  echo "CHANGELOG validation PASSED!"
-else
+if ! diff <(grep -ne '^# ' CHANGELOG.md) <(grep -ne '^# v[0-9]\+\.[0-9]\+\.[0-9]\+' CHANGELOG.md); then
   echo "CHANGELOG validation FAILED! Headers must match the regex '^# v[0-9]\+\.[0-9]\+\.[0-9]\+.'"
   exit 1
 fi
+
+# check that all versions are unique
+versions=$(grep -o '^# v[0-9]\+\.[0-9]\+\.[0-9]\+' CHANGELOG.md)
+if [[ $(echo "${versions}" | sort | uniq -d | wc -l) -gt 0 ]]; then
+  echo "CHANGELOG validation FAILED! Duplicate versions found."
+  exit 1
+fi
+
+# check that versions are in descending order
+# sort the versions and check the diff with current set of versions
+if ! echo "${versions}" | sort -V -r | diff - <(echo "${versions}"); then
+  echo "CHANGELOG validation FAILED! Versions must be in descending order."
+  exit 1
+fi
+
+echo "CHANGELOG validation PASSED!"


### PR DESCRIPTION
Add a check to verify that last two versions are not same

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


**Description of changes:**

Added the following checks to `CHANGELOG` validation
- All release versions are unique
- All release versions in `CHANGELOG` are in descending order

**Testing done:**

- Validation passed with current `CHANGELOG.md`
- Validation failed with duplicate kit versions
- Validation failed with version in non descending order eg: v4.0.2 before v4.0.1

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
