### PR TITLE
Add mps control server and control binaries to NVIDIA kmod packages

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -79,6 +79,7 @@ Requires: %{name}-open-gpu
 %if "%{_cross_arch}" == "x86_64"
 Requires: %{name}-grid
 %endif
+Requires: %{name}-mps
 
 %description
 %{summary}.
@@ -125,6 +126,13 @@ Provides: %{name}-tesla(fabricmanager)
 
 %description tesla
 %{summary}
+
+%package mps
+Summary: NVIDIA CUDA Multi-Process Service
+Requires: %{name}
+
+%description mps
+%{summary}.
 
 %prep
 # Extract nvidia sources with `-x`, otherwise the script will try to install
@@ -666,10 +674,7 @@ popd
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-peermem.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.mod.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.o
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
-%exclude %{_cross_bindir}/nvidia-cuda-mps-control
-%exclude %{_cross_bindir}/nvidia-cuda-mps-server
+
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-ngx-updater
 %exclude %{_cross_bindir}/nvidia-ngx-updater
@@ -734,3 +739,9 @@ popd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.env
 %{_cross_unitdir}/nvidia-fabricmanager.service
+
+%files mps
+%{_cross_bindir}/nvidia-cuda-mps-control
+%{_cross_bindir}/nvidia-cuda-mps-server
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server

--- a/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
+++ b/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
@@ -79,6 +79,7 @@ Requires: %{name}-open-gpu
 %if "%{_cross_arch}" == "x86_64"
 Requires: %{name}-grid
 %endif
+Requires: %{name}-mps
 
 %description
 %{summary}.
@@ -125,6 +126,13 @@ Provides: %{name}-tesla(fabricmanager)
 
 %description tesla
 %{summary}
+
+%package mps
+Summary: NVIDIA CUDA Multi-Process Service
+Requires: %{name}
+
+%description mps
+%{summary}.
 
 %prep
 # Extract nvidia sources with `-x`, otherwise the script will try to install
@@ -674,10 +682,7 @@ popd
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-peermem.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.mod.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.o
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
-%exclude %{_cross_bindir}/nvidia-cuda-mps-control
-%exclude %{_cross_bindir}/nvidia-cuda-mps-server
+
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-ngx-updater
 %exclude %{_cross_bindir}/nvidia-ngx-updater
@@ -742,3 +747,9 @@ popd
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.env
 %{_cross_unitdir}/nvidia-fabricmanager.service
+
+%files mps
+%{_cross_bindir}/nvidia-cuda-mps-control
+%{_cross_bindir}/nvidia-cuda-mps-server
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -86,6 +86,7 @@ Requires: %{name}-open-gpu
 %if "%{_cross_arch}" == "x86_64"
 Requires: %{name}-grid
 %endif
+Requires: %{name}-mps
 
 %description
 %{summary}.
@@ -140,6 +141,13 @@ Provides: %{name}-tesla(fabricmanager)
 
 %description tesla
 %{summary}
+
+%package mps
+Summary: NVIDIA CUDA Multi-Process Service
+Requires: %{name}
+
+%description mps
+%{summary}.
 
 %prep
 # Extract nvidia sources with `-x`, otherwise the script will try to install
@@ -692,10 +700,7 @@ popd
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-peermem.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.mod.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.o
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
-%exclude %{_cross_bindir}/nvidia-cuda-mps-control
-%exclude %{_cross_bindir}/nvidia-cuda-mps-server
+
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-ngx-updater
 %exclude %{_cross_bindir}/nvidia-ngx-updater
@@ -755,6 +760,12 @@ popd
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-drm.ko
 %{_cross_datadir}/nvidia/grid/drivers/nvidia-peermem.ko
 %endif
+
+%files mps
+%{_cross_bindir}/nvidia-cuda-mps-control
+%{_cross_bindir}/nvidia-cuda-mps-server
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
 
 %files fabricmanager
 %{_cross_factorydir}%{_cross_sysconfdir}/nvidia/fabricmanager.cfg

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -86,6 +86,7 @@ Requires: %{name}-open-gpu
 %if "%{_cross_arch}" == "x86_64"
 Requires: %{name}-grid
 %endif
+Requires: %{name}-mps
 
 %description
 %{summary}.
@@ -140,6 +141,13 @@ Provides: %{name}-tesla(fabricmanager)
 
 %description tesla
 %{summary}
+
+%package mps
+Summary: NVIDIA CUDA Multi-Process Service
+Requires: %{name}
+
+%description mps
+%{summary}.
 
 %prep
 # Extract nvidia sources with `-x`, otherwise the script will try to install
@@ -698,10 +706,6 @@ popd
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-peermem.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.mod.o
 %exclude %{_cross_datadir}/nvidia/tesla/module-objects.d/nvidia-drm.o
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
-%exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
-%exclude %{_cross_bindir}/nvidia-cuda-mps-control
-%exclude %{_cross_bindir}/nvidia-cuda-mps-server
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-ngx-updater
 %exclude %{_cross_bindir}/nvidia-ngx-updater
@@ -770,3 +774,9 @@ popd
 %files imex
 %{_cross_bindir}/nvidia-imex
 %{_cross_bindir}/nvidia-imex-ctl
+
+%files mps
+%{_cross_bindir}/nvidia-cuda-mps-control
+%{_cross_bindir}/nvidia-cuda-mps-server
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
+%{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server


### PR DESCRIPTION
**Issue number:**

Related to: https://github.com/bottlerocket-os/bottlerocket/issues/4673

**Description of changes:**
This adds the MPS binaries to the NVIDIA kmod packages. These can be used by upcoming changes in the core kit and bottlerocket-settings-sdk to enable MPS support. This change is safe to include since the MPS binaries are very small so it is negligible impact to include them.

**Testing done:**
Built the kernel kit and validated the size of the binaries in the new subpackage:
```
70784 vidia-cuda-mps-control # 70K size
18664  nvidia-cuda-mps-server # 19K size
```
I built this kit into an image along with several in-draft changes and got the nodes to offer shared GPUs via MPS as well. Those PRs will include more exhaustive testing and validation but this was the base of those changes.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
