### PR TITLE
Update NVIDIA driver, IMEX, Fabric Manager, and Subnet Manager

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r570/Cargo.toml
@@ -17,23 +17,23 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.172.08/NVIDIA-Linux-x86_64-570.172.08.run"
-sha512 = "8000f31575392ca8a575879f36b6e3e0fdee14e63efb856b77035e5aa434a02de0fd4ff5472d01984cbc541d40656ed6b7b77c78d00f6e1bc4341864bad725c5"
+url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-x86_64-570.195.03.run"
+sha512 = "77041ef60bd4c637a53750b6ef5c5121e3eb299c5b2859d65fd0a3683c4fb32b5fd34ae419cfdb982588992706264c839338d1ff02850cae2c88fd67f7cda27d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.172.08/NVIDIA-Linux-aarch64-570.172.08.run"
-sha512 = "291012513c2b9bff94a0892248207734b1d12a13ff994036045fd159f60bf410508fd66873d78388d0e289ded1b76f8d0980219c289fa2ba99303f2cf872e9d6"
+url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-aarch64-570.195.03.run"
+sha512 = "4ed4c4863dce0ec53a9fa1a7e3cdc7ce3e915db4ec014b2c5030e8a6c961d4e58c99c42b6c6b17020d8c31acf95e14254bca446c2a56ce29b10067730910e2a0"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.172.08-1.x86_64.rpm"
-sha512 = "6cbc0d14c6de8a21aad9e247df6d9fbb425c38abe783218b10d1ff9fcf2736c0221e2817c0f9dd9ea2886f78e2182bcc2ad44a9884228a6abe86ed8a9d1b6940"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
+sha512 = "2b26abd802e4360cc51b4990e1925732437817e6e9fac94fd2c629f2b74dffe04ea913771a61d77957a4791610d90288c7ac6a474d634b63173e3f11dce299ac"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.172.08-1.aarch64.rpm"
-sha512 = "324557df51e56aca1337744554ff6bf78177f413bc0778cc5dd6a76bba9423d538afecd2326707b92af3a086aa1bf5535d7cbabebe614eeec75cbeede644dd9a"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
+sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.1-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r570/Cargo.toml
@@ -27,12 +27,12 @@ sha512 = "4ed4c4863dce0ec53a9fa1a7e3cdc7ce3e915db4ec014b2c5030e8a6c961d4e58c99c4
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
 sha512 = "2b26abd802e4360cc51b4990e1925732437817e6e9fac94fd2c629f2b74dffe04ea913771a61d77957a4791610d90288c7ac6a474d634b63173e3f11dce299ac"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
 sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
 force-upstream = true
 

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -1,6 +1,6 @@
 %global tesla_major 570
-%global tesla_minor 172
-%global tesla_patch 08
+%global tesla_minor 195
+%global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
@@ -668,11 +668,11 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.19
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.2
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.2
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -33,8 +33,8 @@ Source2: NVidiaEULAforAWS.pdf
 Source3: COPYING
 
 # fabricmanager for NVSwitch
-Source10: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
-Source11: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
+Source10: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
+Source11: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in

