### PR TITLE
Add RTX PRO 6000 profiles

### DIFF
--- a/sources/nvidia-migmanager/src/main.rs
+++ b/sources/nvidia-migmanager/src/main.rs
@@ -97,6 +97,7 @@ enum NvidiaGpu {
     H100_80GB,
     H200_141GB,
     B200_180GB,
+    RtxPro6000_96GB,
     Other,
 }
 
@@ -210,6 +211,9 @@ fn get_gpu_model(pci_device_id: &str) -> Result<NvidiaGpu> {
     } else if pci_device_id.starts_with("0x2901") || pci_device_id.starts_with("0x2941") {
         info!("Found NVIDIA B200-180GB GPU.");
         Ok(NvidiaGpu::B200_180GB)
+    } else if pci_device_id.starts_with("0x2BB5") {
+        info!("Found NVIDIA RTX PRO 6000 Blackwell GPU.");
+        Ok(NvidiaGpu::RtxPro6000_96GB)
     } else {
         warn!("Found NVIDIA Device but couldn't confirm variant.");
         Ok(NvidiaGpu::Other)
@@ -402,6 +406,9 @@ fn enable_mig(mig_settings: NvidiaMigConfig, gpu_info: &[MigGpu]) -> Result<()> 
         Ok(NvidiaGpu::B200_180GB) => {
             process_mig_config::<NvidiaB200_180gbMigProfile>("b200.180gb", &mig_settings)
         }
+        Ok(NvidiaGpu::RtxPro6000_96GB) => {
+            process_mig_config::<NvidiaRtxPro6000_96gbMigProfile>("rtxpro6000.96gb", &mig_settings)
+        }
         _ => {
             let known_gpus: Vec<&str> = vec![
                 "a100.40gb",
@@ -409,6 +416,7 @@ fn enable_mig(mig_settings: NvidiaMigConfig, gpu_info: &[MigGpu]) -> Result<()> 
                 "h100.80gb",
                 "h200.141gb",
                 "b200.180gb",
+                "rtxpro6000.96gb",
             ];
             let mut filtered_map = mig_settings.profile;
             filtered_map.retain(|key, _| !known_gpus.contains(&key.as_str()));

--- a/sources/nvidia-migmanager/src/mig_profile.rs
+++ b/sources/nvidia-migmanager/src/mig_profile.rs
@@ -190,6 +190,32 @@ impl MigGpuProfile for NvidiaB200_180gbMigProfile {
     }
 }
 
+#[derive(Deserialize)]
+pub(crate) enum NvidiaRtxPro6000_96gbMigProfile {
+    #[serde(alias = "1g.24gb")]
+    #[serde(alias = "4")]
+    Mig1g24gb,
+
+    #[serde(alias = "2g.48gb")]
+    #[serde(alias = "2")]
+    Mig2g48gb,
+
+    #[serde(alias = "4g.96gb")]
+    #[serde(alias = "1")]
+    #[serde(other)]
+    Mig4g96gb,
+}
+
+impl MigGpuProfile for NvidiaRtxPro6000_96gbMigProfile {
+    fn get_mig_profile(&self) -> &str {
+        match self {
+            NvidiaRtxPro6000_96gbMigProfile::Mig4g96gb => "4g.96gb",
+            NvidiaRtxPro6000_96gbMigProfile::Mig2g48gb => "2g.48gb,2g.48gb",
+            NvidiaRtxPro6000_96gbMigProfile::Mig1g24gb => "1g.24gb,1g.24gb,1g.24gb,1g.24gb",
+        }
+    }
+}
+
 pub(crate) trait MigGpuProfile: for<'de> Deserialize<'de> {
     fn get_mig_profile(&self) -> &str;
 }


### PR DESCRIPTION
**Description of changes:**
Add the MIG profiles for RTX PRO 6000 devices. This change requires https://github.com/bottlerocket-os/bottlerocket-settings-sdk/pull/105 to allow the profile to be set.

<details>
Got the ID from `nvidia-smi`:

```
bash-5.1# nvidia-smi --query-gpu=pci.device_id,mig.mode.current,mig.mode.pending --format=csv,noheader
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
0x2BB510DE, Disabled, Disabled
```

The profiles as well:
```
bash-5.1# nvidia-smi mig -lgip
+-------------------------------------------------------------------------------+
| GPU instance profiles:                                                        |
| GPU   Name               ID    Instances   Memory     P2P    SM    DEC   ENC  |
|                                Free/Total   GiB              CE    JPEG  OFA  |
|===============================================================================|
|   0  MIG 1g.24gb         14     4/4        23.62      No     46     1     1   |
|                                                               1     1     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 1g.24gb+me      21     1/1        23.62      No     46     1     1   |
|                                                               1     1     1   |
+-------------------------------------------------------------------------------+
|   0  MIG 1g.24gb+gfx     47     4/4        23.62      No     46     1     1   |
|                                                               1     1     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 1g.24gb+me.all  65     1/1        23.62      No     46     4     4   |
|                                                               1     4     1   |
+-------------------------------------------------------------------------------+
|   0  MIG 1g.24gb-me      67     4/4        23.62      No     46     0     0   |
|                                                               1     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 2g.48gb          5     2/2        47.38      No     94     2     2   |
|                                                               2     2     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 2g.48gb+gfx     35     2/2        47.38      No     94     2     2   |
|                                                               2     2     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 2g.48gb+me.all  64     1/1        47.38      No     94     4     4   |
|                                                               2     4     1   |
+-------------------------------------------------------------------------------+
|   0  MIG 2g.48gb-me      66     2/2        47.38      No     94     0     0   |
|                                                               2     0     0   |
+-------------------------------------------------------------------------------+
|   0  MIG 4g.96gb          0     1/1        95.00      No     188    4     4   |
|                                                               4     4     1   |
+-------------------------------------------------------------------------------+
|   0  MIG 4g.96gb+gfx     32     1/1        95.00      No     188    4     4   |
|                                                               4     4     1   |
+-------------------------------------------------------------------------------+
```

</details>

**Testing done:**
Built `aws-k8s-1.34-nvidia` and tested setting the profile:
```
apiclient set settings.kubelet-device-plugins.nvidia.device-partitioning-strategy="mig"

apiclient apply <<EOF
[settings.kubelet-device-plugins.nvidia.mig.profile]
"rtxpro6000.96gb"="4"
EOF
```

<details>

The mig manager found the device:
```
bash-5.1# journalctl -u nvidia-migmanager
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal systemd[1]: Starting NVIDIA MIG manager service...
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] nvidia-migmanager started
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Fetching GPU devices data ...
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal nvidia-migmanager[29688]: 16:45:10 [INFO] Found NVIDIA RTX PRO 6000 Blackwell GPU.
Oct 24 16:45:10 ip-192-168-73-199.us-east-2.compute.internal systemd[1]: Finished NVIDIA MIG manager service.
```

Validated that the device is offering 32 vs 8:
```
Capacity:
...
  nvidia.com/gpu:     32
  pods:               110
Allocatable:
...
  nvidia.com/gpu:     32
  pods:               110
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
