### PR TITLE
Prepare for release 4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v4.6.1 (2025-12-10)
+## OS Changes
+* Update kernel from 6.1.158-178.288 to 6.1.158-180.294 ([#332])
+* Update kernel from 6.12.55-74.119 to 6.12.58-82.121 ([#333])
+
+## Build Changes
+* Update to Twoliter 0.14.0 ([#331])
+* Update libkcapi `_spec_install_post` override for SBOM feature compatibility ([#330])
+
+[#330]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/330
+[#331]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/331
+[#332]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/332
+[#333]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/333
+
 # v4.6.0 (2025-12-05)
 ## OS Changes
 * Add package definition for NVIDIA R580 driver for kernel-6.1 ([#304]). Thanks, @mselim00!

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "4.6.0"
+release-version = "4.6.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

- Update changelog for release `v4.6.1`
- Update kernel-6.1 from 6.1.158-178.288 to 6.1.158-180.294
- Update kernel-6.12 from 6.12.55-74.119 to 6.12.58-82.121

**Testing done:**

- Ran `make` and `make ARCH=aarch64`. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
