### PR TITLE
kernel-6.12: Update neuron to 2.25.4.0

### DIFF
--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -24,8 +24,8 @@ sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm.url.sh to get this.
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm"
-sha512 = "2892ad1c6c4ff670d8e4aa0151af57b2b437f647a58ffa58901377b2ddeb504a9e4cce6c148643f8340e1ede8bb26ab66039b0a6bbb184bf5d647c6c71720186"
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.25.4.0.noarch.rpm"
+sha512 = "aa0611880d14a17c01d9221b20305f95565ea54f74574f077e62dff200c8e5f8369ebc2d4039baebdcf5abe99b86c74c714d39a4aec049d02a7264a84275cce3"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -15,7 +15,7 @@ Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.21-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
-Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.7.0.noarch.rpm
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.25.4.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.


### PR DESCRIPTION
**Description of changes:**

aws-neuronx-dkms: **2.24.7.0** → **2.25.4.0**

**Testing done:**

- [x] Ran neuron test in `aws-k8s-tester` on `inf2.xlarge`.
<details>

```
2025/12/23 04:48:12 [INFO] Total Nodes: 2
2025/12/23 04:48:12 [INFO] Total Neuron Count: 2, Neuron Per Node: 1
2025/12/23 04:48:12 [INFO] Total Neuron Core Count: 4, Neuron Core Per Node: 2
2025/12/23 04:48:12 [INFO] Total EFA Count: 0, EFA Per Node: 0
=== RUN   TestNeuronNodes
=== RUN   TestNeuronNodes/single-node
    neuron_test.go:60: Applying single node manifest
    neuron_test.go:65: Manifest applied successfully
=== RUN   TestNeuronNodes/single-node/Single_node_test_Job_succeeds
    neuron_test.go:72: Waiting for single node job to complete
=== NAME  TestNeuronNodes/single-node
```
...
```
=== RUN   TestNeuronNodes/multi-node
    neuron_test.go:157: Skipping feature: "multi-node": name matched
--- PASS: TestNeuronNodes (450.08s)
    --- PASS: TestNeuronNodes/single-node (450.08s)
        --- PASS: TestNeuronNodes/single-node/Single_node_test_Job_succeeds (450.01s)
    --- SKIP: TestNeuronNodes/multi-node (0.00s)
PASS
```
</details>

- [x] Logged onto the node to make sure everything was as expected.
<details>

```
bash-5.1# modinfo neuron
filename:       /lib/modules/6.12.58/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.25.4.0
license:        GPL
description:    Neuron Driver, built from SHA: 5ebb67d2e5be7052dcf1774cff03c69ab40d21ee
import_ns:      DMA_BUF
srcversion:     8F4B84923F1778DB06BA152
depends:
name:           neuron
retpoline:      Y
vermagic:       6.12.58 SMP preempt mod_unload modversions
```
```
bash-5.1# systemctl status load-neuron-latest-modules
● load-neuron-latest-modules.service - Load Neuron Latest modules
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/load-neuron-latest-modules.service; enabled; preset: enabled)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf
     Active: active (exited) since Tue 2025-12-23 04:32:28 UTC; 14h ago
 Invocation: 504d6daa97c44db7a646e44d048a9cf7
   Main PID: 1606 (code=exited, status=0/SUCCESS)
   Mem peak: 150.5M
        CPU: 231ms

Dec 23 04:32:27 localhost systemd[1]: Starting Load Neuron Latest modules...
Dec 23 04:32:27 localhost driverdog[1555]: 04:32:27 [INFO] Copied neuron.ko
Dec 23 04:32:28 localhost driverdog[1606]: 04:32:28 [INFO] Updated modules dependencies
Dec 23 04:32:28 localhost driverdog[1606]: 04:32:28 [INFO] Loaded kernel modules
Dec 23 04:32:28 localhost systemd[1]: Finished Load Neuron Latest modules.
```
</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
