### PR TITLE
kmod-6.12-amdgpu: update amdgpu to version 30.20.1

### DIFF
--- a/packages/kmod-6.12-amdgpu/Cargo.toml
+++ b/packages/kmod-6.12-amdgpu/Cargo.toml
@@ -13,8 +13,8 @@ releases-url = "https://repo.radeon.com/amdgpu/"
 path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
-url = "https://repo.radeon.com/amdgpu/30.20/el/10/main/x86_64/amdgpu-dkms-6.16.6-2238411.el10.noarch.rpm"
-sha512 = "978eff171b54e02cd831ff06d541506891f149037a7a81d3e48bb8ffb5e80b3964d529868bcce32a7f33e2a7ceb8ebbfb2900e4e5108231c4adb50c4b6b0bed8"
+url = "https://repo.radeon.com/amdgpu/30.20.1/el/10.1/main/x86_64/amdgpu-dkms-6.16.6-2255209.el10.noarch.rpm"
+sha512 = "a6abf721863e843ffdd5e78ccf76842c38cc22f50aacc35b0666a0c51d648c8ab32cb7248fab8da28a8155575a960119d7c677399fa9d019a3a2bd26510a479e"
 
 [build-dependencies]
 kernel-6_12 = { path = "../kernel-6.12" }

--- a/packages/kmod-6.12-amdgpu/kmod-6.12-amdgpu.spec
+++ b/packages/kmod-6.12-amdgpu/kmod-6.12-amdgpu.spec
@@ -5,13 +5,13 @@
 %global _ko ko
 
 Name: %{_cross_os}kmod-6.12-amdgpu
-Version: 30.20
+Version: 30.20.1
 Release: 1%{?dist}
 Summary: AMD GPU drivers for the 6.12 kernel
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only WITH Linux-syscall-note) AND GPL-2.0-or-later AND (GPL-2.0-or-later WITH Linux-syscall-note) AND LGPL-2.0-or-later AND (BSD-3-Clause OR GPL-2.0-only)
 URL: https://repo.radeon.com/amdgpu/
 
-Source0: https://repo.radeon.com/amdgpu/30.20/el/10/main/x86_64/amdgpu-dkms-6.16.6-2238411.el10.noarch.rpm
+Source0: https://repo.radeon.com/amdgpu/30.20.1/el/10.1/main/x86_64/amdgpu-dkms-6.16.6-2255209.el10.noarch.rpm
 Source1: gpgkey-9386B48A1A693C5C.asc
 
 BuildRequires: %{_cross_os}kernel-6.12-devel


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

## Description of changes:

  This PR updates the `kmod-6.12-amdgpu` package from version 30.20 to 30.20.1, incorporating the latest AMD GPU driver release.

  **Changes:**
  - Updated AMDGPU driver package from `amdgpu-dkms-6.16.6-2238411` to `amdgpu-dkms-6.16.6-2255209`
  - Updated source URL to point to AMD's 30.20.1 release repository (`https://repo.radeon.com/amdgpu/30.20.1/el/10.1/main/x86_64/`)
  - Updated SHA512 hash for the new RPM package
  - Verified GPG signature with existing key (gpgkey-9386B48A1A693C5C.asc)
  - Updated version number in spec file from 30.20 to 30.20.1

  ## Testing done:

Built a custom Bottlerocket AMI with the new AMDGPU version 30.20.1 and successfully launched it on hardware with 8 AMD GPUs.

  **Verification of installed package:**

  ```bash
  bash-5.1# cat /var/lib/bottlerocket/inventory/application.json | grep -i kmod-6.12-amdgpu -A 11 -B 1
      {
        "Name": "kmod-6.12-amdgpu",
        "Publisher": "bottlerocket-kernel-kit",
        "Version": "30.20.1",
        "Release": "1.1764180962.e1c03144.br1",
        "Epoch": "0",
        "InstalledTime": "2025-11-26T21:50:16Z",
        "ApplicationType": "Unspecified",
        "Architecture": "x86_64",
        "Url": "https://repo.radeon.com/amdgpu/",
        "Summary": "AMD GPU drivers for the 6.12 kernel"
      },
```

**Driver initialization confirmation (8 AMD GPUs successfully initialized):**

```bash
  bash-5.1# dmesg | grep -i "amd.*initialized"
  [    8.720736] amdgpu 0000:51:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   10.964144] amdgpu 0000:51:00.0: amdgpu: SMU is initialized successfully!
  [   11.618320] amdgpu 0000:52:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   13.876835] amdgpu 0000:52:00.0: amdgpu: SMU is initialized successfully!
  [   14.550825] amdgpu 0000:62:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   16.821963] amdgpu 0000:62:00.0: amdgpu: SMU is initialized successfully!
  [   17.523612] amdgpu 0000:63:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   19.799327] amdgpu 0000:63:00.0: amdgpu: SMU is initialized successfully!
  [   20.535028] amdgpu 0000:73:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   22.825446] amdgpu 0000:73:00.0: amdgpu: SMU is initialized successfully!
  [   23.589896] amdgpu 0000:74:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   25.898019] amdgpu 0000:74:00.0: amdgpu: SMU is initialized successfully!
  [   26.690606] amdgpu 0000:84:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   29.010831] amdgpu 0000:84:00.0: amdgpu: SMU is initialized successfully!
  [   29.829678] amdgpu 0000:85:00.0: amdgpu: RAS INFO: ras initialized successfully, hardware ability[65bff] ras_mask[65bff]
  [   32.153702] amdgpu 0000:85:00.0: amdgpu: SMU is initialized successfully!
```

**Module information:**

```bash
  bash-5.1# modinfo amdgpu | head -15
  filename:       /lib/modules/6.12.55/kernel/drivers/updates/gpu/drm/amd/amdgpu/amdgpu.ko
  version:        6.16.6
  license:        GPL and additional rights
  description:    AMD GPU
  author:         AMD linux driver team
  firmware:       amdgpu/cyan_skillfish_gpu_info.bin
  firmware:       amdgpu/navi12_gpu_info.bin
  firmware:       amdgpu/arcturus_gpu_info.bin
  firmware:       amdgpu/raven2_gpu_info.bin
  firmware:       amdgpu/picasso_gpu_info.bin
  firmware:       amdgpu/raven_gpu_info.bin
  firmware:       amdgpu/vega12_gpu_info.bin
  firmware:       amdgpu/vega10_gpu_info.bin
```

**Hardware detection (8x AMD GPU device 75a3 detected):**

```bash
  bash-5.1# lspci | grep -i "75a3"
  51:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  52:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  62:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  63:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  73:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  74:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  84:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  85:00.0 Processing accelerators: Advanced Micro Devices, Inc. [AMD/ATI] Device 75a3
  ```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
