### PR TITLE
tools: add makefile targets for kernel configuration generation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TOOLS_DIR := $(TOP)tools
 TWOLITER_DIR := $(TOOLS_DIR)/twoliter
 TWOLITER := $(TWOLITER_DIR)/twoliter
 CARGO_HOME := $(TOP).cargo
+KERNEL_CONFIG_SCRIPT := $(TOOLS_DIR)/latest-kernel-full-config.sh
 
 TWOLITER_VERSION ?= "0.11.0"
 TWOLITER_SHA256_AARCH64 ?= "418f762baf1698472af697d40bc4877dd5fa0b033fda31250b3d38e02d72a289"
@@ -20,6 +21,67 @@ endif
 
 
 all: build
+
+merge-kernel-configs:
+	@echo "Validating parameters for merge-kernel-configs..."
+	@usage_msg="Usage: make merge-kernel-configs RPM_FILE=/path/to/kernel-source.rpm SDK_IMAGE=image:tag KVER=x.y"; \
+	validate_param() { \
+		param_name="$${1}"; param_value="$${2}"; error_msg="$${3}"; \
+		[ -n "$${param_value}" ] || { echo "Error: $${error_msg}"; echo "$${usage_msg}"; exit 1; }; \
+	}; \
+	validate_param "SDK_IMAGE" "$(SDK_IMAGE)" "SDK_IMAGE parameter is required"; \
+	validate_param "KVER" "$(KVER)" "KVER parameter is required"; \
+	echo "All parameter checks passed. Merging kernel configs for version $(KVER)..."
+
+	@tmpdir=$$(mktemp -d); \
+	if [ $$? -ne 0 ]; then \
+		echo "Error: Failed to create temporary directory"; \
+		exit 1; \
+	fi; \
+	cp "$(RPM_FILE)" "$${tmpdir}/kernel-source.rpm"; \
+	if [ $$? -ne 0 ]; then \
+		echo "Error: Failed to copy RPM file to temporary directory"; \
+		rm -rf "$${tmpdir}"; \
+		exit 1; \
+	fi; \
+	cd packages/kernel-$(KVER) && \
+	docker run --rm \
+		-v "$(PWD)/packages/kernel-$(KVER)/":/kernel-package \
+		-v "$${tmpdir}":/work \
+		-v "$(PWD)/packages/microcode/":/microcode \
+		-v "$(PWD)/tools/latest-kernel-full-config.sh":/latest-kernel-full-config.sh \
+		--user "$$(id -u):$$(id -g)" \
+		--name "kernel-$(KVER)-inner-full" \
+		"$(SDK_IMAGE)" \
+		bash -c "source /latest-kernel-full-config.sh && inner_full_config"; \
+	docker_exit_code=$$?; \
+	rm -rf "$${tmpdir}"; \
+	if [ $$docker_exit_code -ne 0 ]; then \
+		echo "Error: Docker container execution failed with exit code $$docker_exit_code"; \
+		exit $$docker_exit_code; \
+	fi; \
+	echo "Successfully merged kernel configs for version $(KVER)"
+
+full-config:
+	@if [ -z "$(RPM_FILE)" ]; then \
+		echo "Error: RPM_FILE parameter is required"; \
+		echo "Usage: make full-config RPM_FILE=/path/to/kernel-source.rpm"; \
+		exit 1; \
+	fi; \
+	echo "Checking kernel configuration dependencies..."; \
+	source $(KERNEL_CONFIG_SCRIPT) && check_dependencies; \
+	echo "All dependencies are available."; \
+	rpm_file=$$(realpath "$(RPM_FILE)"); \
+	if [ ! -f "$${rpm_file}" ]; then \
+		echo "Error: RPM file not found: $${rpm_file}"; \
+		exit 1; \
+	fi; \
+	sdk_image=$$(source $(KERNEL_CONFIG_SCRIPT) && resolve_bottlerocket_sdk); \
+	kver=$$(rpm --query --nosignature --queryformat '%{VERSION}' "$${rpm_file}" | sed 's/\.[^.]*$$//'); \
+	echo "Processing kernel version: $${kver}"; \
+	echo "Using SDK image: $${sdk_image}"; \
+	echo "Using RPM file: $${rpm_file}"; \
+	$(MAKE) merge-kernel-configs RPM_FILE="$${rpm_file}" SDK_IMAGE="$${sdk_image}" KVER="$${kver}"
 
 prep:
 	@mkdir -p $(TWOLITER_DIR)
