### PR TITLE
Include efa from efa-installer

### DIFF
--- a/packages/kernel-6.12/2000-config-efa.cmake-execute-config-tests-in-serial.patch
+++ b/packages/kernel-6.12/2000-config-efa.cmake-execute-config-tests-in-serial.patch
@@ -1,0 +1,41 @@
+From ca4c769ebfd7aa545ace9ebe8df7e250619c1c8e Mon Sep 17 00:00:00 2001
+From: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+Date: Wed, 12 Nov 2025 03:12:41 +0000
+Subject: [PATCH] config/efa.cmake: execute config tests in serial
+
+Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
+---
+ config/efa.cmake | 10 ++--------
+ 1 file changed, 2 insertions(+), 8 deletions(-)
+
+diff --git a/config/efa.cmake b/config/efa.cmake
+index 5bdad0b..02fc5f4 100644
+--- a/config/efa.cmake
++++ b/config/efa.cmake
+@@ -53,15 +53,10 @@ include(ProcessorCount)
+ ProcessorCount(max_process)
+ 
+ function(try_compile prologue body success_def fail_def)
+-  # Rate limit processes
+-  process_rl()
+   set_conf_tmp_dir("${prologue}" "${body}")
+-  execute_process(COMMAND ${CMAKE_SOURCE_DIR}/config/runbg.sh ${CMAKE_SOURCE_DIR}/config/compile_conftest.sh ${CMAKE_CURRENT_BINARY_DIR}/${tmp_dir} ${KERNEL_DIR} "${success_def}" "${fail_def}"
++  execute_process(COMMAND ${CMAKE_SOURCE_DIR}/config/compile_conftest.sh ${CMAKE_CURRENT_BINARY_DIR}/${tmp_dir} ${KERNEL_DIR} "${success_def}" "${fail_def}"
+     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+-    OUTPUT_STRIP_TRAILING_WHITESPACE
+-    OUTPUT_VARIABLE pid)
+-  list(APPEND pids ${pid})
+-  set(pids "${pids}" CACHE INTERNAL "")
++    RESULT_VARIABLE res)
+ endfunction()
+ 
+ function(try_compile_dev_or_ops fp_name prologue fn success_def fail_def)
+@@ -535,5 +530,4 @@ struct ib_mr *efa_reg_user_mr_dmabuf(struct ib_pd *ibpd, u64 start, u64 length,
+   "
+   HAVE_REG_USER_MR_DMAH "")
+ 
+-wait_for_pids()
+ message("-- Inspecting kernel - done")
+-- 
+2.50.1
+

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -27,5 +27,9 @@ sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm"
 sha512 = "2892ad1c6c4ff670d8e4aa0151af57b2b437f647a58ffa58901377b2ddeb504a9e4cce6c148643f8340e1ede8bb26ab66039b0a6bbb184bf5d647c6c71720186"
 
+[[package.metadata.build-package.external-files]]
+url = "https://efa-installer.amazonaws.com/aws-efa-installer-1.44.0.tar.gz"
+sha512 = "eaa336d8eb2affed5f5960a133af9f98b2b113c2dde17246c51947324f2318710012e7bced124e73f7113c8261748aaa0f4856063d71340b2d85a7f089551526"
+
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.12/EFACMakeLists.txt.in
+++ b/packages/kernel-6.12/EFACMakeLists.txt.in
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+project(efa C)
+
+set(KERNEL_VER "__KERNEL_VERSION__")
+set(KERNEL_DIR "__KERNEL_DIR__")
+set(KERNEL_MAKEFILE "__KERNEL_MAKEFILE__")
+
+set(GCOV_PROFILE OFF CACHE BOOL "Enable GCOV profiling")
+set(ENABLE_P2P ON CACHE BOOL "Enable Peer-to-peer memory")
+set(ENABLE_KVERBS ON CACHE BOOL "Enable kernel verbs support")
+
+add_subdirectory(src)

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -17,6 +17,7 @@ Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarc
 # Use latest-neuron-srpm-url.sh to get this.
 Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
+Source5: https://efa-installer.amazonaws.com/aws-efa-installer-1.44.0.tar.gz
 
 # Custom Bottlerocket kernel configurations.
 Source100: config-bottlerocket
@@ -46,6 +47,9 @@ Source224: load-neuron-latest-modules.service
 Source300: bootconfig-aws.conf
 Source301: bootconfig-vmware.conf
 
+# Replace upstream CMakeLists.txt with one that allows overriding kernel paths.
+Source400: EFACMakeLists.txt.in
+
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
 # Expose tools/* targets for out-of-tree module builds.
