### PR TITLE
Add `nvidia-gridd` for G6f 

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r570/Cargo.toml
@@ -17,6 +17,10 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
+url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLicenseAgreement.DOCX"
+sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
+
+[[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-x86_64-570.195.03.run"
 sha512 = "77041ef60bd4c637a53750b6ef5c5121e3eb299c5b2859d65fd0a3683c4fb32b5fd34ae419cfdb982588992706264c839338d1ff02850cae2c88fd67f7cda27d"
 force-upstream = true
@@ -34,6 +38,11 @@ force-upstream = true
 [[package.metadata.build-package.external-files]]
 url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
 sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-18.5/NVIDIA-Linux-x86_64-570.195.03-grid-aws.run"
+sha512 = "7b824cf7ddcde4739cadf99dad136a6cb90f19cc759c907e8f856574abf2bb513efb19d2b564f44403f1662e9978e1cbcdbb92d3ed49d6d048088c9fdf27de8f"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.1-nvidia-r570/gridd.conf
+++ b/packages/kmod-6.1-nvidia-r570/gridd.conf
@@ -1,0 +1,1 @@
+EnableUI=FALSE

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -2,6 +2,7 @@
 %global tesla_minor 195
 %global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
+%global grid_ver grid-18.5
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -29,8 +30,10 @@ URL: http://www.nvidia.com/
 # NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
-Source2: NVidiaEULAforAWS.pdf
-Source3: COPYING
+Source2: https://s3.amazonaws.com/ec2-linux-nvidia-drivers/%{grid_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws.run
+Source3: NVidiaEULAforAWS.pdf
+Source4: COPYING
+Source5: NvidiaGridAWSUserLicenseAgreement.DOCX
 
 # fabricmanager for NVSwitch
 Source10: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
@@ -44,6 +47,8 @@ Source204: nvidia-fabricmanager.cfg
 Source205: nvidia-sysusers.conf
 Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
+Source208: gridd.conf
+Source209: nvidia-gridd.service
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -100,9 +105,10 @@ Requires: %{name}
 %package grid
 Summary: NVIDIA %{tesla_major} GRID driver
 Version: %{tesla_ver}
-License: MIT AND GPL-2.0-only
+License: MIT AND GPL-2.0-only AND LicenceRef-NVIDIA-GRID-AWS-EULA
 Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
+Requires: %{_cross_os}libstdc++
 
 %description grid
 %{summary}.
@@ -127,8 +133,15 @@ sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 # Move to the sources directory and apply patch
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
 %patch 1 -p1
-cp -r kernel-open grid
 popd
+
+# Extract GRID drivers just like Tesla
+%if "%{_cross_arch}" == "x86_64"
+sh %{_sourcedir}/NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws.run -x
+pushd NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws
+%patch 1 -p1
+popd
+%endif
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
@@ -136,7 +149,7 @@ mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
-install -p -m 0644 %{S:2} %{S:3} .
+install -p -m 0644 %{S:3} %{S:4} %{S:5} .
 
 %global kernel_sources %{_builddir}/kernel-devel
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
@@ -188,11 +201,11 @@ popd
 
 %if "%{_cross_arch}" == "x86_64"
 # Begin GRID build
-pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/grid
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}-grid-aws/kernel-open
 
 # We set IGNORE_CC_MISMATCH even though we are using the same compiler used to
 # compile the kernel, if we don't set this flag the compilation fails
-make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 GRID_BUILD=1 GRID_BUILD_CSP=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
+make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
 # Strip symbols out of the .ko files
 for module in *.ko; do
@@ -362,21 +375,27 @@ ln -rs %{buildroot}%{_cross_datadir}/vulkan/icd.d/nvidia_layers.json %{buildroot
 
 %if "%{_cross_arch}" == "x86_64"
 # GRID driver
+pushd ../NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws
 install -d %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
-install grid/nvidia.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # uvm
-install grid/nvidia-uvm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-uvm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # modeset
-install grid/nvidia-modeset.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-modeset.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # peermem
-install grid/nvidia-peermem.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-peermem.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # drm
-install grid/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
+# Install nvidia-gridd and related files
+install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
+install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
+install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+popd
 # End GRID driver
 %endif
 
@@ -696,8 +715,13 @@ popd
 %if "%{_cross_arch}" == "x86_64"
 %files grid
 %license COPYING
+%license NvidiaGridAWSUserLicenseAgreement.DOCX
+%license NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws/grid-third-party-licenses.txt
 %dir %{_cross_datadir}/nvidia/grid/drivers
 %dir %{_cross_factorydir}/nvidia/grid
+%{_cross_bindir}/nvidia-gridd
+%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
+%{_cross_unitdir}/nvidia-gridd.service
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.1-nvidia-r570/nvidia-gridd.service
+++ b/packages/kmod-6.1-nvidia-r570/nvidia-gridd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NVIDIA Grid Daemon
+Wants=systemd-resolved.service network-online.target nvidia-persistenced.service
+After=systemd-resolved.service network-online.target nvidia-persistenced.service
+
+[Service]
+Type=forking
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=/usr/bin/nvidia-gridd
+ExecStopPost=/bin/rm -rf /var/run/nvidia-gridd
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kmod-6.1-nvidia-r570/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.1-nvidia-r570/nvidia-tmpfiles.conf.in
@@ -6,5 +6,6 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gr
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
+C /etc/nvidia/gridd.conf - - - -
 d /run/nvidia 0700 root root -
 D /var/run/nvidia-persistenced 0755 nvidia nvidia - -

--- a/packages/kmod-6.12-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r570/Cargo.toml
@@ -17,6 +17,10 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
+url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLicenseAgreement.DOCX"
+sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
+
+[[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-x86_64-570.195.03.run"
 sha512 = "77041ef60bd4c637a53750b6ef5c5121e3eb299c5b2859d65fd0a3683c4fb32b5fd34ae419cfdb982588992706264c839338d1ff02850cae2c88fd67f7cda27d"
 force-upstream = true
@@ -34,6 +38,11 @@ force-upstream = true
 [[package.metadata.build-package.external-files]]
 url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
 sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-18.5/NVIDIA-Linux-x86_64-570.195.03-grid-aws.run"
+sha512 = "7b824cf7ddcde4739cadf99dad136a6cb90f19cc759c907e8f856574abf2bb513efb19d2b564f44403f1662e9978e1cbcdbb92d3ed49d6d048088c9fdf27de8f"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.12-nvidia-r570/gridd.conf
+++ b/packages/kmod-6.12-nvidia-r570/gridd.conf
@@ -1,0 +1,1 @@
+EnableUI=FALSE

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -2,6 +2,7 @@
 %global tesla_minor 195
 %global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
+%global grid_ver grid-18.5
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -32,8 +33,10 @@ URL: http://www.nvidia.com/
 # NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
-Source2: NVidiaEULAforAWS.pdf
-Source3: COPYING
+Source2: https://s3.amazonaws.com/ec2-linux-nvidia-drivers/%{grid_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws.run
+Source3: NVidiaEULAforAWS.pdf
+Source4: COPYING
+Source5: NvidiaGridAWSUserLicenseAgreement.DOCX
 
 # fabricmanager for NVSwitch
 Source10: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-%{tesla_ver}-1.x86_64.rpm
@@ -51,6 +54,8 @@ Source204: nvidia-fabricmanager.cfg
 Source205: nvidia-sysusers.conf
 Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
+Source208: gridd.conf
+Source209: nvidia-gridd.service
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -115,9 +120,10 @@ Requires: %{name}
 %package grid
 Summary: NVIDIA %{tesla_major} GRID driver
 Version: %{tesla_ver}
-License: MIT AND GPL-2.0-only
+License: MIT AND GPL-2.0-only AND LicenseRef-NVIDIA-AWS-GRID-EULA
 Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
+Requires: %{_cross_os}libstdc++
 
 %description grid
 %{summary}.
@@ -142,8 +148,15 @@ sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 # Move to the sources directory and apply patch
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
 %patch 1 -p1
-cp -r kernel-open grid
 popd
+
+# Extract GRID drivers just like Tesla
+%if "%{_cross_arch}" == "x86_64"
+sh %{_sourcedir}/NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws.run -x
+pushd NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws
+%patch 1 -p1
+popd
+%endif
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
@@ -151,7 +164,7 @@ mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 rpm2cpio %{_sourcedir}/nvidia-fabric-manager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
-install -p -m 0644 %{S:2} %{S:3} .
+install -p -m 0644 %{S:3} %{S:4} %{S:5} .
 
 # Extract imex from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
@@ -202,11 +215,11 @@ popd
 
 %if "%{_cross_arch}" == "x86_64"
 # Begin GRID build
-pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/grid
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}-grid-aws/kernel-open
 
 # We set IGNORE_CC_MISMATCH even though we are using the same compiler used to
 # compile the kernel, if we don't set this flag the compilation fails
-make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 GRID_BUILD=1 GRID_BUILD_CSP=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
+make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
 # Strip symbols out of the .ko files
 for module in *.ko; do
@@ -378,21 +391,27 @@ install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/open-gpu/
 
 %if "%{_cross_arch}" == "x86_64"
 # GRID driver
+pushd ../NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws
 install -d %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
-install grid/nvidia.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # uvm
-install grid/nvidia-uvm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-uvm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # modeset
-install grid/nvidia-modeset.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-modeset.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # peermem
-install grid/nvidia-peermem.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-peermem.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # drm
-install grid/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
+# Install nvidia-gridd and related files
+install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
+install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
+install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+popd
 # End GRID driver
 %endif
 
@@ -722,8 +741,13 @@ popd
 %if "%{_cross_arch}" == "x86_64"
 %files grid
 %license COPYING
+%license NvidiaGridAWSUserLicenseAgreement.DOCX
+%license NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws/grid-third-party-licenses.txt
 %dir %{_cross_datadir}/nvidia/grid/drivers
 %dir %{_cross_factorydir}/nvidia/grid
+%{_cross_bindir}/nvidia-gridd
+%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
+%{_cross_unitdir}/nvidia-gridd.service
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.12-nvidia-r570/nvidia-gridd.service
+++ b/packages/kmod-6.12-nvidia-r570/nvidia-gridd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NVIDIA Grid Daemon
+Wants=systemd-resolved.service network-online.target nvidia-persistenced.service
+After=systemd-resolved.service network-online.target nvidia-persistenced.service
+
+[Service]
+Type=forking
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=/usr/bin/nvidia-gridd
+ExecStopPost=/bin/rm -rf /var/run/nvidia-gridd
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kmod-6.12-nvidia-r570/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.12-nvidia-r570/nvidia-tmpfiles.conf.in
@@ -6,5 +6,6 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gr
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
+C /etc/nvidia/gridd.conf - - - -
 d /run/nvidia 0700 root root -
 D /var/run/nvidia-persistenced 0755 nvidia nvidia - -

--- a/packages/kmod-6.12-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r580/Cargo.toml
@@ -17,6 +17,10 @@ url = "https://s3.amazonaws.com/EULA/NVidiaEULAforAWS.pdf"
 sha512 = "e1926fe99afc3ab5b2f2744fcd53b4046465aefb2793e2e06c4a19455a3fde895e00af1415ff1a5804c32e6a2ed0657e475de63da6c23a0e9c59feeef52f3f58"
 
 [[package.metadata.build-package.external-files]]
+url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLicenseAgreement.DOCX"
+sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
+
+[[package.metadata.build-package.external-files]]
 url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-x86_64-580.95.05.run"
 sha512 = "21e8076f593ce255c8e96dd456524f700e76b230130659ed73a279432dd9f2aa60735411c6fc906e9f60882e905cc1c5b91aaf80d5d5e64d317b1dd27f6e4c13"
 force-upstream = true
@@ -44,6 +48,11 @@ force-upstream = true
 [[package.metadata.build-package.external-files]]
 url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-580.95.05-1.aarch64.rpm"
 sha512 = "7cdfbaab907fc64d3f58a85fffd8fc47d137be70d62274fbbbe15bf6f27b5ad17eee3d78e506437f391fd448a918176890293c212eaea94390668c4ac531673c"
+force-upstream = true
+
+[[package.metadata.build-package.external-files]]
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-19.2/NVIDIA-Linux-x86_64-580.95.05-grid-aws.run"
+sha512 = "fdc8279a147a491a2cfed6a7883515ddd824108b4003d70b97b43a70ab5912285d832ccd8102f7d2c7bf88911e507f1bab6a770bd40e45dacd9a7e1855716457"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.12-nvidia-r580/gridd.conf
+++ b/packages/kmod-6.12-nvidia-r580/gridd.conf
@@ -1,0 +1,1 @@
+EnableUI=FALSE

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -2,6 +2,7 @@
 %global tesla_minor 95
 %global tesla_patch 05
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
+%global grid_ver grid-19.2
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -32,8 +33,10 @@ URL: http://www.nvidia.com/
 # NVIDIA .run scripts for kernel and userspace drivers
 Source0: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}.run
 Source1: https://us.download.nvidia.com/tesla/%{tesla_ver}/NVIDIA-Linux-aarch64-%{tesla_ver}.run
-Source2: NVidiaEULAforAWS.pdf
-Source3: COPYING
+Source2: https://s3.amazonaws.com/ec2-linux-nvidia-drivers/%{grid_ver}/NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws.run
+Source3: NVidiaEULAforAWS.pdf
+Source4: COPYING
+Source5: NvidiaGridAWSUserLicenseAgreement.DOCX
 
 # fabricmanager for NVSwitch
 Source10: https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-%{tesla_ver}-1.x86_64.rpm
@@ -51,6 +54,8 @@ Source204: nvidia-fabricmanager.cfg
 Source205: nvidia-sysusers.conf
 Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
+Source208: gridd.conf
+Source209: nvidia-gridd.service
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -115,9 +120,10 @@ Requires: %{name}
 %package grid
 Summary: NVIDIA %{tesla_major} GRID driver
 Version: %{tesla_ver}
-License: MIT AND GPL-2.0-only
+License: MIT AND GPL-2.0-only AND LicenceRef-NVIDIA-GRID-AWS-EULA
 Requires: %{_cross_os}variant-platform(aws)
 Requires: %{name}
+Requires: %{_cross_os}libstdc++
 
 %description grid
 %{summary}.
@@ -142,8 +148,15 @@ sh %{_sourcedir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}.run -x
 # Move to the sources directory and apply patch
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}
 %patch 1 -p1
-cp -r kernel-open grid
 popd
+
+# Extract GRID drivers just like Tesla
+%if "%{_cross_arch}" == "x86_64"
+sh %{_sourcedir}/NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws.run -x
+pushd NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws
+%patch 1 -p1
+popd
+%endif
 
 # Extract fabricmanager from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
@@ -151,7 +164,7 @@ mkdir fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 rpm2cpio %{_sourcedir}/nvidia-fabricmanager-%{tesla_ver}-1.%{_cross_arch}.rpm | cpio -idmV -D fabricmanager-linux-%{nvidia_arch}-%{tesla_ver}-archive
 
 # Add the license.
-install -p -m 0644 %{S:2} %{S:3} .
+install -p -m 0644 %{S:3} %{S:4} %{S:5} .
 
 # Extract imex from the rpm via cpio rather than `%%setup` since the
 # correct source is architecture-dependent.
@@ -202,11 +215,11 @@ popd
 
 %if "%{_cross_arch}" == "x86_64"
 # Begin GRID build
-pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/grid
+pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}-grid-aws/kernel-open
 
 # We set IGNORE_CC_MISMATCH even though we are using the same compiler used to
 # compile the kernel, if we don't set this flag the compilation fails