@@ -57,4 +119,4 @@ endif
 twoliter: prep
 	@$(TWOLITER_MAKE) $(TWOLITER_MAKE_ARGS)
 
-.PHONY: prep update fetch build publish twoliter
+.PHONY: prep update fetch build publish twoliter merge-kernel-configs full-config

--- a/tools/latest-kernel-full-config.sh
+++ b/tools/latest-kernel-full-config.sh
@@ -2,17 +2,7 @@
 
 set -e -o pipefail
 
-#
 # Common error handling
-#
-
-# Cleanup all tmp files/directories
-cleanup() {
-    rm -rf "$tmpdir"
-}
-
-trap cleanup INT EXIT
-
 bail() {
     if [[ $# -gt 0 ]]; then
         >&2 echo "Error: $*"
@@ -26,16 +16,23 @@ usage() {
 Usage: $(basename "$0") -r RPM_FILE
 
 Extract kernel configurations from an RPM, merge with Bottlerocket's, and write out to a file, per architecture (x86_64 and aarch64).
-Run from the top-level bottlerocket-kernel-kit directory with the following parameters:
+
+This script provides functions intended to be run inside the bottlerocket-sdk container.
+For typical usage, run 'make full-config RPM_FILE=/path/to/kernel-source.rpm' from the top-level bottlerocket-kernel-kit directory.
+
+Direct script usage (for development/debugging):
     -r RPM_FILE    Path to RPM file
     -h             Display this help message
 
-Dependencies:
+Dependencies (when running directly):
     - docker
     - rpm2cpio
     - cpio
     - tar
     - tq
+
+Note: The inner_full_config() function is designed to run within the bottlerocket-sdk container environment
+and expects specific mount points and toolchain paths to be available.
 EOF
 }
 
@@ -70,31 +67,28 @@ resolve_bottlerocket_sdk() {
     echo "${registry}/${name}:v${version}"
 }
 
-# expect $pwd to be packages/kernel-${kver}
-merge_kernel_configs() {
-    rpm_file=$1
-    sdk_image=$2
-    kernel_path=$PWD
+# Function to perform the kernel configuration merging inside Docker container
+inner_full_config() {
+    pushd /work || bail "Unable to enter /work (bind mount to tmp dir)"
 
-    version="$(rpm --query --nosignature --queryformat '%{VERSION}' "${rpm_file}")"
+    version="$(rpm --query --nosignature --queryformat '%{VERSION}' kernel-source.rpm)"
     majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
     if [ "${majorminor}" == "6.12" ]; then
         # kernel 6.12 has a patch file that is not applied to the kernel sources, so
         # only pick up the 1000-series kernel patches for our purposes here.
-        readarray -t br_patches < <(find "${kernel_path}" -maxdepth 1 -name "10*.patch")
+        readarray -t br_patches < <(find /kernel-package -maxdepth 1 -name "10*.patch")
         spec_file="kernel6.12.spec"
         microcode_file="config-microcode-6-12"
     else
-        readarray -t br_patches < <(find "${kernel_path}" -maxdepth 1 -name "*.patch")
+        readarray -t br_patches < <(find /kernel-package -maxdepth 1 -name "*.patch")
         spec_file="kernel.spec"
         microcode_file="config-microcode"
     fi
 
-    tmpdir=$(mktemp -d)
-    cp "${rpm_file}" "${tmpdir}/"
-    pushd "${tmpdir}" || bail "Could not move around"
+    kernel_path=/kernel-package
 
-    rpm2cpio "${rpm_file}" | cpio -iu {,./}linux-"${version}".tar{,.xz} {,./}config-x86_64 {,./}config-aarch64 {,./}"*.patch" {,./}"${spec_file}"
+    rpm2cpio kernel-source.rpm | cpio -iu {,./}linux-"${version}".tar{,.xz} {,./}config-x86_64 {,./}config-aarch64 {,./}"*.patch" {,./}"${spec_file}"
+
     # Upstream source is either xz compressed tarball or plain tarball
     if [ -f "./linux-${version}.tar" ]; then
         tar -xof linux-"${version}".tar; rm linux-"${version}".tar
@@ -102,9 +96,10 @@ merge_kernel_configs() {
         tar -xof linux-"${version}".tar.xz; rm linux-"${version}".tar.xz
     fi
 
-    # Find patch ordering based on the upstream SRPM and apply in that order
+    # Find upstream patch ordering based on the upstream SRPM so we can apply in that order
     readarray -t patches < <(grep -P "^Patch\d+" "${spec_file}" | sort -n -k1.6 | grep -oP "^Patch\d+: \K.*\.patch$" "${spec_file}")
 
+    # Enter the source directory extracted from the tarball and patch
     pushd "linux-${version}" || bail "Could not move into linux-${version}"
 
     # Patches from the upstream
@@ -114,99 +109,32 @@ merge_kernel_configs() {
 
     # Patches from bottlerocket
     for patch in "${br_patches[@]}"; do
-        echo "Applying ${patch}"
+        echo "Applying bottlerocket patch ${patch}"
         patch -p1 <"$patch"
     done
 
-    popd || bail "Could not move around - 'popd' failed. Lets stop before we break anything further."
+    popd || bail "Could not move around - 'popd' back to /work failed. Lets stop before we break anything further."
 
     for arch in "x86_64" "aarch64"; do
 
+        export CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu-
+        export KCONFIG_CONFIG=bottlerocket_${arch}_defconfig
+
         br_cfg="${kernel_path}/config-bottlerocket"
-        microcode_cfg="${kernel_path}/../microcode/${microcode_file}"
-        al_cfg="${PWD}/config-${arch}"
-        linux_src="${PWD}/linux-${version}"
+        microcode_cfg="/microcode/${microcode_file}"
 
         pushd "linux-${version}" || bail "Could not move into linux-${version}"
 
         if [ "${arch}" = "aarch64" ]; then
             karch="arm64"
-            script_args=("../config-${arch}" "../config-bottlerocket")
+            script_args=("../config-${arch}" "${br_cfg}")
         elif [ "${arch}" = "x86_64" ]; then
             karch="x86"
-            script_args=("../config-${arch}" "../config-microcode" "../config-bottlerocket")
+            script_args=("../config-${arch}" "${microcode_cfg}" "${br_cfg}")
         fi
 
-        # mount config files and start the sdk docker container
-        docker run --rm \
-            -v "${br_cfg}":/config-bottlerocket \
-            -v "${microcode_cfg}":/config-microcode \
-            -v "${al_cfg}":/config-${arch} \
-            -v "${linux_src}":/linux-"${version}" \
-            -e ARCH="${karch}" \
-            -e CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu- \
-            -e KCONFIG_CONFIG=bottlerocket_${arch}_defconfig \
-            -w /linux-"${version}" \
-            -u "$(id -u)":1000 \
-            --name "${arch}-kernel-${version}-config-merger" \
-            "${sdk_image}" \
-            ./scripts/kconfig/merge_config.sh \
-            "${script_args[@]}"
-
-        mv -f "bottlerocket_${arch}_defconfig" "${kernel_path}/config-full-bottlerocket-${arch}"
-        popd || bail "Could not move around - 'popd' failed. Lets stop before we break anything further."
+        ARCH=${karch} ./scripts/kconfig/merge_config.sh "${script_args[@]}"
+        mv -f "bottlerocket_${arch}_defconfig" "${kernel_path}/config-full-bottlerocket-${arch}" || bail "Failed to create config-full-bottlerocket-${arch}"
+        popd || bail "Could not move around - 'popd' failed in merge_config loop. Lets stop before we break anything further."
     done
-
-    popd || bail "Could not move around - 'popd' failed. Lets stop before we break anything further."
-
 }
-
-################################################################################
-# START MAIN CONTROL FLOW
-################################################################################
-
-# parse arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -r|--rpm-file)
-            shift; rpm_file="$1" ;;
-        *)
-            usage_error "Invalid option '$1'" ;;
-    esac
-    shift
-done
-
-# Verify all required parameters are provided
-if [ -z "${rpm_file}" ]; then
-    echo "Error: Missing required parameters"
-    usage
-    exit 1
-fi
-
-rpm_file=$(realpath "${rpm_file}")
-
-# Check if the RPM file exists
-if [ ! -f "${rpm_file}" ]; then
-    bail "RPM file not found: ${rpm_file}"
-fi
-
-# Check dependencies
-check_dependencies
-
-# Get SDK image from Twoliter.lock and/or Twoliter.override
-sdk_image=$(resolve_bottlerocket_sdk)
-
-# Parse RPM file for kernel version (6.1, 6.12, etc.)
-kver=$(rpm --query --nosignature --queryformat '%{VERSION}' "${rpm_file}" | sed 's/\.[^.]*$//')
-
-# pushd into kernel dir
-pushd packages || bail "Could not move into packages"
-pushd kernel-"${kver}" || bail "Could not move into packages/kernel-${kver}"
-
-# Merge configs
-merge_kernel_configs "${rpm_file}" "${sdk_image}"
-
-# Exit kernel-${kver}/ dir
-popd  || bail "Could not move around - 'popd' failed."
-# Exit packages/ dir
-popd  || bail "Could not move around - 'popd' failed."


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #174

**Description of changes:**

Move the work to extract, patch, and merge kernel configurations into a new inner-full-config function, and execute that function in an SDK container in Makefile. As seen in issue https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/173, running this logic on a build machine can break for many reasons. Running inside the SDK world gives the script a stable environment.

**Testing done:**
- [X] generate configs for the kernel 6.1
```
╭─ in ~/workplace/repos/bottlerocket-kernel-kit/packages/kernel-6.1 on develop ✘ (origin/develop)
╰$ diff -u config-full-bottlerocket-x86_64 /home/xxx/workplace/larvacr_branch/bottlerocket-kernel-kit/packages/kernel-6.1/config-full-bottlerocket-x86_64
╭─ in ~/workplace/repos/bottlerocket-kernel-kit/packages/kernel-6.1 on develop ✘ (origin/develop)
╰$ diff -u config-full-bottlerocket-aarch64 /home/xxx/workplace/larvacr_branch/bottlerocket-kernel-kit/packages/kernel-6.1/config-full-bottlerocket-aarch64
╭─ ~/workplace/repos/bottlerocket-kernel-kit/packages/kernel-6.1 on develop ✘ (origin/develop)
╰$
```
diff generate same
- [x] generate config for the kernel 6.12
```
╭─in ~/workplace/repos/bottlerocket-kernel-kit/packages/kernel-6.12 on develop ✘ (origin/develop)
╰$ diff -u config-full-bottlerocket-aarch64 /home/xxx/workplace/larvacr_branch/bottlerocket-kernel-kit/packages/kernel-6.12/config-full-bottlerocket-aarch64
╭─in ~/workplace/repos/bottlerocket-kernel-kit/packages/kernel-6.12 on develop ✘ (origin/develop)
╰$ diff -u config-full-bottlerocket-x86_64 /home/xxx/workplace/larvacr_branch/bottlerocket-kernel-kit/packages/kernel-6.12/config-full-bottlerocket-x86_64
╭─ in ~/workplace/repos/bottlerocket-kernel-kit/packages/kernel-6.12 on develop ✘ (origin/develop)
╰$
```
- [x] change and test the kernel update automation
    - successfully generate the script



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