--- a/packages/kmod-6.12-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r570/Cargo.toml
@@ -17,33 +17,33 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.172.08/NVIDIA-Linux-x86_64-570.172.08.run"
-sha512 = "8000f31575392ca8a575879f36b6e3e0fdee14e63efb856b77035e5aa434a02de0fd4ff5472d01984cbc541d40656ed6b7b77c78d00f6e1bc4341864bad725c5"
+url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-x86_64-570.195.03.run"
+sha512 = "77041ef60bd4c637a53750b6ef5c5121e3eb299c5b2859d65fd0a3683c4fb32b5fd34ae419cfdb982588992706264c839338d1ff02850cae2c88fd67f7cda27d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.172.08/NVIDIA-Linux-aarch64-570.172.08.run"
-sha512 = "291012513c2b9bff94a0892248207734b1d12a13ff994036045fd159f60bf410508fd66873d78388d0e289ded1b76f8d0980219c289fa2ba99303f2cf872e9d6"
+url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-aarch64-570.195.03.run"
+sha512 = "4ed4c4863dce0ec53a9fa1a7e3cdc7ce3e915db4ec014b2c5030e8a6c961d4e58c99c42b6c6b17020d8c31acf95e14254bca446c2a56ce29b10067730910e2a0"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.172.08-1.x86_64.rpm"
-sha512 = "6cbc0d14c6de8a21aad9e247df6d9fbb425c38abe783218b10d1ff9fcf2736c0221e2817c0f9dd9ea2886f78e2182bcc2ad44a9884228a6abe86ed8a9d1b6940"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
+sha512 = "2b26abd802e4360cc51b4990e1925732437817e6e9fac94fd2c629f2b74dffe04ea913771a61d77957a4791610d90288c7ac6a474d634b63173e3f11dce299ac"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.172.08-1.aarch64.rpm"
-sha512 = "324557df51e56aca1337744554ff6bf78177f413bc0778cc5dd6a76bba9423d538afecd2326707b92af3a086aa1bf5535d7cbabebe614eeec75cbeede644dd9a"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
+sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-570-570.172.08-1.x86_64.rpm"
-sha512 = "09210f102aafd0e4583751c20e0fb8adb2e7bbec1d71adaaf742b2ab4b7b1b676e79e7612749fe9a88d70b3a1cf93ea42a03c78f7ae32d8b2b7a757ff48cc9f0"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-570-570.195.03-1.x86_64.rpm"
+sha512 = "15d8a8653520994204e345d589f84c750b38924b9e4e3bb949d43c2a702bd04c946b993da158145f38dea1cf459aa2d9cec0f16828aad8e2b95a3b27f85d629a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-570-570.172.08-1.aarch64.rpm"
-sha512 = "b3a5e5e838d4318d4d3c5267f0af7daf57c354a2d3422e10b9b6457a8c62f90a770c73101a0d2e0e995c0372b3bf5a2b96457aca957e56e842c3e746cb98a912"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-570-570.195.03-1.aarch64.rpm"
+sha512 = "d620a3f02ce673cd27f96d9a3206c04d13a047c03da03ebb2a93db7335b2c620c249f826d80885783f3f0a676ce622ca882f6e1144afd7258351c5b79ccbeba9"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.12-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r570/Cargo.toml
@@ -27,22 +27,22 @@ sha512 = "4ed4c4863dce0ec53a9fa1a7e3cdc7ce3e915db4ec014b2c5030e8a6c961d4e58c99c4
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
 sha512 = "2b26abd802e4360cc51b4990e1925732437817e6e9fac94fd2c629f2b74dffe04ea913771a61d77957a4791610d90288c7ac6a474d634b63173e3f11dce299ac"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
 sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-570-570.195.03-1.x86_64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-570-570.195.03-1.x86_64.rpm"
 sha512 = "15d8a8653520994204e345d589f84c750b38924b9e4e3bb949d43c2a702bd04c946b993da158145f38dea1cf459aa2d9cec0f16828aad8e2b95a3b27f85d629a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-570-570.195.03-1.aarch64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-570-570.195.03-1.aarch64.rpm"
 sha512 = "d620a3f02ce673cd27f96d9a3206c04d13a047c03da03ebb2a93db7335b2c620c249f826d80885783f3f0a676ce622ca882f6e1144afd7258351c5b79ccbeba9"
 force-upstream = true
 

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -1,6 +1,6 @@
 %global tesla_major 570
-%global tesla_minor 172
-%global tesla_patch 08
+%global tesla_minor 195
+%global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
@@ -694,11 +694,11 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.19
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.2
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.2
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -36,12 +36,12 @@ Source2: NVidiaEULAforAWS.pdf
 Source3: COPYING
 
 # fabricmanager for NVSwitch
-Source10: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
-Source11: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
+Source10: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
+Source11: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-%{tesla_ver}-1.aarch64.rpm
 
 # IMEX for GB200
-Source20: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-%{tesla_ver}-1.x86_64.rpm
-Source21: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-%{tesla_ver}-1.aarch64.rpm
+Source20: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-%{tesla_ver}-1.x86_64.rpm
+Source21: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-%{tesla_ver}-1.aarch64.rpm
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in