-make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 GRID_BUILD=1 GRID_BUILD_CSP=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
+make %{?_smp_mflags} ARCH=%{_cross_karch} IGNORE_CC_MISMATCH=1 SYSSRC=%{kernel_sources} CC=%{_cross_target}-gcc LD=%{_cross_target}-ld
 
 # Strip symbols out of the .ko files
 for module in *.ko; do
@@ -378,21 +391,27 @@ install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/open-gpu/
 
 %if "%{_cross_arch}" == "x86_64"
 # GRID driver
+pushd ../NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws
 install -d %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
-install grid/nvidia.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # uvm
-install grid/nvidia-uvm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-uvm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # modeset
-install grid/nvidia-modeset.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-modeset.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # peermem
-install grid/nvidia-peermem.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-peermem.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
 # drm
-install grid/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
+install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/drivers/
 
+# Install nvidia-gridd and related files
+install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
+install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
+install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+popd
 # End GRID driver
 %endif
 
@@ -728,8 +747,13 @@ popd
 %if "%{_cross_arch}" == "x86_64"
 %files grid
 %license COPYING
+%license NvidiaGridAWSUserLicenseAgreement.DOCX
+%license NVIDIA-Linux-x86_64-%{tesla_ver}-grid-aws/grid-third-party-licenses.txt
 %dir %{_cross_datadir}/nvidia/grid/drivers
 %dir %{_cross_factorydir}/nvidia/grid
