### PR TITLE
nvidia-migmanager: override SBOM generation for Rust package

### DIFF
--- a/packages/nvidia-migmanager/nvidia-migmanager.spec
+++ b/packages/nvidia-migmanager/nvidia-migmanager.spec
@@ -1,5 +1,12 @@
 %global _cross_first_party 1
 %undefine _debugsource_packages
+%global cross_generate_sbom %{shrink: \
+  mkdir -p %{_builddir}/sbom-temp && \
+  sbomtool generate \
+    --name nvidia-migmanager \
+    --out-dir %{_builddir}/sbom-temp \
+    --build-dir %{_builddir}/sources \
+    --spdx --cyclonedx}
 
 # Do not prefer shared linking, since the libstd we use at build time
 # may not match the one installed on the final image.


### PR DESCRIPTION
Rust packages using %cargo_build macros build to ${HOME}/.cache rather than %{_builddir}. Override %cross_generate_sbom to scan the correct directory for SBOM generation.

<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes #345

**Description of changes:**
Override cross_generate_sbom for first party rust packages to point to the correct sources directory.


**Testing done:**
Built Bottlerocket images and inspected SBOM files, ensure that Bottlerocket Rust dependencies showed up.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
