### PR TITLE
Prepare for release 4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v4.3.3 (2025-10-03)
+## OS Changes
+* Update r570 NVIDIA driver to 570.195.03 ([#283])
+* Update r580 NVIDIA driver to 580.95.05 ([#283])
+* Update nvlsm to 2025.06.6 ([#283])
+* Provide nvidia-gridd as a system service ([#285])
+
+[#283]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/283
+[#285]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/285
+
 # v4.3.2 (2025-09-29)
 ## OS Changes
 * Update kernel from 6.1.150-174.273 to 6.1.153-175.280 ([#279])

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "4.3.2"
+release-version = "4.3.3"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]


### PR DESCRIPTION
**Description of changes:**
Prepare for the 4.3.3 release.

**Testing done:**
`make` and `make ARCH=aarch64` passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