--- a/packages/kmod-6.12-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r580/Cargo.toml
@@ -17,33 +17,33 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/580.65.06/NVIDIA-Linux-x86_64-580.65.06.run"
-sha512 = "e9149873cc83c250f601be58ea919cbdc891773157587366d78f505ee1db96bf392bc5e689d39ce8fa339287699118897b8d6eba2b2a9caf163126a9bb2a6044"
+url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-x86_64-580.95.05.run"
+sha512 = "21e8076f593ce255c8e96dd456524f700e76b230130659ed73a279432dd9f2aa60735411c6fc906e9f60882e905cc1c5b91aaf80d5d5e64d317b1dd27f6e4c13"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/580.65.06/NVIDIA-Linux-aarch64-580.65.06.run"
-sha512 = "c4f2902412e9f47006e50c7f687e8f3cfc4580877c945b5da35c9e3a00f5e72eba8b0aaf250ff51d382fcf611177c9115f72f23b7858a520f0a7e1b27354d3e6"
+url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-aarch64-580.95.05.run"
+sha512 = "e07b31824f7e6dd485df5c73e3a58f85962239ea20a92f18d82b9c55564d69309fe5bb279f39ed8ef152ccdbffc6d0fdf7bccfa3c794e4ecd9fac83bcfbb91a9"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabricmanager-580.65.06-1.x86_64.rpm"
-sha512 = "da9df788ddc5eac1f18930c1f4f20cabb2313a2159604b7eb460baff80ecd7076a90c714198b6a0a953e0d4523edd79ede6a8f07ae8c9d8d4e9c917dd8555e13"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabricmanager-580.95.05-1.x86_64.rpm"
+sha512 = "38cb3a7cbe5aa687f396809c4a43511a7f6885b22f2c08c5c2c82cd2dc33103340d0771248b3150f797123294b564323525ed51b46d84584d29f7f4307f74490"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabricmanager-580.65.06-1.aarch64.rpm"
-sha512 = "f28faa3c4b6e4052746aa526966b36ccfdc64f84677fb808dc1ddd8f80e586d228d2190a926bf41251790e2817bc0c3162e6f599a5844e0d57ded5e1551ac099"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabricmanager-580.95.05-1.aarch64.rpm"
+sha512 = "333cd4e54df830e59a7a2507b64d626b29d78aafd88ffc1da4ee24739abcea93885ee524119ea930100dd3dce395b71049905389858ddae1ab0dbb74b97a6bfa"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-580.65.06-1.x86_64.rpm"
-sha512 = "7cfcaf3a7752a8d8f3949948321949356ef31209a1dd35b41b164c416eaf5df6ce720bf63af2ff58bca6184e8ebadf36fbfa3c5978436ef000b845a22862a797"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-580.95.05-1.x86_64.rpm"
+sha512 = "8bc09565558404366382d81d02db8f4f5dfe16556200846ea7e1d8f43d408b7a02627995b3a73bbf6b74a26067f30500b7c9f3f9ecabca789d296722bccfd2d7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-580.65.06-1.aarch64.rpm"
-sha512 = "5468ac57e3827e83690f78f02ca0517b5b51e398a3eb30580e7e27a46277052761f6b13c4e9c70042f8ed8e81277ffb224c9771085d2463645199689e817ebc5"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-580.95.05-1.aarch64.rpm"
+sha512 = "7cdfbaab907fc64d3f58a85fffd8fc47d137be70d62274fbbbe15bf6f27b5ad17eee3d78e506437f391fd448a918176890293c212eaea94390668c4ac531673c"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.12-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r580/Cargo.toml
@@ -27,22 +27,22 @@ sha512 = "e07b31824f7e6dd485df5c73e3a58f85962239ea20a92f18d82b9c55564d69309fe5bb
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabricmanager-580.95.05-1.x86_64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-580.95.05-1.x86_64.rpm"
 sha512 = "38cb3a7cbe5aa687f396809c4a43511a7f6885b22f2c08c5c2c82cd2dc33103340d0771248b3150f797123294b564323525ed51b46d84584d29f7f4307f74490"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabricmanager-580.95.05-1.aarch64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabricmanager-580.95.05-1.aarch64.rpm"
 sha512 = "333cd4e54df830e59a7a2507b64d626b29d78aafd88ffc1da4ee24739abcea93885ee524119ea930100dd3dce395b71049905389858ddae1ab0dbb74b97a6bfa"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-580.95.05-1.x86_64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-580.95.05-1.x86_64.rpm"
 sha512 = "8bc09565558404366382d81d02db8f4f5dfe16556200846ea7e1d8f43d408b7a02627995b3a73bbf6b74a26067f30500b7c9f3f9ecabca789d296722bccfd2d7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-580.95.05-1.aarch64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-580.95.05-1.aarch64.rpm"
 sha512 = "7cdfbaab907fc64d3f58a85fffd8fc47d137be70d62274fbbbe15bf6f27b5ad17eee3d78e506437f391fd448a918176890293c212eaea94390668c4ac531673c"
 force-upstream = true
 

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -36,12 +36,12 @@ Source2: NVidiaEULAforAWS.pdf
 Source3: COPYING
 
 # fabricmanager for NVSwitch
-Source10: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-fabricmanager-%{tesla_ver}-1.x86_64.rpm
-Source11: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-fabricmanager-%{tesla_ver}-1.aarch64.rpm
+Source10: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-%{tesla_ver}-1.x86_64.rpm
+Source11: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabricmanager-%{tesla_ver}-1.aarch64.rpm
 
 # IMEX for GB200
-Source20: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvidia-imex-%{tesla_ver}-1.x86_64.rpm
-Source21: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvidia-imex-%{tesla_ver}-1.aarch64.rpm
+Source20: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-%{tesla_ver}-1.x86_64.rpm
+Source21: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-%{tesla_ver}-1.aarch64.rpm
 
 # Common NVIDIA conf files from 200 to 299
 Source200: nvidia-tmpfiles.conf.in

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -1,6 +1,6 @@
 %global tesla_major 580
