### PR TITLE
Backport patch to prevent race in SMB subsystem

### DIFF
--- a/packages/kernel-6.1/1006-strscpy-write-destination-buffer-only-once.patch
+++ b/packages/kernel-6.1/1006-strscpy-write-destination-buffer-only-once.patch
@@ -1,4 +1,4 @@
-From 9022ed0e7e65734d83a0648648589b9fbea8e8c9 Mon Sep 17 00:00:00 2001
+From ed2be07555332ec51bb1a0197c60b6db08c10226 Mon Sep 17 00:00:00 2001
 From: Linus Torvalds <torvalds@linux-foundation.org>
 Date: Sun, 1 Dec 2024 09:23:33 -0800
 Subject: [PATCH] strscpy: write destination buffer only once
@@ -58,10 +58,8 @@ So avoid any "copy possibly non-terminated string, and terminate later"
 behavior, and write the destination buffer only once.
 
 Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
-[vyaghras:
-  - backport to 6.1
-  - apply changes in original patch to strscpy, since sized_strscpy
-    doesn't exist in 6.1]
+[vyaghras: adjust context since e6584c3964f2f ("string: Allow 2-argument
+strscpy()") is not present]
 Signed-off-by: Shikha Vyaghra <vyaghras@amazon.com>
 Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
 ---
@@ -69,7 +67,7 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 18 insertions(+), 6 deletions(-)
 
 diff --git a/lib/string.c b/lib/string.c
-index 3371d26a0e39..f2915577e056 100644
+index c4b8349ff058..9b963182326b 100644
 --- a/lib/string.c
 +++ b/lib/string.c
 @@ -172,6 +172,13 @@ EXPORT_SYMBOL(strlcpy);
@@ -86,7 +84,7 @@ index 3371d26a0e39..f2915577e056 100644
  ssize_t strscpy(char *dest, const char *src, size_t count)
  {
  	const struct word_at_a_time constants = WORD_AT_A_TIME_CONSTANTS;
-@@ -215,13 +222,18 @@ ssize_t strscpy(char *dest, const char *src, size_t count)
+@@ -222,13 +229,18 @@ ssize_t strscpy(char *dest, const char *src, size_t count)
  			*(unsigned long *)(dest+res) = c & zero_bytemask(data);
  			return res + find_zero(data);
  		}
@@ -107,7 +105,7 @@ index 3371d26a0e39..f2915577e056 100644
  		char c;
  
  		c = src[res];
-@@ -232,11 +244,11 @@ ssize_t strscpy(char *dest, const char *src, size_t count)
+@@ -239,11 +251,11 @@ ssize_t strscpy(char *dest, const char *src, size_t count)
  		count--;
  	}
  
@@ -124,5 +122,5 @@ index 3371d26a0e39..f2915577e056 100644
  EXPORT_SYMBOL(strscpy);
  #endif
 -- 
-2.49.0
+2.50.1
 

--- a/packages/kernel-6.1/1007-smb-client-Avoid-race-in-open_cached_dir-with-lease-.patch
+++ b/packages/kernel-6.1/1007-smb-client-Avoid-race-in-open_cached_dir-with-lease-.patch
@@ -1,0 +1,104 @@
+From 9a09a8898decb5c077846396378f8deb612355a0 Mon Sep 17 00:00:00 2001
+From: Paul Aurich <paul@darkrain42.org>
+Date: Tue, 6 May 2025 22:28:09 -0700
+Subject: [PATCH] smb: client: Avoid race in open_cached_dir with lease breaks
+
+commit 3ca02e63edccb78ef3659bebc68579c7224a6ca2 upstream.
+
+A pre-existing valid cfid returned from find_or_create_cached_dir might
+race with a lease break, meaning open_cached_dir doesn't consider it
+valid, and thinks it's newly-constructed. This leaks a dentry reference
+if the allocation occurs before the queued lease break work runs.
+
+Avoid the race by extending holding the cfid_list_lock across
+find_or_create_cached_dir and when the result is checked.
+
+Cc: stable@vger.kernel.org
+Reviewed-by: Henrique Carvalho <henrique.carvalho@suse.com>
+Signed-off-by: Paul Aurich <paul@darkrain42.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+[agarrcia: adjust context for find_or_create_cached_dir and
+open_cached_dir since 6a50d71d0fff ("smb3: allow controlling maximum
+number number of cached directories"), 73a57b25b4df ("smb: Don't leak
+cfid when reconnect races with open_cached_dir"), and 81ba10959970
+("smb: client: prevent new fids from being removed by laundromat") are
+not present ]
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Signed-off-by: Andrew Paniakin <apanyaki@amazon.com>
+---
+ fs/smb/client/cached_dir.c | 11 ++++-------
+ 1 file changed, 4 insertions(+), 7 deletions(-)
+
+diff --git a/fs/smb/client/cached_dir.c b/fs/smb/client/cached_dir.c
+index a77e2b5bb723..eed3aa1f60e3 100644
+--- a/fs/smb/client/cached_dir.c
++++ b/fs/smb/client/cached_dir.c
+@@ -22,7 +22,6 @@ static struct cached_fid *find_or_create_cached_dir(struct cached_fids *cfids,
+ {
+ 	struct cached_fid *cfid;
+ 
+-	spin_lock(&cfids->cfid_list_lock);
+ 	list_for_each_entry(cfid, &cfids->entries, entry) {
+ 		if (!strcmp(cfid->path, path)) {
+ 			/*
+@@ -31,25 +30,20 @@ static struct cached_fid *find_or_create_cached_dir(struct cached_fids *cfids,
+ 			 * being deleted due to a lease break.
+ 			 */
+ 			if (!cfid->time || !cfid->has_lease) {
+-				spin_unlock(&cfids->cfid_list_lock);
+ 				return NULL;
+ 			}
+ 			kref_get(&cfid->refcount);
+-			spin_unlock(&cfids->cfid_list_lock);
+ 			return cfid;
+ 		}
+ 	}
+ 	if (lookup_only) {
+-		spin_unlock(&cfids->cfid_list_lock);
+ 		return NULL;
+ 	}
+ 	if (cfids->num_entries >= MAX_CACHED_FIDS) {
+-		spin_unlock(&cfids->cfid_list_lock);
+ 		return NULL;
+ 	}
+ 	cfid = init_cached_dir(path);
+ 	if (cfid == NULL) {
+-		spin_unlock(&cfids->cfid_list_lock);
+ 		return NULL;
+ 	}
+ 	cfid->cfids = cfids;
+@@ -57,7 +51,6 @@ static struct cached_fid *find_or_create_cached_dir(struct cached_fids *cfids,
+ 	list_add(&cfid->entry, &cfids->entries);
+ 	cfid->on_list = true;
+ 	kref_get(&cfid->refcount);
+-	spin_unlock(&cfids->cfid_list_lock);
+ 	return cfid;
+ }
+ 
+@@ -162,8 +155,10 @@ int open_cached_dir(unsigned int xid, struct cifs_tcon *tcon,
+ 	if (!utf16_path)
+ 		return -ENOMEM;
+ 
++	spin_lock(&cfids->cfid_list_lock);
+ 	cfid = find_or_create_cached_dir(cfids, path, lookup_only);
+ 	if (cfid == NULL) {
++		spin_unlock(&cfids->cfid_list_lock);
+ 		kfree(utf16_path);
+ 		return -ENOENT;
+ 	}
+@@ -173,10 +168,12 @@ int open_cached_dir(unsigned int xid, struct cifs_tcon *tcon,
+ 	 * this cfid.
+ 	 */
+ 	if (cfid->has_lease) {
++		spin_unlock(&cfids->cfid_list_lock);
+ 		*ret_cfid = cfid;
+ 		kfree(utf16_path);
+ 		return 0;
+ 	}
++	spin_unlock(&cfids->cfid_list_lock);
+ 
+ 	/*
+ 	 * Skip any prefix paths in @path as lookup_positive_unlocked() ends up
+-- 
+2.50.1
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -48,6 +48,8 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 # Backport patch to ensure NUL-terminated task->comm buffer 
 Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
+# Backport patch to prevent race conditions in SMB's open_cached_dir
+Patch1007: 1007-smb-client-Avoid-race-in-open_cached_dir-with-lease-.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Issue number:**

Closes #252

**Description of changes:**

Backport https://github.com/gregkh/linux/commit/3ca02e63. Also, adjust commit message for another patch that was backported to 6.1.


**Testing done:**
I built an AMI with the the patch and confirmed the instance boots. Anecdotal data suggests from the 6.12 kernel suggests that the problem observed in 6.1 isn't present due to this change.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
