### PR TITLE
Provide two versions of the Neuron driver

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -18,9 +18,14 @@ sha512 = "395940a92892d92612c51edc566e9bd7bb59432048a796e9e4934246f20aca8f7cef95
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-# Use latest-neuron-srpm-url.sh to get this.
+# Use latest-2.21-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm"
 sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5e94fd564e1d9898f52a8cbd960a6a65435b90ba7d7839c807e7ca8736d"
+
+[[package.metadata.build-package.external-files]]
+# Use latest-neuron-srpm.url.sh to get this
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm"
+sha512 = "2892ad1c6c4ff670d8e4aa0151af57b2b437f647a58ffa58901377b2ddeb504a9e4cce6c148643f8340e1ede8bb26ab66039b0a6bbb184bf5d647c6c71720186"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -9,9 +9,11 @@ URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
 Source0: https://cdn.amazonlinux.com/al2023/blobstore/f3b09a804dce910af99d51994144a9e73322ac17d13feb47547b70b7833fa40a/kernel-6.1.155-176.282.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
-# Use latest-neuron-srpm-url.sh to get this.
+# Use latest-2.21-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
-Source3: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
+# Use latest-neuron-srpm-url.sh to get this.
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm
+Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.
 Source100: config-bottlerocket
@@ -30,9 +32,12 @@ Source202: fipsmodules-aarch64
 # Adjust kernel-devel mount behavior if not squashfs.
 Source210: var-lib-kernel-devel-lower.mount.drop-in.conf.in
 
-# Neuron-related drop-ins.
-Source220: neuron-sysinit.target.drop-in.conf
-Source221: modprobe@neuron.service.drop-in.conf
+# Neuron-related configuration and unit files
+Source220: neuron-tmpfiles.conf.in
+Source221: neuron-inf1.toml.in
+Source222: neuron-latest.toml.in
+Source223: load-neuron-inf1-modules.service
+Source224: load-neuron-latest-modules.service
 
 # Bootconfig snippets to adjust the default kernel command line for the platform.
 Source300: bootconfig-aws.conf