-%global tesla_minor 65
-%global tesla_patch 06
+%global tesla_minor 95
+%global tesla_patch 05
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
@@ -700,11 +700,11 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.19
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.1
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.1
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"

--- a/packages/nvlsm/Cargo.toml
+++ b/packages/nvlsm/Cargo.toml
@@ -13,12 +13,12 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvlsm-2025.06.6-1.x86_64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvlsm-2025.06.6-1.x86_64.rpm"
 sha512 = "61bf367cd95c854bd96cffd4f9abbd6a79c91e30c701ffe6aba7ff2f1621a17eb32c85df31482581e2c0ae9ef64f3a339e7db2b12de5108c3e25a63ff2aa552d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvlsm-2025.06.6-1.aarch64.rpm"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvlsm-2025.06.6-1.aarch64.rpm"
 sha512 = "a2f712455592497101668b2b8e6f216248bf79a7797bc32509533aa4031eed32505b3387ec736569ae0ea3de620490171d116845ca7c3f565b37ca342e49e9b2"
 force-upstream = true
 

--- a/packages/nvlsm/Cargo.toml
+++ b/packages/nvlsm/Cargo.toml
@@ -13,13 +13,13 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvlsm-2025.03.1-1.x86_64.rpm"
-sha512 = "24ccbc168f0ab0f96c8154fcbd942381f493488fe66328fb1f07ce02b2f4af0e52fd8f2cc62b8a6c5ebd5f6ef4bdbf7373fa96df437b7b7d16acf54566a65765"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvlsm-2025.06.6-1.x86_64.rpm"
+sha512 = "61bf367cd95c854bd96cffd4f9abbd6a79c91e30c701ffe6aba7ff2f1621a17eb32c85df31482581e2c0ae9ef64f3a339e7db2b12de5108c3e25a63ff2aa552d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvlsm-2025.03.1-1.aarch64.rpm"
-sha512 = "3e7be45f89da67fea91040c89357bb81867ce93cc4951fd56d6eb8f3e7f22ee6cd75b368b27ebca9b83e442422d9d314882ada66526c36f76a38f74c66e6b058"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvlsm-2025.06.6-1.aarch64.rpm"
+sha512 = "a2f712455592497101668b2b8e6f216248bf79a7797bc32509533aa4031eed32505b3387ec736569ae0ea3de620490171d116845ca7c3f565b37ca342e49e9b2"
 force-upstream = true
 
 [build-dependencies]

--- a/packages/nvlsm/nvlsm.spec
+++ b/packages/nvlsm/nvlsm.spec
@@ -18,8 +18,8 @@ License: LicenseRef-NVIDIA-AWS-EULA
 URL: https://nvidia.com
 
 # NVIDIA rpms and license files from 0 to 199
-Source0: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/nvlsm-%{nvlsm_ver}-1.x86_64.rpm
-Source1: https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/nvlsm-%{nvlsm_ver}-1.aarch64.rpm
+Source0: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvlsm-%{nvlsm_ver}-1.x86_64.rpm
+Source1: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvlsm-%{nvlsm_ver}-1.aarch64.rpm
 Source2: NVidiaEULAforAWS.pdf
 
 # NVLSM configuration files

--- a/packages/nvlsm/nvlsm.spec
+++ b/packages/nvlsm/nvlsm.spec
@@ -1,6 +1,6 @@
 %global nvlsm_major 2025
-%global nvlsm_minor 03
-%global nvlsm_patch 1
+%global nvlsm_minor 06
+%global nvlsm_patch 6
 %global nvlsm_ver %{nvlsm_major}.%{nvlsm_minor}.%{nvlsm_patch}
 # Both `lib/libgrpc_mgr.so` and `sbin/nvlsm` have RPATHs set to `opt/nvidia/nvlsm` which causes the RPATH check to fail.
 %global __brp_check_rpaths %{nil}


### PR DESCRIPTION
**Description of changes:**

Updated the NVIDIA drivers to the latest:

`kmod-6.1-nvidia-r570`: **570.172.08** → **570.195.03**
`kmod-6.12-nvidia-r570`: **570.172.08** → **570.195.03**
`kmod-6.12-nvidia-r580`: **580.65.06** → **580.95.05**
`nvlsm`: **2025.03.1** → **2025.06.6**

Also switched from `rhel9` repos to `amzn2023` where applicable.

**Testing done:**

Built and tested both architectures using `aws-k8s-1.32` and `aws-k8s-1.33`.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
