### PR TITLE
libkcapi: update _spec_install_post override

### DIFF
--- a/packages/libkcapi/libkcapi.spec
+++ b/packages/libkcapi/libkcapi.spec
@@ -5,6 +5,7 @@
 # We need to compute the HMAC after the binaries have been stripped.
 %define __spec_install_post\
 %{?__debug_package:%{__debug_install_post}}\
+%{?__sbom_package:%{__sbom_install_post}}\
 %{__arch_install_post}\
 %{__os_install_post}\
 cd %{buildroot}/%{_cross_bindir}\


### PR DESCRIPTION

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->
**Description of changes:**
The new SBOM feature also overrides _spec_install post. Updating this overide to include the sbom override feature.



**Testing done:**
Built kernel kit


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