@@ -62,6 +66,8 @@ Patch1006: 1006-Select-prerequisites-for-gpu-drivers.patch
 Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1008: 1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+# Execute EFA tests in serial; concurrency doesn't work with the `make prepare` patch.
+Patch2000: 2000-config-efa.cmake-execute-config-tests-in-serial.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel
@@ -197,7 +203,7 @@ for patch in ${patches[@]}; do
     patch -p1 <../"$patch"
 done
 # Patches listed in this spec (Patch0001...)
-%autopatch -p1
+%autopatch -p1 -m 1000 -M 1999
 
 %if "%{_cross_arch}" == "x86_64"
 microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P\n' | sort | tr '\n' ' ')"
@@ -232,9 +238,9 @@ if ! diff "${KCONFIG_CONFIG}" "${SOURCE_FILE}"; then
 fi
 
 rm -f ../config-* ../*.patch
+cd %{_builddir}
 
 %if "%{_cross_arch}" == "x86_64"
-cd %{_builddir}
 # 2.21 for inf1 support
 rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
@@ -252,14 +258,29 @@ find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_latest \;
 rm -r usr
 %endif
 
-%global kmake \
-make -s\\\
-  ARCH="%{_cross_karch}"\\\
-  CROSS_COMPILE="%{_cross_target}-"\\\
-  INSTALL_HDR_PATH="%{buildroot}%{_cross_prefix}"\\\
-  INSTALL_MOD_PATH="%{buildroot}%{_cross_prefix}"\\\
-  INSTALL_MOD_STRIP=1\\\
-%{nil}
+# EFA driver
+tar -xf %{S:5}
+rpm2cpio aws-efa-installer/RPMS/ALINUX2023/%{_cross_arch}/efa-driver/efa-*.%{_cross_arch}.rpm | cpio -idmu './usr/src/efa-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} efa_driver \;
+rm -r aws-efa-installer
+mkdir efa_driver/build
+sed \
+  -e "s|__KERNEL_VERSION__|%{version}|g" \
+  -e "s|__KERNEL_DIR__|%{builddir}/linux-%{version}|g" \
+  -e "s|__KERNEL_MAKEFILE__|%{builddir}/linux-%{version}/Makefile|g" %{S:400} > efa_driver/CMakeLists.txt
+
+pushd efa_driver
+%patch -P 2000 -p1 -d .
+popd
+
+%global kmake %{shrink: \
+make -s \
+  ARCH="%{_cross_karch}" \
+  CROSS_COMPILE="%{_cross_target}-" \
+  INSTALL_HDR_PATH="%{buildroot}%{_cross_prefix}" \
+  INSTALL_MOD_PATH="%{buildroot}%{_cross_prefix}" \
+  INSTALL_MOD_STRIP=1 \
+  %{nil}}
 
 %build
 %kmake mrproper
@@ -271,6 +292,18 @@ make -s\\\
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_21
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
 %endif
+
+# Build EFA driver
+pushd %{_builddir}/efa_driver/build
+sed -i -e 's,$(MAKE),%{kmake},g' ../config/Makefile
+
+# Prevent polluting the parent environment by configuring CMAKE in a subshell
+(
+%{cross_cmake} ..
+)
+
+%kmake %{?_smp_mflags} M=%{_builddir}/efa_driver/build modules
+popd
 
 make -C tools/bpf/bpftool bootstrap
 ./tools/bpf/bpftool/bootstrap/bpftool btf dump file vmlinux format c > vmlinux.h
@@ -287,6 +320,7 @@ install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2_21/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
 mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 %endif
+mv %{_builddir}/efa_driver/build/src/efa.%{_ko} %{buildroot}%{_cross_kmoddir}/kernel/drivers/amazon/net/efa/
 
 install -d %{buildroot}/boot
 install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz


### PR DESCRIPTION
**Issue**

Closes: #312

**Description of changes:**

The EFA driver in the Amazon Linux kernel can have some delay between when the installer is released and it making it into the kernel tree. This adds a build step to update the driver from the installer to get the latest changes as soon as the installer is available.

**Testing done:**

@vigh-m tested the change (thanks!)

<details>

```bash
bash-5.1# modinfo efa
filename:       /lib/modules/6.12.53/kernel/drivers/amazon/net/efa/efa.ko
description:    Elastic Fabric Adapter (EFA)
license:        Dual BSD/GPL
author:         Amazon.com, Inc. or its affiliates
softdep:        pre: ib_uverbs
version:        2.17.3g
srcversion:     78EE70912A60CFABFF7A78E
alias:          pci:v00001D0Fd0000EFA3sv*sd*bc*sc*i*
alias:          pci:v00001D0Fd0000EFA2sv*sd*bc*sc*i*
alias:          pci:v00001D0Fd0000EFA1sv*sd*bc*sc*i*
alias:          pci:v00001D0Fd0000EFA0sv*sd*bc*sc*i*
depends:        ib_uverbs,ib_core
name:           efa
retpoline:      Y
vermagic:       6.12.53 SMP preempt mod_unload modversions
```

```bash
        [1,0]<stdout>:        2048            32     float    none      -1   106.88    0.02    0.02       0   111.25    0.02    0.02    N/A
        [1,0]<stdout>:        4096            64     float    none      -1   108.09    0.04    0.04       0   116.71    0.04    0.03    N/A
        [1,0]<stdout>:        8192           128     float    none      -1   104.22    0.08    0.07       0   117.86    0.07    0.07    N/A
        [1,0]<stdout>:       16384           256     float    none      -1   111.35    0.15    0.14       0   110.76    0.15    0.14    N/A
        [1,0]<stdout>:       32768           512     float    none      -1   114.40    0.29    0.27       0   112.46    0.29    0.27    N/A
        [1,0]<stdout>:       65536          1024     float    none      -1   122.32    0.54    0.50       0   114.84    0.57    0.54    N/A
        [1,0]<stdout>:      131072          2048     float    none      -1   129.31    1.01    0.95       0   133.03    0.99    0.92    N/A
        [1,0]<stdout>:      262144          4096     float    none      -1   161.17    1.63    1.52       0   151.94    1.73    1.62    N/A
        [1,0]<stdout>:      524288          8192     float    none      -1   212.76    2.46    2.31       0   223.82    2.34    2.20    N/A
        [1,0]<stdout>:     1048576         16384     float    none      -1   303.15    3.46    3.24       0   294.36    3.56    3.34    N/A
        [1,0]<stdout>:     2097152         32768     float    none      -1   417.95    5.02    4.70       0   417.58    5.02    4.71    N/A
        [1,0]<stdout>:     4194304         65536     float    none      -1   641.11    6.54    6.13       0   650.81    6.44    6.04    N/A
        [1,0]<stdout>:     8388608        131072     float    none      -1  1203.19    6.97    6.54       0  1156.25    7.26    6.80    N/A
        [1,0]<stdout>:    16777216        262144     float    none      -1  1929.85    8.69    8.15       0  1898.98    8.83    8.28    N/A
        [1,0]<stdout>:    33554432        524288     float    none      -1  3404.45    9.86    9.24       0  3501.64    9.58    8.98    N/A
        [1,0]<stdout>:    67108864       1048576     float    none      -1  6430.14   10.44    9.78       0  6539.67   10.26    9.62    N/A
        [1,0]<stdout>:   134217728       2097152     float    none      -1  12415.7   10.81   10.13       0  12439.1   10.79   10.12    N/A
        [1,0]<stdout>:   268435456       4194304     float    none      -1  24417.4   10.99   10.31       0  24422.7   10.99   10.30    N/A
        [1,0]<stdout>:   536870912       8388608     float    none      -1  48484.6   11.07   10.38       0  48437.9   11.08   10.39    N/A
        [1,0]<stdout>:  1073741824      16777216     float    none      -1  96677.8   11.11   10.41       0  96700.7   11.10   10.41    N/A
        [1,0]<stdout>:  2147483648      33554432     float    none      -1   193577   11.09   10.40       0   193607   11.09   10.40    N/A
        [1,7]<stdout>:multi-node-alltoall-perf-worker-0:60:143 [7] NCCL INFO comm 0x555e87a27e50 rank 7 nranks 16 cudaDev 7 busId a01d0 - Destroy COMPLETE
        [1,5]<stdout>:multi-node-alltoall-perf-worker-0:54:139 [5] NCCL INFO comm 0x564172fd8f20 rank 5 nranks 16 cudaDev 5 busId 901d0 - Destroy COMPLETE
        [1,8]<stdout>:multi-node-alltoall-perf-worker-1:47:142 [0] NCCL INFO comm 0x564f89ad3050 rank 8 nranks 16 cudaDev 0 busId 101c0 - Destroy COMPLETE
        [1,10]<stdout>:multi-node-alltoall-perf-worker-1:49:138 [2] NCCL INFO comm 0x55c3039f2420 rank 10 nranks 16 cudaDev 2 busId 201c0 - Destroy COMPLETE
        [1,0]<stdout>:multi-node-alltoall-perf-worker-0:47:141 [0] NCCL INFO comm 0x559509694b90 rank 0 nranks 16 cudaDev 0 busId 101c0 - Destroy COMPLETE
        [1,0]<stdout>:# Out of bounds values : 0 OK
        [1,0]<stdout>:# Avg bus bandwidth    : 3.62885
        [1,0]<stdout>:#
        [1,0]<stdout>:# Collective test concluded: alltoall_perf
        [1,12]<stdout>:multi-node-alltoall-perf-worker-1:51:140 [4] NCCL INFO comm 0x55e1e5e34c30 rank 12 nranks 16 cudaDev 4 busId 901c0 - Destroy COMPLETE
        [1,14]<stdout>:multi-node-alltoall-perf-worker-1:55:139 [6] NCCL INFO comm 0x56117bd21510 rank 14 nranks 16 cudaDev 6 busId a01c0 - Destroy COMPLETE
        [1,4]<stdout>:multi-node-alltoall-perf-worker-0:52:137 [4] NCCL INFO comm 0x55e0f2e481b0 rank 4 nranks 16 cudaDev 4 busId 901c0 - Destroy COMPLETE
        [1,2]<stdout>:multi-node-alltoall-perf-worker-0:49:136 [2] NCCL INFO comm 0x55bda1d012c0 rank 2 nranks 16 cudaDev 2 busId 201c0 - Destroy COMPLETE
        [1,6]<stdout>:multi-node-alltoall-perf-worker-0:58:140 [6] NCCL INFO comm 0x560433af21c0 rank 6 nranks 16 cudaDev 6 busId a01c0 - Destroy COMPLETE
        [1,15]<stdout>:multi-node-alltoall-perf-worker-1:59:141 [7] NCCL INFO comm 0x560425ad2d00 rank 15 nranks 16 cudaDev 7 busId a01d0 - Destroy COMPLETE
        [1,13]<stdout>:multi-node-alltoall-perf-worker-1:53:136 [5] NCCL INFO comm 0x564507ca2340 rank 13 nranks 16 cudaDev 5 busId 901d0 - Destroy COMPLETE
        [1,9]<stdout>:multi-node-alltoall-perf-worker-1:48:137 [1] NCCL INFO comm 0x56295e016170 rank 9 nranks 16 cudaDev 1 busId 101d0 - Destroy COMPLETE
        [1,11]<stdout>:multi-node-alltoall-perf-worker-1:50:135 [3] NCCL INFO comm 0x5586b0cafd30 rank 11 nranks 16 cudaDev 3 busId 201d0 - Destroy COMPLETE
        [1,1]<stdout>:multi-node-alltoall-perf-worker-0:48:142 [1] NCCL INFO comm 0x558a750c1560 rank 1 nranks 16 cudaDev 1 busId 101d0 - Destroy COMPLETE
        [1,3]<stdout>:multi-node-alltoall-perf-worker-0:50:138 [3] NCCL INFO comm 0x55ce95020d80 rank 3 nranks 16 cudaDev 3 busId 201d0 - Destroy COMPLETE
        [1,0]<stdout>:

    mpi_test.go:124: Multi node job completed
--- PASS: TestMPIJobPytorchTraining (325.30s)
    --- SKIP: TestMPIJobPytorchTraining/single-node (0.00s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:all_reduce_perf (240.10s)
        --- PASS: TestMPIJobPytorchTraining/multi-node:all_reduce_perf/MPIJob_succeeds (240.06s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:all_gather_perf (45.11s)
        --- PASS: TestMPIJobPytorchTraining/multi-node:all_gather_perf/MPIJob_succeeds (45.06s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:alltoall_perf (40.09s)
        --- PASS: TestMPIJobPytorchTraining/multi-node:alltoall_perf/MPIJob_succeeds (40.06s)
=== RUN   TestSingleNodeUnitTest
=== RUN   TestSingleNodeUnitTest/unit-test
    unit_test.go:139: Skipping feature "unit-test": name not matched
=== RUN   TestSingleNodeUnitTest/hpc-benckmarks
    unit_test.go:139: Skipping feature "hpc-benckmarks": name not matched
--- PASS: TestSingleNodeUnitTest (0.00s)
    --- SKIP: TestSingleNodeUnitTest/unit-test (0.00s)
    --- SKIP: TestSingleNodeUnitTest/hpc-benckmarks (0.00s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 342.083s
```
</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
