### PR TITLE
kernel-6.1, -6.12: disable PCR 9 measurement

### DIFF
--- a/packages/kernel-6.1/1007-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+++ b/packages/kernel-6.1/1007-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
@@ -1,0 +1,33 @@
+From fa0eefb655d457b24bdaffab3e7beb968faae223 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 4 Nov 2025 16:42:55 +0000
+Subject: [PATCH] efi/libstub: don't measure kernel command line into PCR 9
+
+The kernel command line can be extended via bootconfig, which may add
+additional parameters but depends on initrd parsing that happens at a
+later point in the boot.
+
+Disable the boot-time measurement so that the verified userspace can
+perform a complete measurement later.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ drivers/firmware/efi/libstub/efi-stub-helper.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/firmware/efi/libstub/efi-stub-helper.c b/drivers/firmware/efi/libstub/efi-stub-helper.c
+index 587ba946ba9d..e932673f5209 100644
+--- a/drivers/firmware/efi/libstub/efi-stub-helper.c
++++ b/drivers/firmware/efi/libstub/efi-stub-helper.c
+@@ -431,9 +431,11 @@ char *efi_convert_cmdline(efi_loaded_image_t *image, int *cmd_line_len)
+ 	efi_status_t status;
+ 	u32 options_chars;
+ 
++#if 0
+ 	if (options_size > 0)
+ 		efi_measure_tagged_event((unsigned long)options, options_size,
+ 					 EFISTUB_EVT_LOAD_OPTIONS);
++#endif
+ 
+ 	efi_apply_loadoptions_quirk((const void **)&options, &options_size);
+ 	options_chars = options_size / sizeof(efi_char16_t);

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -57,6 +57,8 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 # Backport patch to ensure NUL-terminated task->comm buffer
 Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
+# Disable incomplete measurement into PCR 9 on aarch64.
+Patch1007: 1007-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.12/1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+++ b/packages/kernel-6.12/1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
@@ -1,0 +1,33 @@
+From 7582a3b837ddffaddf2a4121285464b8655fe4f0 Mon Sep 17 00:00:00 2001
+From: Ben Cressey <bcressey@amazon.com>
+Date: Tue, 4 Nov 2025 16:42:55 +0000
+Subject: [PATCH] efi/libstub: don't measure kernel command line into PCR 9
+
+The kernel command line can be extended via bootconfig, which may add
+additional parameters but depends on initrd parsing that happens at a
+later point in the boot.
+
+Disable the boot-time measurement so that the verified userspace can
+perform a complete measurement later.
+
+Signed-off-by: Ben Cressey <bcressey@amazon.com>
+---
+ drivers/firmware/efi/libstub/efi-stub-helper.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/firmware/efi/libstub/efi-stub-helper.c b/drivers/firmware/efi/libstub/efi-stub-helper.c
+index 1ad414da9920..f8363a5d31f7 100644
+--- a/drivers/firmware/efi/libstub/efi-stub-helper.c
++++ b/drivers/firmware/efi/libstub/efi-stub-helper.c
+@@ -338,9 +338,11 @@ char *efi_convert_cmdline(efi_loaded_image_t *image, int *cmd_line_len)
+ 	efi_status_t status;
+ 	u32 options_chars;
+ 
++#if 0
+ 	if (options_size > 0)
+ 		efi_measure_tagged_event((unsigned long)options, options_size,
+ 					 EFISTUB_EVT_LOAD_OPTIONS);
++#endif
+ 
+ 	efi_apply_loadoptions_quirk((const void **)&options, &options_size);
+ 	options_chars = options_size / sizeof(efi_char16_t);

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -60,6 +60,8 @@ Patch1005: 1005-Lustre-cast-unsigned-long-to-pointer.patch
 Patch1006: 1006-Select-prerequisites-for-gpu-drivers.patch
 # Backport patch to ensure NUL-terminated task->comm buffer
 Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
+# Disable incomplete measurement into PCR 9 on aarch64.
+Patch1008: 1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Issue number:**
Related: https://github.com/bottlerocket-os/bottlerocket/issues/4680

**Description of changes:**
Since the kernel command line contains the dm-verity root hash, it reflects the exact root filesystem that's paired to that kernel. Consequently, it's useful to measure it into a PCR, and PCR 9 is standardized for this purpose.

For Bottlerocket, the kernel command line can additionally be extended by [bootconfig](https://docs.kernel.org/admin-guide/bootconfig.html), which is configurable via `settings.boot`. bootconfig data is not parsed until relatively late in the boot process, so it's not available when the kernel performs its PCR 9 measurement.

Disable the kernel's measurement - which currently only happens for aarch64 - to allow our verified userspace to measure the full kernel command line into PCR 9 later.

**Testing done:**
Verified that no PCR 9 measurements took place before exiting EFI boot services:
```
# tpm2_eventlog /sys/kernel/security/tpm0/binary_bios_measurements|grep 'PCRIndex: 9'
<no output>
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
