### PR TITLE
Add dependency on the GRID license for NVIDIA k8s device plugin

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/grid-license-check.service
+++ b/packages/kmod-6.1-nvidia-r570/grid-license-check.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=GRID License Check
+RefuseManualStart=true
+RefuseManualStop=true
+After=nvidia-gridd.service
+Requires=nvidia-gridd.service
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=-/usr/bin/truncate /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/nvidia-smi -q
+ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+StandardOutput=append:/tmp/.nvidia-gridd-license
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r570/grid-license-check.timer
+++ b/packages/kmod-6.1-nvidia-r570/grid-license-check.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=GRID License Check Timer
+RefuseManualStart=true
+
+[Timer]
+Unit=grid-license-check.service
+OnBootSec=5s
+OnUnitActiveSec=2s
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/packages/kmod-6.1-nvidia-r570/grid-license-file-check.conf
+++ b/packages/kmod-6.1-nvidia-r570/grid-license-file-check.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -49,6 +49,11 @@ Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
 Source208: gridd.conf
 Source209: nvidia-gridd.service
+Source210: grid-license-check.service
+Source211: grid-license-check.timer
+Source212: open-gpu-license-fallback.service
+Source213: tesla-license-fallback.service
+Source214: grid-license-file-check.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -394,7 +399,9 @@ install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/driv
 # Install nvidia-gridd and related files
 install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
 install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
-install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:209} %{S:210} %{S:211} %{S:212} %{S:213} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
+install -p -m 0644 %{S:214} %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 popd
 # End GRID driver
 %endif
@@ -722,6 +729,11 @@ popd
 %{_cross_bindir}/nvidia-gridd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
 %{_cross_unitdir}/nvidia-gridd.service
+%{_cross_unitdir}/grid-license-check.service
+%{_cross_unitdir}/grid-license-check.timer
+%{_cross_unitdir}/open-gpu-license-fallback.service
+%{_cross_unitdir}/tesla-license-fallback.service
+%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d/grid-license-file-check.conf
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.1-nvidia-r570/open-gpu-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r570/open-gpu-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Open GPU GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r570/tesla-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r570/tesla-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tesla GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver tesla
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r580/grid-license-check.service
+++ b/packages/kmod-6.1-nvidia-r580/grid-license-check.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=GRID License Check
+RefuseManualStart=true
+RefuseManualStop=true
+After=nvidia-gridd.service
+Requires=nvidia-gridd.service
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=-/usr/bin/truncate /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/nvidia-smi -q
+ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+StandardOutput=append:/tmp/.nvidia-gridd-license
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r580/grid-license-check.timer
+++ b/packages/kmod-6.1-nvidia-r580/grid-license-check.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=GRID License Check Timer
+RefuseManualStart=true
+
+[Timer]
+Unit=grid-license-check.service
+OnBootSec=5s
+OnUnitActiveSec=2s
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/packages/kmod-6.1-nvidia-r580/grid-license-file-check.conf
+++ b/packages/kmod-6.1-nvidia-r580/grid-license-file-check.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed

--- a/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
+++ b/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
@@ -49,6 +49,11 @@ Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
 Source208: gridd.conf
 Source209: nvidia-gridd.service
+Source210: grid-license-check.service
+Source211: grid-license-check.timer
+Source212: open-gpu-license-fallback.service
+Source213: tesla-license-fallback.service
+Source214: grid-license-file-check.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -394,7 +399,9 @@ install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/driv
 # Install nvidia-gridd and related files
 install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
 install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
-install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:209} %{S:210} %{S:211} %{S:212} %{S:213} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
+install -p -m 0644 %{S:214} %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 popd
 # End GRID driver
 %endif
@@ -730,6 +737,11 @@ popd
 %{_cross_bindir}/nvidia-gridd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
 %{_cross_unitdir}/nvidia-gridd.service
+%{_cross_unitdir}/grid-license-check.service
+%{_cross_unitdir}/grid-license-check.timer
+%{_cross_unitdir}/open-gpu-license-fallback.service
+%{_cross_unitdir}/tesla-license-fallback.service
+%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d/grid-license-file-check.conf
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.1-nvidia-r580/open-gpu-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r580/open-gpu-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Open GPU GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r580/tesla-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r580/tesla-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tesla GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver tesla
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r570/grid-license-check.service
+++ b/packages/kmod-6.12-nvidia-r570/grid-license-check.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=GRID License Check
+RefuseManualStart=true
+RefuseManualStop=true
+After=nvidia-gridd.service
+Requires=nvidia-gridd.service
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=-/usr/bin/truncate /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/nvidia-smi -q
+ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+StandardOutput=append:/tmp/.nvidia-gridd-license
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r570/grid-license-check.timer
+++ b/packages/kmod-6.12-nvidia-r570/grid-license-check.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=GRID License Check Timer
+RefuseManualStart=true
+
+[Timer]
+Unit=grid-license-check.service
+OnBootSec=5s
+OnUnitActiveSec=2s
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/packages/kmod-6.12-nvidia-r570/grid-license-file-check.conf
+++ b/packages/kmod-6.12-nvidia-r570/grid-license-file-check.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -56,6 +56,11 @@ Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
 Source208: gridd.conf
 Source209: nvidia-gridd.service