+%{_cross_bindir}/nvidia-gridd
+%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
+%{_cross_unitdir}/nvidia-gridd.service
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.12-nvidia-r580/nvidia-gridd.service
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-gridd.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NVIDIA Grid Daemon
+Wants=systemd-resolved.service network-online.target nvidia-persistenced.service
+After=systemd-resolved.service network-online.target nvidia-persistenced.service
+
+[Service]
+Type=forking
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=/usr/bin/nvidia-gridd
+ExecStopPost=/bin/rm -rf /var/run/nvidia-gridd
+
+[Install]
+WantedBy=preconfigured.target

--- a/packages/kmod-6.12-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -6,5 +6,6 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gr
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
+C /etc/nvidia/gridd.conf - - - -
 d /run/nvidia 0700 root root -
 D /var/run/nvidia-persistenced 0755 nvidia nvidia - -


### PR DESCRIPTION
**Description of changes:**
G6f instances will work without the gridd running for a time, but after [24 hours the GPU degrades](https://docs.nvidia.com/vgpu/latest/grid-licensing-user-guide/index.html) and workloads stop working. This change adds gridd so that the GPU will report as licensed and avoid the degradation. 


**Testing done:**
Booting this on g6f.xlarge and confirmed `nvida-smi -q` reports as Licensed. 
```
bash-5.1# nvidia-smi -q | grep 'vGPU Software Licensed Product' -A 2
    vGPU Software Licensed Product
        Product Name                      : NVIDIA RTX Virtual Workstation
        License Status                    : Licensed (Expiry: N/A)
```
nvidia-grid is running:
```
bash-5.1# journalctl -u nvidia-gridd
Oct 01 22:53:58 localhost systemd[1]: Starting NVIDIA Grid Daemon...
Oct 01 22:53:58 localhost nvidia-gridd[1976]: Started (1976)
Oct 01 22:53:58 localhost systemd[1]: Started NVIDIA Grid Daemon.
Oct 01 22:53:59 localhost nvidia-gridd[1976]: vGPU Software package (1)
Oct 01 22:53:59 localhost nvidia-gridd[1976]: Platform initialized (2)
Oct 01 22:53:59 localhost nvidia-gridd[1976]: Platform detection successful (2)
```
After 24 hours of running, CUDA workloads still run:
```
deviceQuery Starting...

 CUDA Device Query (Runtime API) version (CUDART static linking)

Detected 1 CUDA Capable device(s)

Device 0: "NVIDIA L4-3Q"
  CUDA Driver Version / Runtime Version          12.8 / 12.8
  CUDA Capability Major/Minor version number:    8.9
  Total amount of global memory:                 2866 MBytes (3005480960 bytes)
  (058) Multiprocessors, (128) CUDA Cores/MP:    7424 CUDA Cores
  GPU Max Clock rate:                            2040 MHz (2.04 GHz)
  Memory Clock rate:                             6251 Mhz
  Memory Bus Width:                              192-bit
  L2 Cache Size:                                 50331648 bytes
  Maximum Texture Dimension Size (x,y,z)         1D=(131072), 2D=(131072, 65536), 3D=(16384, 16384, 16384)
  Maximum Layered 1D Texture Size, (num) layers  1D=(32768), 2048 layers
  Maximum Layered 2D Texture Size, (num) layers  2D=(32768, 32768), 2048 layers
  Total amount of constant memory:               65536 bytes
  Total amount of shared memory per block:       49152 bytes
  Total shared memory per multiprocessor:        102400 bytes
  Total number of registers available per block: 65536
  Warp size:                                     32
  Maximum number of threads per multiprocessor:  1536
  Maximum number of threads per block:           1024
  Max dimension size of a thread block (x,y,z): (1024, 1024, 64)
  Max dimension size of a grid size    (x,y,z): (2147483647, 65535, 65535)
  Maximum memory pitch:                          2147483647 bytes
  Texture alignment:                             512 bytes
  Concurrent copy and kernel execution:          Yes with 2 copy engine(s)
  Run time limit on kernels:                     No
  Integrated GPU sharing Host Memory:            No
  Support host page-locked memory mapping:       Yes
  Alignment requirement for Surfaces:            Yes
  Device has ECC support:                        Enabled
  Device supports Unified Addressing (UVA):      Yes
  Device supports Managed Memory:                No
  Device supports Compute Preemption:            Yes
  Supports Cooperative Kernel Launch:            Yes
  Supports MultiDevice Co-op Kernel Launch:      Yes
  Device PCI Domain ID / Bus ID / location ID:   0 / 49 / 0
  Compute Mode:
     < Default (multiple host threads can use ::cudaSetDevice() with device simultaneously) >

deviceQuery, CUDA Driver = CUDART, CUDA Driver Version = 12.8, CUDA Runtime Version = 12.8, NumDevs = 1
Result = PASS
...
=========================================
  Running sample warpAggregatedAtomicsCG
=========================================

GPU Device 0: "Ada" with compute capability 8.9

CPU max matches GPU max

Warp Aggregated Atomics PASSED
```

On G6f, gridd does not run:
```
bash-5.1# journalctl -u nvidia-gridd
Oct 01 23:07:38 ip-192-168-51-101.us-west-2.compute.internal systemd[1]: Starting NVIDIA Grid Daemon...
Oct 01 23:07:38 ip-192-168-51-101.us-west-2.compute.internal ghostdog[2025]: Error: grid is not preferred driver: open-gpu
Oct 01 23:07:38 ip-192-168-51-101.us-west-2.compute.internal systemd[1]: nvidia-gridd.service: Skipped due to 'exec-condition'.
Oct 01 23:07:38 ip-192-168-51-101.us-west-2.compute.internal systemd[1]: Condition check resulted in NVIDIA Grid Daemon being skipped.
```

The size of the root filesystem is still under 95% for `aws-k8s-1.32-nvidia`:
```
[disk_usage.ROOT-A]
bytes_total = 1929379840
bytes_used = 1797292032
blocks_total = 471040
blocks_used = 438792
percentage = 93
[disk_usage.BOOT-A]
bytes_total = 46584832
bytes_used = 26307584
blocks_total = 45493
blocks_used = 25691
percentage = 56
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
