### PR TITLE
kernel-6.12: enable FIPS support

### DIFF
--- a/packages/kernel-6.12/fipsmodules-aarch64
+++ b/packages/kernel-6.12/fipsmodules-aarch64
@@ -21,7 +21,6 @@ sha512-ce
 cipher_null
 des3_ede
 aes
-cfb
 dh
 ecdh
 aes-arm64
@@ -39,7 +38,6 @@ ccm
 authenc
 hmac
 cmac
-ofb
 cts
 lzo
 essiv

--- a/packages/kernel-6.12/fipsmodules-x86_64
+++ b/packages/kernel-6.12/fipsmodules-x86_64
@@ -18,7 +18,6 @@ sha512-ssse3
 cipher_null
 des3_ede
 aes
-cfb
 dh
 ecdh
 aesni-intel
@@ -31,7 +30,6 @@ ccm
 authenc
 hmac
 cmac
-ofb
 cts
 lzo
 essiv

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -69,9 +69,6 @@ Requires: %{_cross_os}microcode-licenses
 # No bare-metal for this kernel
 Conflicts: %{_cross_os}variant-platform(metal)
 
-# No FIPS submission
-Conflicts: %{_cross_os}image-feature(fips)
-
 # No squashfs support, rely on erofs for compression
 Conflicts: %{_cross_os}image-feature(no-erofs-root-partition)
 


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #262 

**Description of changes:**

Remove FIPS conflict and update FIPS module lists to enable FIPS for kernel 6.12.

FIPS module list changes found following these steps for both architectures:

1. Launch AL2023 instance
2. Enable FIPS mode on the instance following https://docs.aws.amazon.com/linux/al2023/ug/fips-mode.html
3. Extract initramfs with `lsinitrd --unpack`
4. List of modules provided in `<initramfs>/etc/fipsmodules`

**Testing done:**

Custom aarch64 k8s-1.33-fips variant:

```
[ssm-user@control]$ apiclient report fips
Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2025-09-03T21:48:30.825448753Z

[PASS] 1.0       FIPS mode is enabled. (Automatic)
[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[PASS] 1.2       FIPS self-tests passed. (Automatic)

Passed:          3
Failed:          0
Skipped:         0
Total checks:    3

Compliance check result: PASS
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "aarch64",
    "build_id": "431fe75a-dirty",
    "pretty_name": "Bottlerocket OS 1.46.0 (aws-k8s-1.33-fips)",
    "variant_id": "aws-k8s-1.33-fips",
    "version_id": "1.46.0"
  }
}
```

Custom x86_64 k8s-1.33-fips variant:

```
[ssm-user@control]$ apiclient report fips
Benchmark name:  FIPS Security Policy
Version:         v1.0.0
Reference:       https://csrc.nist.gov/
Benchmark level: 1
Start time:      2025-09-03T21:43:02.091923361Z

[PASS] 1.0       FIPS mode is enabled. (Automatic)
[PASS] 1.1       FIPS module is Amazon Linux 2023 Kernel Cryptographic API. (Automatic)
[PASS] 1.2       FIPS self-tests passed. (Automatic)

Passed:          3
Failed:          0
Skipped:         0
Total checks:    3

Compliance check result: PASS
[ssm-user@control]$ apiclient get os
{
  "os": {
    "arch": "x86_64",
    "build_id": "431fe75a-dirty",
    "pretty_name": "Bottlerocket OS 1.46.0 (aws-k8s-1.33-fips)",
    "variant_id": "aws-k8s-1.33-fips",
    "version_id": "1.46.0"
  }
}
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
