### PR TITLE
Move NVIDIA kmods to drivers.target

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/copy-grid-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r570/copy-grid-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r570/copy-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r570/copy-open-gpu-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r570/link-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r570/link-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r570/load-grid-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r570/load-grid-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r570/load-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r570/load-open-gpu-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r570/load-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r570/load-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/copy-grid-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r580/copy-grid-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/copy-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r580/copy-open-gpu-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/link-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r580/link-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/load-grid-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r580/load-grid-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/load-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r580/load-open-gpu-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/load-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.1-nvidia-r580/load-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r570/copy-grid-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r570/copy-grid-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r570/copy-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r570/copy-open-gpu-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r570/link-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r570/link-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r570/load-grid-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r570/load-grid-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r570/load-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r570/load-open-gpu-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r570/load-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r570/load-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/copy-grid-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r580/copy-grid-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/copy-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r580/copy-open-gpu-kernel-modules.service.in
@@ -17,4 +17,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/link-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r580/link-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/load-grid-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r580/load-grid-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/load-open-gpu-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r580/load-open-gpu-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/load-tesla-kernel-modules.service.in
+++ b/packages/kmod-6.12-nvidia-r580/load-tesla-kernel-modules.service.in
@@ -16,4 +16,4 @@ RemainAfterExit=true
 StandardError=journal+console
 
 [Install]
-RequiredBy=preconfigured.target
+RequiredBy=drivers.target


### PR DESCRIPTION
**Related to** : https://github.com/bottlerocket-os/bottlerocket/issues/4218#issuecomment-3272332222

**Description of changes:**
This change moves the NVIDIA kmod package to load before `drivers.target` instead of `preconfigured.target`. This allows us to separate the state of loading all kernel modules from the rest of configuration. 


**Testing done:**
Built NVIDIA variants for both arches and k8s 1.33 and ECS 2. Validated that the drivers come up for all 3 versions of the driver based upon hardware and fail as expected if no NVIDIA devices are present:

### Failure on m6i.large:
```
[  OK  ] Finished Sets the hostname.
[  OK  ] Finished Bootstrap Commands.
[  OK  ] Finished Link Tesla kernel modules.
         Starting Load Tesla kernel modules...
[   28.104268] NVRM: No NVIDIA GPU found.
[   28.426169] NVRM: No NVIDIA GPU found.
[   28.745379] NVRM: No NVIDIA GPU found.
[   28.932771] driverdog[1535]: 02:34:25 [ERROR] '/usr/bin/modprobe' failed - stderr: modprobe: ERROR: could not insert 'nvidia': No such device
[   28.934905] driverdog[1535]: modprobe: ERROR: could not insert 'nvidia_modeset': No such device
[   28.936271] driverdog[1535]: modprobe: ERROR: could not insert 'nvidia_uvm': No such device
[FAILED] Failed to start Load Tesla kernel modules.
See 'systemctl status load-tesla-kernel-modules.service' for details.
[DEPEND] Dependency failed for Driver units.
[DEPEND] Dependency failed for Bottlerocket initial configuration complete.
[DEPEND] Dependency failed for Activate configured.target.
         Starting NVIDIA Persistence Daemon...
[FAILED] Failed to start NVIDIA Persistence Daemon.
See 'systemctl status nvidia-persistenced.service' for details.
[DEPEND] Dependency failed for Generate CDI specifications.
         Starting NVIDIA Grid Daemon...
	2025-11-15T02:35:39+00:00
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
