### PR TITLE
kernel-6.1: update to 6.1.155

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/c61dc7ce8c78913f077a1ebc5199ae4d3da832932b1b8d34a32c9668c19a353f/kernel-6.1.153-175.280.amzn2023.src.rpm"
-sha512 = "516cd696271df0586b738ab63e717d8554a11c5d352312cf1da43d1778596dd43c7d5a3fa1872bff3dc3b0cf4e51724467af7ba119cebf2c243ebcac61d6b961"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/f3b09a804dce910af99d51994144a9e73322ac17d13feb47547b70b7833fa40a/kernel-6.1.155-176.282.amzn2023.src.rpm"
+sha512 = "395940a92892d92612c51edc566e9bd7bb59432048a796e9e4934246f20aca8f7cef956d19457f87b258dd4de305828c13df10495afbb36b690152b7065425cc"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/config-full-bottlerocket-aarch64
+++ b/packages/kernel-6.1/config-full-bottlerocket-aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.1.153 Kernel Configuration
+# Linux/arm64 6.1.155 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-6.1/config-full-bottlerocket-x86_64
+++ b/packages/kernel-6.1/config-full-bottlerocket-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 6.1.153 Kernel Configuration
+# Linux/x86 6.1.155 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0"
 CONFIG_CC_IS_GCC=y

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name: %{_cross_os}kernel-6.1
-Version: 6.1.153
+Version: 6.1.155
 Release: 1%{?dist}
 Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/c61dc7ce8c78913f077a1ebc5199ae4d3da832932b1b8d34a32c9668c19a353f/kernel-6.1.153-175.280.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/f3b09a804dce910af99d51994144a9e73322ac17d13feb47547b70b7833fa40a/kernel-6.1.155-176.282.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm


### PR DESCRIPTION
**Description of changes:**
Updating the 6.1 kernel to 6.1.155-176.282

Patches that changed:
None
Patches that were dropped:
None
Patches that were added:
0280-scsi-mpi3mr-A-performance-fix.patch
0281-AL2023-6.1-Update-ena-driver-to-2.15.0g.patch

**Testing done:**
make


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