+Source210: grid-license-check.service
+Source211: grid-license-check.timer
+Source212: open-gpu-license-fallback.service
+Source213: tesla-license-fallback.service
+Source214: grid-license-file-check.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -410,7 +415,9 @@ install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/driv
 # Install nvidia-gridd and related files
 install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
 install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
-install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:209} %{S:210} %{S:211} %{S:212} %{S:213} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
+install -p -m 0644 %{S:214} %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 popd
 # End GRID driver
 %endif
@@ -748,6 +755,11 @@ popd
 %{_cross_bindir}/nvidia-gridd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
 %{_cross_unitdir}/nvidia-gridd.service
+%{_cross_unitdir}/grid-license-check.service
+%{_cross_unitdir}/grid-license-check.timer
+%{_cross_unitdir}/open-gpu-license-fallback.service
+%{_cross_unitdir}/tesla-license-fallback.service
+%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d/grid-license-file-check.conf
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.12-nvidia-r570/open-gpu-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r570/open-gpu-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Open GPU GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r570/tesla-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r570/tesla-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tesla GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver tesla
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r580/grid-license-check.service
+++ b/packages/kmod-6.12-nvidia-r580/grid-license-check.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=GRID License Check
+RefuseManualStart=true
+RefuseManualStop=true
+After=nvidia-gridd.service
+Requires=nvidia-gridd.service
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver grid
+ExecStart=-/usr/bin/truncate /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/nvidia-smi -q
+ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-license
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+StandardOutput=append:/tmp/.nvidia-gridd-license
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r580/grid-license-check.timer
+++ b/packages/kmod-6.12-nvidia-r580/grid-license-check.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=GRID License Check Timer
+RefuseManualStart=true
+
+[Timer]
+Unit=grid-license-check.service
+OnBootSec=5s
+OnUnitActiveSec=2s
+AccuracySec=1s
+
+[Install]
+WantedBy=timers.target

--- a/packages/kmod-6.12-nvidia-r580/grid-license-file-check.conf
+++ b/packages/kmod-6.12-nvidia-r580/grid-license-file-check.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -56,6 +56,11 @@ Source206: nvidia-persistenced.service
 Source207: fabricmanager.env
 Source208: gridd.conf
 Source209: nvidia-gridd.service
+Source210: grid-license-check.service
+Source211: grid-license-check.timer
+Source212: open-gpu-license-fallback.service
+Source213: tesla-license-fallback.service
+Source214: grid-license-file-check.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -410,7 +415,9 @@ install kernel-open/nvidia-drm.ko %{buildroot}%{_cross_datadir}/nvidia/grid/driv
 # Install nvidia-gridd and related files
 install -m 755 nvidia-gridd %{buildroot}%{_cross_bindir}/nvidia-gridd
 install -m 644 %{S:208} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
-install -p -m 0644 %{S:209} %{buildroot}%{_cross_unitdir}
+install -p -m 0644 %{S:209} %{S:210} %{S:211} %{S:212} %{S:213} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
+install -p -m 0644 %{S:214} %{buildroot}%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d
 popd
 # End GRID driver
 %endif
@@ -754,6 +761,11 @@ popd
 %{_cross_bindir}/nvidia-gridd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/gridd.conf
 %{_cross_unitdir}/nvidia-gridd.service
+%{_cross_unitdir}/grid-license-check.service
+%{_cross_unitdir}/grid-license-check.timer
+%{_cross_unitdir}/open-gpu-license-fallback.service
+%{_cross_unitdir}/tesla-license-fallback.service
+%{_cross_unitdir}/nvidia-k8s-device-plugin.service.d/grid-license-file-check.conf
 
 %{_cross_datadir}/nvidia/grid/drivers/nvidia.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-uvm.ko

--- a/packages/kmod-6.12-nvidia-r580/open-gpu-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r580/open-gpu-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Open GPU GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r580/tesla-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r580/tesla-license-fallback.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tesla GRID License Check Fallback
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver tesla
+ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
+ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
+RemainAfterExit=true
+
+[Install]
+WantedBy=nvidia-k8s-device-plugin.service


### PR DESCRIPTION
**Description of changes:**
The GRID driver requires a license to fully function. This currently is fetched as a best effort but a node can come up without a "Licensed" driver and fail later after some amount of time. This change a new file to confirm the license has been correctly acquired or is not needed. This includes a drop in for nvidia-k8s-device-plugin.service to depend on this file:
```
ExecStartPre=/usr/bin/test -f /etc/drivers/.grid-licensed
```
This will be before the `ExecStart` so that the device plugin will not register GPUs unless the license is not required or properly configured.