@@ -252,11 +257,20 @@ rm -f ../config-* ../*.patch
 
 %if "%{_cross_arch}" == "x86_64"
 cd %{_builddir}
-rpmkeys --import %{S:3} --dbpath "${PWD}/rpmdb"
+# 2.21 for inf1 support
+rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:2} | cpio -idmu './usr/src/aws-neuronx-*'
-find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron \;
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_21 \;
+rm -r usr
+
+# latest neuron driver
+rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
+rpmkeys --checksig %{S:3} --dbpath "${PWD}/rpmdb"
+rm -rf "${PWD}/rpmdb"
+rpm2cpio %{S:3} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_latest \;
 rm -r usr
 %endif
 
@@ -276,7 +290,8 @@ make -s\\\
 %kmake %{?_smp_mflags} modules
 
 %if "%{_cross_arch}" == "x86_64"
-%kmake %{?_smp_mflags} M=%{_builddir}/neuron
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_21
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
 %endif
 
 %install
@@ -284,7 +299,12 @@ make -s\\\
 %kmake %{?_smp_mflags} modules_install
 
 %if "%{_cross_arch}" == "x86_64"
-%kmake %{?_smp_mflags} M=%{_builddir}/neuron modules_install
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_21 M=%{_builddir}/neuron_2_21 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_latest M=%{_builddir}/neuron_latest modules_install
+mv %{buildroot}%{_cross_kmoddir}/neuron_2_21/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 %endif
 
 install -d %{buildroot}/boot
@@ -426,12 +446,22 @@ sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:210} \
   > %{buildroot}%{_cross_unitdir}/"${LOWERPATH}.mount.d"/no-squashfs.conf
 
 %if "%{_cross_arch}" == "x86_64"
-# Add Neuron-related drop-ins to load the module when the hardware is present.
-mkdir -p %{buildroot}%{_cross_unitdir}/sysinit.target.d
-install -p -m 0644 %{S:220} %{buildroot}%{_cross_unitdir}/sysinit.target.d/neuron.conf
-
-mkdir -p %{buildroot}%{_cross_unitdir}/modprobe@neuron.service.d
-install -p -m 0644 %{S:221} %{buildroot}%{_cross_unitdir}/modprobe@neuron.service.d/neuron.conf
+# Add Neuron-related configuration files to load the module when the hardware is present.
+install -d 0644 %{buildroot}%{_cross_tmpfilesdir}
+sed \
+  -e "s|__KERNEL_VERSION__|%{version}|" \
+  -e "s|__PREFIX__|%{_cross_prefix}|" %{S:220} > neuron.conf
+install -p -m 0644 neuron.conf %{buildroot}%{_cross_tmpfilesdir}/
+install -d 0644 %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+# inf1
+sed -e 's|__NEURON_MODULES__|%{_cross_libexecdir}/neuron|' %{S:221} > \
+  neuron-inf1.toml
+install -m 0644 neuron-inf1.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+# latest
+sed -e 's|__NEURON_MODULES__|%{_cross_libexecdir}/neuron|' %{S:222} > \
+  neuron-latest.toml
+install -m 0644 neuron-latest.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+install -p -m 0644 %{S:223} %{S:224} %{buildroot}%{_cross_unitdir}
 %endif
 
 # Install platform-specific bootconfig snippets.
@@ -1501,9 +1531,13 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 
 %if "%{_cross_arch}" == "x86_64"
 %files modules-neuron
-%{_cross_kmoddir}/extra/neuron.ko.gz
-%{_cross_unitdir}/sysinit.target.d/neuron.conf
-%{_cross_unitdir}/modprobe@neuron.service.d/neuron.conf
+%{_cross_libexecdir}/neuron/neuron_2_21/neuron.ko.gz
+%{_cross_libexecdir}/neuron/neuron_latest/neuron.ko.gz
+%{_cross_tmpfilesdir}/neuron.conf
+%{_cross_unitdir}/load-neuron-inf1-modules.service
+%{_cross_unitdir}/load-neuron-latest-modules.service
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/neuron-inf1.toml
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/neuron-latest.toml
 %endif
 
 %changelog

--- a/packages/kernel-6.1/latest-2.21-neuron-srpms-url.sh
+++ b/packages/kernel-6.1/latest-2.21-neuron-srpms-url.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+cmd="
+dnf install -q -y --releasever=latest yum-utils &&
+dnf download -q --repofrompath neuron,https://yum.repos.neuron.amazonaws.com --repo=neuron --urls aws-neuronx-dkms-2.21*
+"
+docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2023 sh -c "${cmd}" \
+    | grep '^http' \
+    | xargs --max-args=1 --no-run-if-empty realpath --canonicalize-missing --relative-to=. \
+    | sed 's_:/_://_'

--- a/packages/kernel-6.1/load-neuron-inf1-modules.service
+++ b/packages/kernel-6.1/load-neuron-inf1-modules.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Load Neuron Inf1 modules
+After=local-fs.target
+Requires=local-fs.target
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-driver neuron inf1
+ExecStart=/usr/bin/driverdog --modules-set neuron-inf1 link-modules
+ExecStart=/usr/bin/driverdog --modules-set neuron-inf1 load-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install] 
+RequiredBy=drivers.target

--- a/packages/kernel-6.1/load-neuron-latest-modules.service
+++ b/packages/kernel-6.1/load-neuron-latest-modules.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Load Neuron Latest modules
+After=local-fs.target
+Requires=local-fs.target
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-driver neuron latest
+ExecStart=/usr/bin/driverdog --modules-set neuron-latest link-modules
+ExecStart=/usr/bin/driverdog --modules-set neuron-latest load-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install] 
+RequiredBy=drivers.target

--- a/packages/kernel-6.1/modprobe@neuron.service.drop-in.conf
+++ b/packages/kernel-6.1/modprobe@neuron.service.drop-in.conf
@@ -1,7 +1,0 @@
-[Unit]
-ConditionPathExists=!/etc/.neuron-modprobe-done
-
-[Service]
-ExecCondition=/usr/bin/touch /etc/.neuron-modprobe-done
-ExecCondition=/usr/bin/ghostdog neuron-present
-RemainAfterExit=true

--- a/packages/kernel-6.1/neuron-inf1.toml.in
+++ b/packages/kernel-6.1/neuron-inf1.toml.in
@@ -1,0 +1,5 @@
+[neuron-inf1]
+lib-modules-path = "kernel/drivers/neuron"
+
+[neuron-inf1.kernel-modules."neuron.ko.gz"]
+copy-source = "__NEURON_MODULES__/neuron_2_21"

--- a/packages/kernel-6.1/neuron-latest.toml.in
+++ b/packages/kernel-6.1/neuron-latest.toml.in
@@ -1,0 +1,5 @@
+[neuron-latest]
+lib-modules-path = "kernel/drivers/neuron"
+
+[neuron-latest.kernel-modules."neuron.ko.gz"]
+copy-source = "__NEURON_MODULES__/neuron_latest"

--- a/packages/kernel-6.1/neuron-sysinit.target.drop-in.conf
+++ b/packages/kernel-6.1/neuron-sysinit.target.drop-in.conf
@@ -1,2 +1,0 @@
-[Unit]
-Wants=modprobe@neuron.service

--- a/packages/kernel-6.1/neuron-tmpfiles.conf.in
+++ b/packages/kernel-6.1/neuron-tmpfiles.conf.in
@@ -1,0 +1,4 @@
+C /etc/drivers/neuron-inf1.toml
+C /etc/drivers/neuron-latest.toml
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/neuron - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/neuron 0755 root root - -

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -18,9 +18,14 @@ sha512 = "ca7fc22f52e6d0c29d02ed2d51636a63e460d4ec5f2ac49a2cd0ad901af1031ff5741f
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-# Use latest-neuron-srpm-url.sh to get this.
+# Use latest-2.21-neuron-srpm-url.sh to get this.
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm"
 sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5e94fd564e1d9898f52a8cbd960a6a65435b90ba7d7839c807e7ca8736d"
+
+[[package.metadata.build-package.external-files]]
+# Use latest-neuron-srpm.url.sh to get this.
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm"
+sha512 = "2892ad1c6c4ff670d8e4aa0151af57b2b437f647a58ffa58901377b2ddeb504a9e4cce6c148643f8340e1ede8bb26ab66039b0a6bbb184bf5d647c6c71720186"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -415,11 +415,11 @@ sed \
 install -p -m 0644 neuron.conf %{buildroot}%{_cross_tmpfilesdir}/
 install -d 0644 %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
 # inf1
-sed -e 's|__NEURON_MODULES__|%{_cross_datadir}/neuron|' %{S:221} > \
+sed -e 's|__NEURON_MODULES__|%{_cross_libexecdir}/neuron|' %{S:221} > \
   neuron-inf1.toml
 install -m 0644 neuron-inf1.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
 # latest
-sed -e 's|__NEURON_MODULES__|%{_cross_datadir}/neuron|' %{S:222} > \
+sed -e 's|__NEURON_MODULES__|%{_cross_libexecdir}/neuron|' %{S:222} > \
   neuron-latest.toml
 install -m 0644 neuron-latest.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
 install -p -m 0644 %{S:223} %{S:224} %{buildroot}%{_cross_unitdir}

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -12,9 +12,11 @@ URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
 Source0: https://cdn.amazonlinux.com/al2023/blobstore/90e970acea5d658008c0707a6c4953b0e877f85b122cd967525bfecb043af96b/kernel6.12-6.12.46-66.121.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
-# Use latest-neuron-srpm-url.sh to get this.
+# Use latest-2.21-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
-Source3: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
+# Use latest-neuron-srpm-url.sh to get this.
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm
+Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.
 Source100: config-bottlerocket
@@ -33,9 +35,12 @@ Source202: fipsmodules-aarch64
 # Adjust kernel-devel mount behavior if not squashfs.
 Source210: var-lib-kernel-devel-lower.mount.drop-in.conf.in
 
-# Neuron-related drop-ins.
-Source220: neuron-sysinit.target.drop-in.conf
-Source221: modprobe@neuron.service.drop-in.conf
+# Neuron-related configuration and unit files
+Source220: neuron-tmpfiles.conf
+Source221: neuron-inf1.toml
+Source222: neuron-latest.toml
+Source223: load-neuron-inf1-modules.service
+Source224: load-neuron-latest-modules.service
 
 # Bootconfig snippets to adjust the default kernel command line for the platform.
 Source300: bootconfig-aws.conf
@@ -228,11 +233,20 @@ rm -f ../config-* ../*.patch
 
 %if "%{_cross_arch}" == "x86_64"
 cd %{_builddir}
-rpmkeys --import %{S:3} --dbpath "${PWD}/rpmdb"
+# 2.21 for inf1 support
+rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:2} | cpio -idmu './usr/src/aws-neuronx-*'
-find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron \;
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_21 \;
+rm -r usr
+
+# latest neuron driver
+rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
+rpmkeys --checksig %{S:3} --dbpath "${PWD}/rpmdb"
+rm -rf "${PWD}/rpmdb"
+rpm2cpio %{S:3} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_latest \;
 rm -r usr
 %endif
 
@@ -252,7 +266,8 @@ make -s\\\
 %kmake %{?_smp_mflags} modules
 
 %if "%{_cross_arch}" == "x86_64"
-%kmake %{?_smp_mflags} M=%{_builddir}/neuron
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_21
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
 %endif
 
 make -C tools/bpf/bpftool bootstrap
@@ -263,7 +278,12 @@ make -C tools/bpf/bpftool bootstrap
 %kmake %{?_smp_mflags} modules_install
 
 %if "%{_cross_arch}" == "x86_64"
-%kmake %{?_smp_mflags} M=%{_builddir}/neuron modules_install
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_21 M=%{_builddir}/neuron_2_21 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_latest M=%{_builddir}/neuron_latest modules_install
+mv %{buildroot}%{_cross_kmoddir}/neuron_2_21/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 %endif
 
 install -d %{buildroot}/boot
@@ -387,12 +407,23 @@ mkdir -p %{buildroot}%{_cross_datadir}/xfsprogs/mkfs
 ln -s lts_6.12.conf %{buildroot}%{_cross_datadir}/xfsprogs/mkfs/default.conf
 
 %if "%{_cross_arch}" == "x86_64"
-# Add Neuron-related drop-ins to load the module when the hardware is present.
-mkdir -p %{buildroot}%{_cross_unitdir}/sysinit.target.d
-install -p -m 0644 %{S:220} %{buildroot}%{_cross_unitdir}/sysinit.target.d/neuron.conf
+# Add Neuron-related configuration files to load the module when the hardware is present.
+install -d 0644 %{buildroot}%{_cross_tmpfilesdir}
+sed \
+  -e "s|__KERNEL_VERSION__|%{kmajor}|" \
+  -e "s|__PREFIX__|%{_cross_prefix}|" %{S:220} > neuron.conf
+install -p -m 0644 neuron.conf %{buildroot}%{_cross_tmpfilesdir}/
+install -d 0644 %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+# inf1
+sed -e 's|__NEURON_MODULES__|%{_cross_datadir}/neuron|' %{S:221} > \
+  neuron-inf1.toml
+install -m 0644 neuron-inf1.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+# latest
+sed -e 's|__NEURON_MODULES__|%{_cross_datadir}/neuron|' %{S:222} > \
+  neuron-latest.toml
+install -m 0644 neuron-latest.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+install -p -m 0644 %{S:223} %{S:224} %{buildroot}%{_cross_unitdir}
 
-mkdir -p %{buildroot}%{_cross_unitdir}/modprobe@neuron.service.d
-install -p -m 0644 %{S:221} %{buildroot}%{_cross_unitdir}/modprobe@neuron.service.d/neuron.conf
 %endif
 
 # Install platform-specific bootconfig snippets.
@@ -1412,9 +1443,13 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 
 %if "%{_cross_arch}" == "x86_64"
 %files modules-neuron
-%{_cross_kmoddir}/updates/neuron.%{_ko}
-%{_cross_unitdir}/sysinit.target.d/neuron.conf
-%{_cross_unitdir}/modprobe@neuron.service.d/neuron.conf
+%{_cross_libexecdir}/neuron/neuron_2_21/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_latest/neuron.%{_ko}
+%{_cross_tmpfilesdir}/neuron.conf
+%{_cross_unitdir}/load-neuron-inf1-modules.service
+%{_cross_unitdir}/load-neuron-latest-modules.service
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/neuron-inf1.toml
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/neuron-latest.toml
 %endif
 
 %changelog

--- a/packages/kernel-6.12/latest-2.21-neuron-srpms-url.sh
+++ b/packages/kernel-6.12/latest-2.21-neuron-srpms-url.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+cmd="
+dnf install -q -y --releasever=latest yum-utils &&
+dnf download -q --repofrompath neuron,https://yum.repos.neuron.amazonaws.com --repo=neuron --urls aws-neuronx-dkms-2.21*
+"
+docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2023 sh -c "${cmd}" \
+    | grep '^http' \
+    | xargs --max-args=1 --no-run-if-empty realpath --canonicalize-missing --relative-to=. \
+    | sed 's_:/_://_'

--- a/packages/kernel-6.12/load-neuron-inf1-modules.service
+++ b/packages/kernel-6.12/load-neuron-inf1-modules.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Load Neuron Inf1 modules
+After=local-fs.target
+Requires=local-fs.target
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-driver neuron inf1
+ExecStart=/usr/bin/driverdog --modules-set neuron-inf1 link-modules
+ExecStart=/usr/bin/driverdog --modules-set neuron-inf1 load-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install] 
+RequiredBy=drivers.target

--- a/packages/kernel-6.12/load-neuron-latest-modules.service
+++ b/packages/kernel-6.12/load-neuron-latest-modules.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Load Neuron Latest modules
+After=local-fs.target
+Requires=local-fs.target
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-driver neuron latest
+ExecStart=/usr/bin/driverdog --modules-set neuron-latest link-modules
+ExecStart=/usr/bin/driverdog --modules-set neuron-latest load-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install] 
+RequiredBy=drivers.target

--- a/packages/kernel-6.12/modprobe@neuron.service.drop-in.conf
+++ b/packages/kernel-6.12/modprobe@neuron.service.drop-in.conf
@@ -1,7 +1,0 @@
-[Unit]
-ConditionPathExists=!/etc/.neuron-modprobe-done
-
-[Service]
-ExecCondition=/usr/bin/touch /etc/.neuron-modprobe-done
-ExecCondition=/usr/bin/ghostdog neuron-present
-RemainAfterExit=true

--- a/packages/kernel-6.12/neuron-inf1.toml
+++ b/packages/kernel-6.12/neuron-inf1.toml
@@ -1,0 +1,5 @@
+[neuron-inf1]
+lib-modules-path = "kernel/drivers/neuron"
+
+[neuron-inf1.kernel-modules."neuron.ko"]
+copy-source = "__NEURON_MODULES__/neuron_2_21"

--- a/packages/kernel-6.12/neuron-latest.toml
+++ b/packages/kernel-6.12/neuron-latest.toml
@@ -1,0 +1,5 @@
+[neuron-latest]
+lib-modules-path = "kernel/drivers/neuron"
+
+[neuron-latest.kernel-modules."neuron.ko"]
+copy-source = "__NEURON_MODULES__/neuron_latest"

--- a/packages/kernel-6.12/neuron-sysinit.target.drop-in.conf
+++ b/packages/kernel-6.12/neuron-sysinit.target.drop-in.conf
@@ -1,2 +1,0 @@
-[Unit]
-Wants=modprobe@neuron.service

--- a/packages/kernel-6.12/neuron-tmpfiles.conf
+++ b/packages/kernel-6.12/neuron-tmpfiles.conf
@@ -1,0 +1,4 @@
+C /etc/drivers/neuron-inf1.toml
+C /etc/drivers/neuron-latest.toml
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/neuron - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/neuron 0755 root root - -


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/238

**Description of changes:**
This provides the 2.21.* version of the driver in addition to the latest (currently on 2.23) for Neuron. This is combined with https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/644 which allows choosing the correct driver for inf1 instances. 

This adds new load-neuron-latest-module and load-neuron-inf1-module services which are installed for the newly created drivers.target. This enables the modules to do similar multi-path to target loading like NVIDIA so that we have a consistent approach to driver loading. Once this is merged, there will be a follow up PR to update NVIDIA module loading to do the same.


**Testing done:**
Booted an image with this and https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/644 and booted on both inf1 and trn1 instances. The correct driver is loaded on each.

### on `trn1.2xlarge'

<details>

```
[ssm-user@control]$ apiclient exec admin modinfo neuron
filename:       /lib/modules/6.12.40/neuron_latest/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.23.9.0
license:        GPL
description:    Neuron Driver, built from SHA: b8ad53947481bbe9d8e76b117c06b2484b8a949f
import_ns:      DMA_BUF
srcversion:     68886FE4A17A11B0934DAFE
depends:
name:           neuron
retpoline:      Y
vermagic:       6.12.40 SMP preempt mod_unload modversions
```

### on `inf1.xlarge`
```
[ssm-user@control]$ apiclient exec admin modinfo neuron
filename:       /lib/modules/6.12.40/neuron/neuron_2_21/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.21.37.0
license:        GPL
description:    Neuron Driver, built from SHA: fd7535995e4b3ae73c543f829b152c3351ef21f6
import_ns:      DMA_BUF
srcversion:     4DE159506B58B4692C035AA
depends:
name:           neuron
retpoline:      Y
```
The units are as you would expect:
```
bash-5.1# systemctl status load-neuron-latest-modules
○ load-neuron-latest-modules.service - Load Neuron Latest modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-latest-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead) (Result: exec-condition) since Mon 2025-09-22 18:42:39 UTC; 8min ago
  Condition: start condition failed at Mon 2025-09-22 18:42:39 UTC; 8min ago
        CPU: 5ms

Sep 22 18:42:39 localhost systemd[1]: Starting Load Neuron Latest modules...
Sep 22 18:42:39 localhost ghostdog[1351]: Error: Detected inf1 hardware
Sep 22 18:42:39 localhost systemd[1]: load-neuron-latest-modules.service: Skipped due to 'exec-condition'.
Sep 22 18:42:39 localhost systemd[1]: Condition check resulted in Load Neuron Latest modules being skipped.
bash-5.1# systemctl status load-neuron-inf1-modules
● load-neuron-inf1-modules.service - Load Neuron Inf1 modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-inf1-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (exited) since Mon 2025-09-22 18:42:40 UTC; 8min ago
   Main PID: 1356 (code=exited, status=0/SUCCESS)
        CPU: 292ms

Sep 22 18:42:39 localhost systemd[1]: Starting Load Neuron Inf1 modules...
Sep 22 18:42:40 localhost driverdog[1356]: 18:42:40 [INFO] Updated modules dependencies
Sep 22 18:42:40 localhost driverdog[1356]: 18:42:40 [INFO] Loaded kernel modules
Sep 22 18:42:40 localhost systemd[1]: Finished Load Neuron Inf1 modules.
```

</details>


### On trn1.2xlarge:

<details>

```
[ssm-user@control]$ apiclient exec admin modinfo neuron
filename:       /lib/modules/6.12.40/neuron/neuron_latest/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.23.9.0
license:        GPL
description:    Neuron Driver, built from SHA: b8ad53947481bbe9d8e76b117c06b2484b8a949f
import_ns:      DMA_BUF
srcversion:     68886FE4A17A11B0934DAFE
depends:
name:           neuron
retpoline:      Y
vermagic:       6.12.40 SMP preempt mod_unload modversions
sig_id:         PKCS#7
....
```
And the services look correct:
```
bash-5.1# systemctl status load-neuron-latest-modules
● load-neuron-latest-modules.service - Load Neuron Latest modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-latest-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (exited) since Mon 2025-09-22 18:53:00 UTC; 19min ago
   Main PID: 1680 (code=exited, status=0/SUCCESS)
        CPU: 228ms

Sep 22 18:52:59 localhost systemd[1]: Starting Load Neuron Latest modules...
Sep 22 18:52:59 localhost driverdog[1680]: 18:52:59 [INFO] Updated modules dependencies
Sep 22 18:53:00 localhost driverdog[1680]: 18:53:00 [INFO] Loaded kernel modules
Sep 22 18:53:00 localhost systemd[1]: Finished Load Neuron Latest modules.
bash-5.1#  systemctl status load-neuron-inf1-modules
○ load-neuron-inf1-modules.service - Load Neuron Inf1 modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-inf1-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead) (Result: exec-condition) since Mon 2025-09-22 18:52:59 UTC; 19min ago
  Condition: start condition failed at Mon 2025-09-22 18:52:59 UTC; 19min ago
        CPU: 3ms

Sep 22 18:52:59 localhost systemd[1]: Starting Load Neuron Inf1 modules...
Sep 22 18:52:59 localhost ghostdog[1665]: Error: Did not detect inf1 hardware
Sep 22 18:52:59 localhost systemd[1]: load-neuron-inf1-modules.service: Skipped due to 'exec-condition'.
Sep 22 18:52:59 localhost systemd[1]: Condition check resulted in Load Neuron Inf1 modules being skipped.
```

</details>

### on m7i.4xlarge both services are not run

<details>

```
bash-5.1# systemctl status load-neuron-latest-modules
○ load-neuron-latest-modules.service - Load Neuron Latest modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-latest-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead) (Result: exec-condition) since Tue 2025-10-07 21:17:25 UTC; 2min 13s ago
  Condition: start condition failed at Tue 2025-10-07 21:17:25 UTC; 2min 13s ago
        CPU: 12ms

Oct 07 21:17:25 localhost systemd[1]: Starting Load Neuron Latest modules...
Oct 07 21:17:25 localhost ghostdog[2099]: Error: Did not detect inf2+ hardware
Oct 07 21:17:25 localhost systemd[1]: load-neuron-latest-modules.service: Skipped due to 'exec-condition'.
Oct 07 21:17:25 localhost systemd[1]: Condition check resulted in Load Neuron Latest modules being skipped.
bash-5.1# systemctl status load-neuron-inf1-modules
○ load-neuron-inf1-modules.service - Load Neuron Inf1 modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-inf1-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: inactive (dead) (Result: exec-condition) since Tue 2025-10-07 21:17:25 UTC; 2min 24s ago
  Condition: start condition failed at Tue 2025-10-07 21:17:25 UTC; 2min 24s ago
        CPU: 12ms

Oct 07 21:17:25 localhost systemd[1]: Starting Load Neuron Inf1 modules...
Oct 07 21:17:25 localhost systemd[1]: load-neuron-inf1-modules.service: Skipped due to 'exec-condition'.
Oct 07 21:17:25 localhost ghostdog[2097]: Error: Did not detect inf1 hardware
Oct 07 21:17:25 localhost systemd[1]: Condition check resulted in Load Neuron Inf1 modules being skipped.
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
