### PR TITLE
Makefile: fix targets `merge-kernel-configs` and `full-config`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,66 +22,8 @@ endif
 
 all: build
 
-merge-kernel-configs:
-	@echo "Validating parameters for merge-kernel-configs..."
-	@usage_msg="Usage: make merge-kernel-configs RPM_FILE=/path/to/kernel-source.rpm SDK_IMAGE=image:tag KVER=x.y"; \
-	validate_param() { \
-		param_name="$${1}"; param_value="$${2}"; error_msg="$${3}"; \
-		[ -n "$${param_value}" ] || { echo "Error: $${error_msg}"; echo "$${usage_msg}"; exit 1; }; \
-	}; \
-	validate_param "SDK_IMAGE" "$(SDK_IMAGE)" "SDK_IMAGE parameter is required"; \
-	validate_param "KVER" "$(KVER)" "KVER parameter is required"; \
-	echo "All parameter checks passed. Merging kernel configs for version $(KVER)..."
-
-	@tmpdir=$$(mktemp -d); \
-	if [ $$? -ne 0 ]; then \
-		echo "Error: Failed to create temporary directory"; \
-		exit 1; \
-	fi; \
-	cp "$(RPM_FILE)" "$${tmpdir}/kernel-source.rpm"; \
-	if [ $$? -ne 0 ]; then \
-		echo "Error: Failed to copy RPM file to temporary directory"; \
-		rm -rf "$${tmpdir}"; \
-		exit 1; \
-	fi; \
-	cd packages/kernel-$(KVER) && \
-	docker run --rm \
-		-v "$(PWD)/packages/kernel-$(KVER)/":/kernel-package \
-		-v "$${tmpdir}":/work \
-		-v "$(PWD)/packages/microcode/":/microcode \
-		-v "$(PWD)/tools/latest-kernel-full-config.sh":/latest-kernel-full-config.sh \
-		--user "$$(id -u):$$(id -g)" \
-		--name "kernel-$(KVER)-inner-full" \
-		"$(SDK_IMAGE)" \
-		bash -c "source /latest-kernel-full-config.sh && inner_full_config"; \
-	docker_exit_code=$$?; \
-	rm -rf "$${tmpdir}"; \
-	if [ $$docker_exit_code -ne 0 ]; then \
-		echo "Error: Docker container execution failed with exit code $$docker_exit_code"; \
-		exit $$docker_exit_code; \
-	fi; \
-	echo "Successfully merged kernel configs for version $(KVER)"
-
 full-config:
-	@if [ -z "$(RPM_FILE)" ]; then \
-		echo "Error: RPM_FILE parameter is required"; \
-		echo "Usage: make full-config RPM_FILE=/path/to/kernel-source.rpm"; \
-		exit 1; \
-	fi; \
-	echo "Checking kernel configuration dependencies..."; \
-	source $(KERNEL_CONFIG_SCRIPT) && check_dependencies; \
-	echo "All dependencies are available."; \
-	rpm_file=$$(realpath "$(RPM_FILE)"); \
-	if [ ! -f "$${rpm_file}" ]; then \
-		echo "Error: RPM file not found: $${rpm_file}"; \
-		exit 1; \
-	fi; \
-	sdk_image=$$(source $(KERNEL_CONFIG_SCRIPT) && resolve_bottlerocket_sdk); \
-	kver=$$(rpm --query --nosignature --queryformat '%{VERSION}' "$${rpm_file}" | sed 's/\.[^.]*$$//'); \
-	echo "Processing kernel version: $${kver}"; \
-	echo "Using SDK image: $${sdk_image}"; \
-	echo "Using RPM file: $${rpm_file}"; \
-	$(MAKE) merge-kernel-configs RPM_FILE="$${rpm_file}" SDK_IMAGE="$${sdk_image}" KVER="$${kver}"
+	./tools/docker-run.sh "/bottlerocket-kernel-kit/tools/latest-kernel-full-config.sh"
 
 prep:
 	@mkdir -p $(TWOLITER_DIR)
@@ -119,4 +61,4 @@ endif
 twoliter: prep
 	@$(TWOLITER_MAKE) $(TWOLITER_MAKE_ARGS)
 