**Testing done:**
WIP - I'm updating the testing with the new approach for every use case but the primary use cases (GRID, open-gpu, and proprietary) all provide the correct experience. 

Built this change and confirmed that it does not run on a G6 (which uses open-gpu, not GRID so this isn't required), fails to have the node become ready when `nvidia-gridd` is misconfigured to not start. And the nodes become ready as expected when `nvidia-gridd` starts running normally.

Normal g6f.xlarge
```
bash-5.1# journalctl -u grid-license-check.service
Dec 03 16:50:39 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 16:50:39 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: grid-license-check.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 16:50:39 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
Dec 03 16:50:39 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: Failed to start GRID License Check.
Dec 03 16:50:40 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 16:50:41 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: grid-license-check.service: Deactivated successfully.
Dec 03 16:50:41 ip-192-168-52-46.us-west-2.compute.internal systemd[1]: Finished GRID License Check.
bash-5.1# ls -al /etc/drivers/.grid-licensed
-rw-r--r--. 1 root root 0 Dec  3 16:50 /etc/drivers/.grid-licensedt-2.compute.internal systemd[1]: Finished GRID License Check.
```

Broken nvidia-gridd results in the node becoming ready but in degraded systemd state and no GPUs offered:
```
bash-5.1# systemctl status
● ip-192-168-71-6.us-west-2.compute.internal
    State: degraded
    Units: 461 loaded (incl. loaded aliases)
     Jobs: 3 queued
   Failed: 1 units
    Since: Wed 2025-12-03 21:24:43 UTC; 46min ago
  systemd: 257.9
  Tainted: unmerged-bin
   CGroup: /


bash-5.1# journalctl -u grid-license-check.service
Dec 03 21:24:55 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 21:24:55 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 21:24:55 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
Dec 03 21:24:55 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Failed to start GRID License Check.
Dec 03 21:24:56 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 21:24:56 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 21:24:56 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
Dec 03 21:24:56 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Failed to start GRID License Check.
Dec 03 21:24:57 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 21:24:57 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 21:24:57 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
Dec 03 21:24:57 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Failed to start GRID License Check.
Dec 03 21:24:59 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 21:25:00 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 21:25:00 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
Dec 03 21:25:00 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Failed to start GRID License Check.
Dec 03 21:25:03 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 21:25:03 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Main process exited, code=exited, status=1/FAILURE
Dec 03 21:25:03 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
Dec 03 21:25:03 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: Failed to start GRID License Check.
Dec 03 21:25:06 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Start request repeated too quickly.
Dec 03 21:25:06 ip-192-168-71-6.us-west-2.compute.internal systemd[1]: grid-license-check.service: Failed with result 'exit-code'.
.... 
# this continues as long as the instances is up but no license exists
```

Output from journal on a g6.2xlarge which uses the fallback:
```
bash-5.1# journalctl -u grid-license-check.service
Dec 03 16:52:46 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 16:52:46 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: grid-license-check.service: Skipped due to 'exec-condition'.
Dec 03 16:52:46 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Condition check resulted in GRID License Check being skipped.
Dec 03 16:52:48 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Starting GRID License Check...
Dec 03 16:52:48 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: grid-license-check.service: Skipped due to 'exec-condition'.
Dec 03 16:52:48 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Condition check resulted in GRID License Check being skipped.
bash-5.1# journalctl -u open-gpu-license-fallback.service
Dec 03 16:52:47 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Starting Open GPU GRID License Check Fallback...
Dec 03 16:52:48 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Finished Open GPU GRID License Check Fallback.
bash-5.1# journalctl -u nvidia-k8s-device-plugin
Dec 03 16:52:48 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Starting Start NVIDIA kubernetes device plugin...
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal systemd[1]: Started Start NVIDIA kubernetes device plugin.
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal nvidia-device-plugin[3114]: I1203 16:52:49.175860    3114 main.go:235] "Starting NVIDIA Device Plugin" version="unknown"
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal nvidia-device-plugin[3114]: I1203 16:52:49.175889    3114 main.go:238] Starting FS watcher for /var/lib/kubelet/device-plugins
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal nvidia-device-plugin[3114]: I1203 16:52:49.175949    3114 main.go:245] Starting OS watcher.
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal nvidia-device-plugin[3114]: I1203 16:52:49.176276    3114 main.go:260] Starting Plugins.
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal nvidia-device-plugin[3114]: I1203 16:52:49.176288    3114 main.go:317] Loading configuration.
Dec 03 16:52:49 ip-192-168-84-108.us-west-2.compute.internal nvidia-device-plugin[3114]: I1203 16:52:49.177360    3114 main.go:342] Updating config with default resource matching patterns.
....

# The file exists to let the device plugin start
bash-5.1# ls -al /etc/drivers/.grid-licensed
-rw-r--r--. 1 root root 0 Dec  3 16:52 /etc/drivers/.grid-licensed
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
