### PR TITLE
Prepare v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v4.1.0 (2025-08-19)
+## OS Changes
+* Provide missing kernel module details for r570 Tesla drivers in 6.12 ([#234])
+* Enable SCSI for VMware ([#237])
+
+## Build Changes
+* Update the Bottlerocket SDK to v0.64.0 ([#248])
+
+[#234]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/234
+[#237]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/237
+[#248]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/248
+
 # v4.0.1 (2025-08-11)
 ## OS Changes
  * Update kernel from 6.12.40-63.107 to 6.12.40-63.114 ([#239])

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 1
-release-version = "4.0.1"
+release-version = "4.1.0"
 
 [vendor.bottlerocket]
 registry = "public.ecr.aws/bottlerocket"


### PR DESCRIPTION
**Description of changes:**

Changes to prepare the 4.1.0 release

**Testing done:**
Along with the Core Kit update:

```bash
[root@admin] go version /.bottlerocket/rootfs/usr/bin/containerd
/.bottlerocket/rootfs/usr/bin/containerd: go1.23.12
[root@admin]
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
