### PR TITLE
Include efa from efa-installer for 6.1 kernel

### DIFF
--- a/packages/kernel-6.1/1001-Makefile-add-prepare-target-for-external-modules.patch
+++ b/packages/kernel-6.1/1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -1,4 +1,4 @@
-From e6e9b5adc830c0924d81c348c8d5b12e3dc4242e Mon Sep 17 00:00:00 2001
+From 0484df519ed944a0e164b4d104e1adc9e851fc0f Mon Sep 17 00:00:00 2001
 From: Ben Cressey <bcressey@amazon.com>
 Date: Mon, 19 Apr 2021 18:46:04 +0000
 Subject: [PATCH] Makefile: add prepare target for external modules
@@ -27,19 +27,19 @@ Signed-off-by: Arnaldo Garcia Rincon <agarrcia@amazon.com>
  1 file changed, 13 insertions(+)
 
 diff --git a/Makefile b/Makefile
-index 23390805e..2f78ac123 100644
+index d8625400c..61273e589 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -1874,6 +1874,19 @@ else # KBUILD_EXTMOD
+@@ -1891,6 +1891,19 @@ else # KBUILD_EXTMOD
  KBUILD_BUILTIN :=
  KBUILD_MODULES := 1
  
 +PHONY += modules_prepare
 +modules_prepare:
-+	$(Q)$(MAKE) $(build)=scripts/basic
-+	$(Q)$(MAKE) $(build)=scripts/dtc
-+	$(Q)$(MAKE) $(build)=scripts/mod
-+	$(Q)$(MAKE) $(build)=scripts
++	$(PREPARE) $(Q)$(MAKE) $(build)=scripts/basic
++	$(PREPARE) $(Q)$(MAKE) $(build)=scripts/dtc
++	$(PREPARE) $(Q)$(MAKE) $(build)=scripts/mod
++	$(PREPARE) $(Q)$(MAKE) $(build)=scripts
 +
 +ifdef CONFIG_OBJTOOL
 +prepare: tools/objtool
@@ -51,5 +51,5 @@ index 23390805e..2f78ac123 100644
  
  compile_commands.json: $(extmod_prefix)compile_commands.json
 -- 
-2.40.0
+2.50.1
 

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -27,5 +27,9 @@ sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm"
 sha512 = "2892ad1c6c4ff670d8e4aa0151af57b2b437f647a58ffa58901377b2ddeb504a9e4cce6c148643f8340e1ede8bb26ab66039b0a6bbb184bf5d647c6c71720186"
 
+[[package.metadata.build-package.external-files]]
+url = "https://efa-installer.amazonaws.com/aws-efa-installer-1.44.0.tar.gz"
+sha512 = "eaa336d8eb2affed5f5960a133af9f98b2b113c2dde17246c51947324f2318710012e7bced124e73f7113c8261748aaa0f4856063d71340b2d85a7f089551526"
+
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/EFACMakeLists.txt.in
+++ b/packages/kernel-6.1/EFACMakeLists.txt.in
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.10)
+project(efa C)
+
+set(KERNEL_VER "__KERNEL_VERSION__")
+set(KERNEL_DIR "__KERNEL_DIR__")
+set(KERNEL_MAKEFILE "__KERNEL_MAKEFILE__")
+
+set(GCOV_PROFILE OFF CACHE BOOL "Enable GCOV profiling")
+set(ENABLE_P2P ON CACHE BOOL "Enable Peer-to-peer memory")
+set(ENABLE_KVERBS ON CACHE BOOL "Enable kernel verbs support")
+
+add_subdirectory(src)

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -14,6 +14,7 @@ Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarc
 # Use latest-neuron-srpm-url.sh to get this.
 Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
+Source5: https://efa-installer.amazonaws.com/aws-efa-installer-1.44.0.tar.gz
 
 # Custom Bottlerocket kernel configurations.
 Source100: config-bottlerocket
@@ -43,6 +44,9 @@ Source224: load-neuron-latest-modules.service
 Source300: bootconfig-aws.conf
 Source301: bootconfig-vmware.conf
 Source302: bootconfig-metal.conf
