### PR TITLE
tools: use latest version when multiple SRPMs exist

### DIFF
--- a/tools/latest-kernel-full-config.sh
+++ b/tools/latest-kernel-full-config.sh
@@ -210,43 +210,33 @@ fi
 # In kernel kit automation, CodePipeline updates each kernel separately.
 # This script processes only kernels that have available RPM files,
 # skipping any kernel packages without corresponding source RPMs.
-kernels_to_process=()
+# Process kernels with available RPMs
+found_any_rpm=0
 for kernel_dir in "${KERNEL_KIT_DIR}/packages"/kernel-*; do
-    if [[ -d "${kernel_dir}" ]]; then
-        kernel_pkg=$(basename "${kernel_dir}")
-        # In CodePipeline, only one RPM exists per kernel package, but during development
-        # multiple RPMs can coexist. Use version sorting to select the latest RPM.
-        # Sorting rules: https://www.gnu.org/software/coreutils/manual/html_node/sort-invocation.html
-        rpm_file=$(find "${kernel_dir}" -name "kernel*.src.rpm" | sort -V | tail -1)
-        if [[ -n "${rpm_file}" ]]; then
-            kernels_to_process+=("${kernel_pkg}")
-            echo "Found RPM for ${kernel_pkg}: $(basename "${rpm_file}")"
-        else
-            echo "No RPM found for ${kernel_pkg}, skipping"
-        fi
-    else
+    if [[ ! -d "${kernel_dir}" ]]; then
         bail "No Kernel directory found for ${kernel_dir}"
     fi
-done
 
-if [[ ${#kernels_to_process[@]} -eq 0 ]]; then
-    bail "No kernel RPMs found in any package directory"
-fi
+    kernel_pkg=$(basename "${kernel_dir}")
+    # Multiple RPMs can coexist. Use version sorting to select the latest RPM.
+    rpm_file=$(find "${kernel_dir}" -name "kernel*.src.rpm" | sort -V | tail -1)
 
-# Process available kernels
-for kernel_pkg in "${kernels_to_process[@]}"; do
-    echo "Processing ${kernel_pkg}..."
+    if [[ -z "${rpm_file}" ]]; then
+        echo "No RPM found for ${kernel_pkg}, skipping"
+        continue
+    fi
+
+    found_any_rpm=$((found_any_rpm + 1))
+
+    echo "Processing ${kernel_pkg}: $(basename "${rpm_file}")"
 
     tmpdir=$(mktemp -d)
-
     pushd "${tmpdir}" || bail "Unable to enter temporary directory"
-
-    rpm_file=$(find "${KERNEL_KIT_DIR}/packages/${kernel_pkg}" -name "kernel*.src.rpm" | head -1)
 
     cp "${rpm_file}" kernel-source.rpm
 
     version="$(rpm --query --nosignature --queryformat '%{VERSION}' kernel-source.rpm)"
-    majorminor=${version%.*} # Trim after last '.', e.g. 6.1.132 -> 6.1
+    majorminor=${version%.*}
 
     merge_kernel_configs "${version}" "${majorminor}" "${tmpdir}"
 
@@ -255,3 +245,8 @@ for kernel_pkg in "${kernels_to_process[@]}"; do
 
     popd || bail "Could not return from temporary directory"
 done
+
+# Check if we found any RPMs at all
+if [ "${found_any_rpm}" -eq 0 ]; then
+    bail "No kernel RPMs found in any directory"
+fi


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
Previously, kernel RPM discovery and processing were split into separate loops, with only the discovery loop using version-based sorting (-V) to select the latest RPM. Without version sorting, RPM selection defaulted to filesystem timestamp ordering, which could lead to inconsistencies. Combined both loops into a single workflow to ensure the same RPM version is used throughout the process.


**Testing done:**
Running on my local machine when using `./update_kernels -b develop -n update_2025-10-10_6.12 -k 6.12 -p 6.12.48-67.114` command
```
Validating kernel-6.12 configurations...
=== Validating kernel-6.12 x86_64 ===
✅ All configs present for x86_64
=== Validating kernel-6.12 aarch64 ===
✅ All configs present for aarch64

🎉 All kernel config validations passed!
/home/builder
~/bottlerocket-kernel-kit/packages ~/bottlerocket-kernel-kit
~/bottlerocket-kernel-kit/packages/kernel-6.12 ~/bottlerocket-kernel-kit/packages ~/bottlerocket-kernel-kit
On branch develop
Your branch is ahead of 'origin/develop' by 1 commit.
  (use "git push" to publish your local commits)

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Cargo.toml
        modified:   config-full-bottlerocket-aarch64
        modified:   config-full-bottlerocket-x86_64
        modified:   kernel-6.12.spec

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        ../../log
        patch_changes/
        ../kmod-6.1-nvidia-r570/NvidiaGridAWSUserLicenseAgreement.DOCX
        ../kmod-6.12-nvidia-r570/NvidiaGridAWSUserLicenseAgreement.DOCX
        ../kmod-6.12-nvidia-r580/NvidiaGridAWSUserLicenseAgreement.DOCX
        ../../update_kernels

no changes added to commit (use "git add" and/or "git commit -a")
~/bottlerocket-kernel-kit/packages ~/bottlerocket-kernel-kit
~/bottlerocket-kernel-kit
Updated kernels: 6.12
```
when there is no rpms at all
```
╰$ make full-config                                                               
./tools/docker-run.sh "/bottlerocket-kernel-kit/tools/latest-kernel-full-config.sh"
No RPM found for kernel-6.1, skipping
No RPM found for kernel-6.12, skipping
Error: No kernel RPMs found in any directory
make: *** [Makefile:26: full-config] Error 1
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