-.PHONY: prep update fetch build publish twoliter merge-kernel-configs full-config
+.PHONY: prep update fetch build publish twoliter full-config

--- a/tools/docker-run.sh
+++ b/tools/docker-run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+
+bail() {
+    if [[ $# -gt 0 ]]; then
+        >&2 echo "Error: $*"
+    fi
+    exit 1
+}
+
+SCRIPT_PATH="$1"
+
+source="$(tq -r ".sdk.source" -f Twoliter.lock)"
+version="$(tq -r ".sdk.version" -f Twoliter.lock)"
+_name="$(tq -r ".sdk.name" -f Twoliter.lock)"
+_registry="${source%/*}"
+
+registry="$(tq -r ".bottlerocket.bottlerocket-sdk.registry" -f Twoliter.override 2>/dev/null || echo "$_registry")"
+name="$(tq -r ".bottlerocket.bottlerocket-sdk.name" -f Twoliter.override 2>/dev/null || echo "$_name")"
+
+SDK="${registry}/${name}:v${version}"
+
+docker run --rm \
+    -v "$(pwd):/bottlerocket-kernel-kit" \
+    --user "$(id -u):$(id -g)" \
+    "${SDK}" \
+    bash "${SCRIPT_PATH}"
+

--- a/tools/latest-kernel-full-config.sh
+++ b/tools/latest-kernel-full-config.sh
@@ -2,6 +2,35 @@
 
 set -e -o pipefail
 
+KERNEL_KIT_DIR="/bottlerocket-kernel-kit"
+MICROCODE_DIR="${KERNEL_KIT_DIR}/packages/microcode"
+
+# Usage information
+usage() {
+    cat << EOF
+Usage: $0
+
+This script generates and validates full kernel configurations for all available
+kernel versions in the Bottlerocket kernel kit.
+
+IMPORTANT: This script is designed to run inside the Bottlerocket SDK container
+and should typically be invoked via the Makefile target:
+
+    make full-config
+
+Running this script directly outside the SDK container will fail because it
+requires the proper build environment and mounted paths.
+
+The script will:
+1. Discover all kernel-* packages with available RPMs
+2. Extract and patch kernel sources
+3. Merge Bottlerocket-specific configurations
+4. Generate full configuration files
+5. Validate that all required configs are present
+
+EOF
+}
+
 # Common error handling
 bail() {
     if [[ $# -gt 0 ]]; then
@@ -10,82 +39,29 @@ bail() {
     exit 1
 }
 
-# Function to display usage information
-usage() {
-    cat << EOF
-Usage: $(basename "$0") -r RPM_FILE
+# Function to merge kernel configurations for a specific kernel version
+merge_kernel_configs() {
+    local version="$1"
+    local majorminor="$2"
+    local tmpdir="$3"
 
-Extract kernel configurations from an RPM, merge with Bottlerocket's, and write out to a file, per architecture (x86_64 and aarch64).
+    local kernel_package_dir="${KERNEL_KIT_DIR}/packages/kernel-${majorminor}"
 
-This script provides functions intended to be run inside the bottlerocket-sdk container.
-For typical usage, run 'make full-config RPM_FILE=/path/to/kernel-source.rpm' from the top-level bottlerocket-kernel-kit directory.
-
-Direct script usage (for development/debugging):
-    -r RPM_FILE    Path to RPM file
-    -h             Display this help message
-
-Dependencies (when running directly):
-    - docker
-    - rpm2cpio
-    - cpio
-    - tar
-    - tq
-
-Note: The inner_full_config() function is designed to run within the bottlerocket-sdk container environment
-and expects specific mount points and toolchain paths to be available.
-EOF
-}
-
-usage_error() {
-    >&2 usage
-    bail "$1"
-}
-
-check_dependencies() {
-    hash rpm2cpio || usage_error "DEPENDENCY ERROR: Please install rpm2cpio somewhere in your PATH"
-    hash cpio || usage_error "DEPENDENCY ERROR: Please install cpio somewhere in your PATH"
-    hash tar || usage_error "DEPENDENCY ERROR: Please install tar somewhere in your PATH"
-    hash docker || usage_error "DEPENDENCY ERROR: Please install docker somewhere in your PATH"
-    hash tq || usage_error "DEPENDENCY ERROR: Please cargo install tomlq somewhere in your PATH"
-}
-
-# Get the SDK version from workspace Twoliter.toml and Twoliter.override, if provided.
-# Assumes running in the top level of the project and `tq` on $PATH.
-resolve_bottlerocket_sdk() {
-    # Inspect Twoliter.lock file for [sdk] section source
-    source="$(tq -r ".sdk.source" -f Twoliter.lock)"
-    version="$(tq -r ".sdk.version" -f Twoliter.lock)"
-    _name="$(tq -r ".sdk.name" -f Twoliter.lock)"
-    # Trim from last slash, e.g. public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.61.0 -> public.ecr.aws/bottlerocket
-    _registry="${source%/*}"
-
-    # Check Twoliter.override to get the registry. For simplicity, assume overrides are only against named project named bottlerocket-sdk
-    registry="$(tq -r ".bottlerocket.bottlerocket-sdk.registry" -f Twoliter.override 2>/dev/null || echo "$_registry")"
-    name="$(tq -r ".bottlerocket.bottlerocket-sdk.name" -f Twoliter.override 2>/dev/null || echo "$_name")"
-
-    # Form the final SDK
-    echo "${registry}/${name}:v${version}"
-}
-
-# Function to perform the kernel configuration merging inside Docker container
-inner_full_config() {
-    pushd /work || bail "Unable to enter /work (bind mount to tmp dir)"
-
-    version="$(rpm --query --nosignature --queryformat '%{VERSION}' kernel-source.rpm)"
-    majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
     if [ "${majorminor}" == "6.12" ]; then
         # kernel 6.12 has a patch file that is not applied to the kernel sources, so
         # only pick up the 1000-series kernel patches for our purposes here.
-        readarray -t br_patches < <(find /kernel-package -maxdepth 1 -name "10*.patch")
+        readarray -t br_patches < <(find "${kernel_package_dir}" -maxdepth 1 -name "10*.patch")
         spec_file="kernel6.12.spec"
         microcode_file="config-microcode-6-12"
     else
-        readarray -t br_patches < <(find /kernel-package -maxdepth 1 -name "*.patch")
+        readarray -t br_patches < <(find "${kernel_package_dir}" -maxdepth 1 -name "*.patch")
         spec_file="kernel.spec"
         microcode_file="config-microcode"
     fi
 
-    kernel_path=/kernel-package
+    local kernel_path="${kernel_package_dir}"
+
+    pushd "${tmpdir}" || bail "Unable to enter temporary directory"
 
     rpm2cpio kernel-source.rpm | cpio -iu {,./}linux-"${version}".tar{,.xz} {,./}config-x86_64 {,./}config-aarch64 {,./}"*.patch" {,./}"${spec_file}"
 
@@ -116,13 +92,9 @@ inner_full_config() {
     popd || bail "Could not move around - 'popd' back to /work failed. Lets stop before we break anything further."
 
     for arch in "x86_64" "aarch64"; do
-
-        export CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu-
-        export KCONFIG_CONFIG=bottlerocket_${arch}_defconfig
-
         br_cfg="${kernel_path}/config-bottlerocket"
         br_cfg_arch="${kernel_path}/config-bottlerocket-${arch}"
-        microcode_cfg="/microcode/${microcode_file}"
+        microcode_cfg="${MICROCODE_DIR}/${microcode_file}"
 
         pushd "linux-${version}" || bail "Could not move into linux-${version}"
 
@@ -134,25 +106,24 @@ inner_full_config() {
             script_args=("../config-${arch}" "${microcode_cfg}" "${br_cfg}" "${br_cfg_arch}")
         fi
 
-        ARCH=${karch} ./scripts/kconfig/merge_config.sh "${script_args[@]}"
+        ARCH=${karch} \
+        CROSS_COMPILE=/usr/bin/${arch}-bottlerocket-linux-gnu- \
+        KCONFIG_CONFIG=bottlerocket_${arch}_defconfig \
+        ./scripts/kconfig/merge_config.sh "${script_args[@]}"
+
         mv -f "bottlerocket_${arch}_defconfig" "${kernel_path}/config-full-bottlerocket-${arch}" || bail "Failed to create config-full-bottlerocket-${arch}"
         popd || bail "Could not move around - 'popd' failed in merge_config loop. Lets stop before we break anything further."
     done
 
-    # Validate the generated configurations
-    echo "Validating generated kernel configurations..."
-    validate_kernel_configs
+    popd || bail "Could not return from temporary directory"
 }
 
 # Function to validate kernel configurations (similar to validate_config.sh)
 validate_kernel_configs() {
+    local version="$1"
+    local majorminor="$2"
     local errors=0
-    local kernel_path=/kernel-package
-
-    # Extract kernel version for validation
-    local version
-    version="$(rpm --query --nosignature --queryformat '%{VERSION}' kernel-source.rpm)"
-    local majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
+    local kernel_path="${KERNEL_KIT_DIR}/packages/kernel-${majorminor}"
 
     for arch in x86_64 aarch64; do
         echo "=== Validating kernel-${majorminor} ${arch} ==="
@@ -213,3 +184,74 @@ validate_kernel_configs() {
         bail "Kernel configuration validation failed"
     fi
 }
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# Ensure this script is run within the Bottlerocket SDK container
+if [[ ! -d "${KERNEL_KIT_DIR}" ]]; then
+    usage
+    bail
+fi
+
+# In kernel kit automation, CodePipeline updates each kernel separately.
+# This script processes only kernels that have available RPM files,
+# skipping any kernel packages without corresponding source RPMs.
+kernels_to_process=()
+for kernel_dir in "${KERNEL_KIT_DIR}/packages"/kernel-*; do
+    if [[ -d "${kernel_dir}" ]]; then
+        kernel_pkg=$(basename "${kernel_dir}")
+        # In CodePipeline, only one RPM exists per kernel package, but during development
+        # multiple RPMs can coexist. Use version sorting to select the latest RPM.
+        # Sorting rules: https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html
+        rpm_file=$(find "${kernel_dir}" -name "kernel*.src.rpm" | sort -V | tail -1)
+        if [[ -n "${rpm_file}" ]]; then
+            kernels_to_process+=("${kernel_pkg}")
+            echo "Found RPM for ${kernel_pkg}: $(basename "${rpm_file}")"
+        else
+            echo "No RPM found for ${kernel_pkg}, skipping"
+        fi
+    else
+        bail "No Kernel directory found for ${kernel_dir}"
+    fi
+done
+
+if [[ ${#kernels_to_process[@]} -eq 0 ]]; then
+    bail "No kernel RPMs found in any package directory"
+fi
+
+# Process available kernels
+for kernel_pkg in "${kernels_to_process[@]}"; do
+    echo "Processing ${kernel_pkg}..."
+
+    tmpdir=$(mktemp -d)
+
+    pushd "${tmpdir}" || bail "Unable to enter temporary directory"
+
+    rpm_file=$(find "${KERNEL_KIT_DIR}/packages/${kernel_pkg}" -name "kernel*.src.rpm" | head -1)
+
+    cp "${rpm_file}" kernel-source.rpm
+
+    version="$(rpm --query --nosignature --queryformat '%{VERSION}' kernel-source.rpm)"
+    majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
+
+    merge_kernel_configs "${version}" "${majorminor}" "${tmpdir}"
+
+    echo "Validating ${kernel_pkg} configurations..."
+    validate_kernel_configs "${version}" "${majorminor}" || bail "Validation failed for ${kernel_pkg}"
+
+    popd || bail "Could not return from temporary directory"
+done


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #174

**Description of changes:**
Refactored Makefile targets merge-kernel-configs and full-config to follow standard Make idioms. Cleaned up latest-kernel-full-config.sh script, corrected environment variables for cross-compilation support and added check for running only in SDK container.

I keep creating the temp directory under the target so that I can clean the temp directory after exit. 


**Testing done:**
Generating the config-full-bottlerocket-aarch64 and config-full-bottlerocket-x86_64 for 6.1 kernel and diff with the one in repo


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