+
+# Replace upstream CMakeLists.txt with one that allows overriding kernel paths.
+Source400: EFACMakeLists.txt.in
 
 # Help out-of-tree module builds run `make prepare` automatically.
 Patch1001: 1001-Makefile-add-prepare-target-for-external-modules.patch
@@ -256,9 +260,9 @@ if ! diff "${KCONFIG_CONFIG}" "${SOURCE_FILE}"; then
 fi
 
 rm -f ../config-* ../*.patch
+cd %{_builddir}
 
 %if "%{_cross_arch}" == "x86_64"
-cd %{_builddir}
 # 2.21 for inf1 support
 rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
@@ -276,14 +280,25 @@ find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_latest \;
 rm -r usr
 %endif
 
-%global kmake \
-make -s\\\
-  ARCH="%{_cross_karch}"\\\
-  CROSS_COMPILE="%{_cross_target}-"\\\
-  INSTALL_HDR_PATH="%{buildroot}%{_cross_prefix}"\\\
-  INSTALL_MOD_PATH="%{buildroot}%{_cross_prefix}"\\\
-  INSTALL_MOD_STRIP=1\\\
-%{nil}
+# EFA driver
+tar -xf %{S:5}
+rpm2cpio aws-efa-installer/RPMS/ALINUX2023/%{_cross_arch}/efa-driver/efa-*.%{_cross_arch}.rpm | cpio -idmu './usr/src/efa-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} efa_driver \;
+rm -r aws-efa-installer
+mkdir efa_driver/build
+sed \
+  -e "s|__KERNEL_VERSION__|%{version}|g" \
+  -e "s|__KERNEL_DIR__|%{builddir}/linux-%{version}|g" \
+  -e "s|__KERNEL_MAKEFILE__|%{builddir}/linux-%{version}/Makefile|g" %{S:400} > efa_driver/CMakeLists.txt
+
+%global kmake %{shrink: \
+make -s \
+  ARCH="%{_cross_karch}" \
+  CROSS_COMPILE="%{_cross_target}-" \
+  INSTALL_HDR_PATH="%{buildroot}%{_cross_prefix}" \
+  INSTALL_MOD_PATH="%{buildroot}%{_cross_prefix}" \
+  INSTALL_MOD_STRIP=1 \
+  %{nil}}
 
 %build
 %kmake mrproper
@@ -295,6 +310,18 @@ make -s\\\
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_21
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
 %endif
+
+# Build EFA driver
+pushd %{_builddir}/efa_driver/build
+sed -i -e 's,$(MAKE),PREPARE=true %{kmake},g' ../config/Makefile
+
+# Prevent polluting the parent environment by configuring CMAKE in a subshell
+(
+%{cross_cmake} ..
+)
+
+%kmake %{?_smp_mflags} M=%{_builddir}/efa_driver/build modules
+popd
 
 %install
 %kmake %{?_smp_mflags} headers_install
@@ -308,6 +335,9 @@ install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2_21/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
 mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 %endif
+
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=efa_driver M=%{_builddir}/efa_driver/build/src V=1 modules_install
+mv %{buildroot}%{_cross_kmoddir}/efa_driver/efa.ko.gz %{buildroot}%{_cross_kmoddir}/kernel/drivers/amazon/net/efa/
 
 install -d %{buildroot}/boot
 install -T -m 0755 arch/%{_cross_karch}/boot/%{_cross_kimage} %{buildroot}/boot/vmlinuz


### PR DESCRIPTION
**Issue number:**

Closes #

**Description of changes:**

The EFA driver in the Amazon Linux kernel can have some delay between when the installer is released and it making it into the kernel tree. This adds a build step to update the driver from the installer to get the latest changes as soon as the installer is available.

As part of this change, the `efa.cmake` file was updated to do a serial execution of the tests to validate the available configurations in the kernel sources. This is a problem unique to Bottlerocket due to how out of tree kmod builds are treated.

**Testing done:**

**Pending**

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
