### PR TITLE
Fix systemd syntax for NVLSM service 

### DIFF
--- a/packages/nvlsm/nvlsm.service
+++ b/packages/nvlsm/nvlsm.service
@@ -9,7 +9,7 @@ PIDFile=/run/nvidia-fabricmanager/nvlsm.pid
 ExecCondition=[ -s /etc/nvidia/nvlsm.env ]
 EnvironmentFile=-/etc/nvidia/nvlsm.env
 ExecStart=/usr/bin/nvlsm -F /usr/share/nvidia/nvlsm/nvlsm.conf -f stdout --pid_file /var/run/nvidia-fabricmanager/nvlsm.pid $GUID_ARG
-Restart=Always
+Restart=always
 StandardError=journal+console
 
 [Install]


### PR DESCRIPTION
**Issue number:**

Closes # https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/306

**Description of changes:**
The Restart directive should be Restart=always since it is case sensitive.


**Testing done:**
When I run `systemd-analyze verify` on my fedora box:
```
$ systemd-analyze verify nvlsm.service
nvlsm.service:12: Failed to parse Restart=Always, ignoring: Invalid argument
nvlsm.service: Command /usr/bin/nvlsm is not executable: No such file or directory
```
After:
```
$ systemd-analyze verify nvlsm.service
nvlsm.service: Command /usr/bin/nvlsm is not executable: No such file or directory
```
Since nvlsm isn't installed on my dev box, the remaining error is expected.



**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
