### PR TITLE
kernel-6.12: allow fips variants for kernel-6.12

### DIFF
--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -69,9 +69,6 @@ Requires: %{_cross_os}microcode-licenses
 # No bare-metal for this kernel
 Conflicts: %{_cross_os}variant-platform(metal)
 
-# No FIPS submission
-Conflicts: %{_cross_os}image-feature(fips)
-
 # No squashfs support, rely on erofs for compression
 Conflicts: %{_cross_os}image-feature(no-erofs-root-partition)
 


### PR DESCRIPTION
**Description of changes:**
- Allow creation of fips variants for 6.12


**Testing done:**
- Changed `aws-k8s-1.33-fips` variant config from 6.1 kernel to 6.12 kernel
  - The AMI builds
  - The instance with that AMI joins the cluster
  - `apiclient report fips` gives correct output 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
