### PR TITLE
Full config containerized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ KIT ?= bottlerocket-kernel-kit
 UNAME_ARCH = $(shell uname -m)
 ARCH ?= $(UNAME_ARCH)
 VENDOR ?= bottlerocket
+SDK ?= ""
 
 ifeq ($(UNAME_ARCH), aarch64)
 	TWOLITER_SHA256=$(TWOLITER_SHA256_AARCH64)
@@ -23,7 +24,7 @@ endif
 all: build
 
 full-config:
-	./tools/docker-run.sh "/bottlerocket-kernel-kit/tools/latest-kernel-full-config.sh"
+	SDK=$(SDK) ./tools/docker-run.sh "/bottlerocket-kernel-kit/tools/latest-kernel-full-config.sh"
 
 prep:
 	@mkdir -p $(TWOLITER_DIR)

--- a/tools/docker-run.sh
+++ b/tools/docker-run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
+TQ_IMAGE=ghcr.io/mdm-code/tq:v2.4.0
 
 bail() {
     if [[ $# -gt 0 ]]; then
@@ -9,17 +10,23 @@ bail() {
     exit 1
 }
 
+find_sdk() {
+  docker run --rm \
+      -v "$(pwd):/bottlerocket-kernel-kit:ro" \
+      --user "$(id -u):$(id -g)" \
+      --network none \
+      "${TQ_IMAGE}" \
+      tq -q "[sdk][source]" /bottlerocket-kernel-kit/Twoliter.lock
+}
+
 SCRIPT_PATH="$1"
 
-source="$(tq -r ".sdk.source" -f Twoliter.lock)"
-version="$(tq -r ".sdk.version" -f Twoliter.lock)"
-_name="$(tq -r ".sdk.name" -f Twoliter.lock)"
-_registry="${source%/*}"
+if [[ -z "${SDK}" ]]; then
+  echo "Retriving SDK from Twoliter.lock"
+  SDK="$(find_sdk)"
+fi
 
-registry="$(tq -r ".bottlerocket.bottlerocket-sdk.registry" -f Twoliter.override 2>/dev/null || echo "$_registry")"
-name="$(tq -r ".bottlerocket.bottlerocket-sdk.name" -f Twoliter.override 2>/dev/null || echo "$_name")"
-
-SDK="${registry}/${name}:v${version}"
+echo "Using SDK: ${SDK} to run the provided script"
 
 docker run --rm \
     -v "$(pwd):/bottlerocket-kernel-kit" \

--- a/tools/latest-kernel-full-config.sh
+++ b/tools/latest-kernel-full-config.sh
@@ -39,6 +39,22 @@ bail() {
     exit 1
 }
 
+# Fetch the sources of the configured kernels
+fetch_sources() {
+    # Use the tools available in the Bottlerocket SDK (curl, grep , sed) since
+    # the running container is configured with the caller's UID which prevents
+    # from installing tools at /home/builder/
+    for kernel_dir in "${KERNEL_KIT_DIR}/packages"/kernel-*; do
+        pushd "${kernel_dir}" || bail "Unable to enter kernel directory '${kernel_dir}'"
+        grep 'url =' "Cargo.toml" | while IFS= read -r url; do
+            url=$(echo "${url#*\"}" | cut -d '"' -f 1)
+            echo "Fetching: ${url}"
+            curl -LOs "${url}"
+        done
+        popd || bail "Could not exit kernel directory '${kernel_dir}'"
+    done
+}
+
 # Function to merge kernel configurations for a specific kernel version
 merge_kernel_configs() {
     local version="$1"
@@ -207,9 +223,10 @@ if [[ ! -d "${KERNEL_KIT_DIR}" ]]; then
     bail
 fi
 
-# In kernel kit automation, CodePipeline updates each kernel separately.
-# This script processes only kernels that have available RPM files,
-# skipping any kernel packages without corresponding source RPMs.
+# Guarantee that at least the kernel sources provided by the kernels are available
+# to generate the configuration.
+fetch_sources
+
 # Process kernels with available RPMs
 found_any_rpm=0
 for kernel_dir in "${KERNEL_KIT_DIR}/packages"/kernel-*; do


### PR DESCRIPTION
**Description of changes:**

The last revision of the script introduced a dependency on `tq` to retrieve which SDK version should be used, but it wasn't clear which `tq` (`tq` the rust binary or `tq` the go binary).

Drop this hardcoded dependency on the running host by calling the [`tq` container] preventing the container from making any network calls. Additionally, allow users provide their own SDK url as they need to instead of extracting the overridden SDK from a `Twoliter.override`.

The last change in the series retrieves the current kernel sources, so that users don't have to do a build to generate the new kernel configs.

[`tq` container]: https://github.com/mdm-code/tq
**Testing done:**

I ran `make full-config` without `tq` in my system, and without prior builds. I confirmed:
- The script finds the correct SDK version
- The script uses the SDK override when provided
- The script fetches the kernel RPMs in brand new kernel kit tree
- The script generates the config

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
