### PR TITLE
Nvidia driver update

### DIFF
--- a/packages/kmod-6.1-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r570/Cargo.toml
@@ -21,28 +21,28 @@ url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLi
 sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-x86_64-570.195.03.run"
-sha512 = "77041ef60bd4c637a53750b6ef5c5121e3eb299c5b2859d65fd0a3683c4fb32b5fd34ae419cfdb982588992706264c839338d1ff02850cae2c88fd67f7cda27d"
+url = "https://us.download.nvidia.com/tesla/570.211.01/NVIDIA-Linux-x86_64-570.211.01.run"
+sha512 = "3e751d90a8f126e369c5167e2d5ba8b218dd306ccf00907290ae70fb1c3f752f0ad0b973ce356a1a24cd0f19c31a07169cfd5705613a6bbb5918881635650839"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-aarch64-570.195.03.run"
-sha512 = "4ed4c4863dce0ec53a9fa1a7e3cdc7ce3e915db4ec014b2c5030e8a6c961d4e58c99c42b6c6b17020d8c31acf95e14254bca446c2a56ce29b10067730910e2a0"
+url = "https://us.download.nvidia.com/tesla/570.211.01/NVIDIA-Linux-aarch64-570.211.01.run"
+sha512 = "22816d8f798d6ce141ff2ce750b5df1ca4fef9b1ba79762157fd7f93c1ea905c74f421dc6ac2b7bf5b383192d2baa735d7a7d240523be815defb68be54c4a6be"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
-sha512 = "2b26abd802e4360cc51b4990e1925732437817e6e9fac94fd2c629f2b74dffe04ea913771a61d77957a4791610d90288c7ac6a474d634b63173e3f11dce299ac"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-570.211.01-1.x86_64.rpm"
+sha512 = "21be6fdfbda1fabad20cc9a0bdabb1fdbf104e0627bb7cf5b51ca7e5da0608240d665bc8a4f5bf9cde5adc16526c195999f47d4ed79130e7c65cc972f92a5182"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
-sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.211.01-1.aarch64.rpm"
+sha512 = "8e89fd4e7983b2ea430a884bd53e58827020c22e604161501570e21d33128431f14a43b05091f401977ed4da046ceb8f0c5015a200d2ad8877870b426b106398"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-18.5/NVIDIA-Linux-x86_64-570.195.03-grid-aws.run"
-sha512 = "7b824cf7ddcde4739cadf99dad136a6cb90f19cc759c907e8f856574abf2bb513efb19d2b564f44403f1662e9978e1cbcdbb92d3ed49d6d048088c9fdf27de8f"
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-18.6/NVIDIA-Linux-x86_64-570.211.01-grid-aws.run"
+sha512 = "940e96ddc744e76a17f7eb196553264b3aaba16bd2f7e20bbd608b4f9958173d24644b7bcba303b8889c875658ce948c07c55d00cf5709bc69b9e21a86188845"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
+++ b/packages/kmod-6.1-nvidia-r570/kmod-6.1-nvidia-r570.spec
@@ -1,8 +1,8 @@
 %global tesla_major 570
-%global tesla_minor 195
-%global tesla_patch 03
+%global tesla_minor 211
+%global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
-%global grid_ver grid-18.5
+%global grid_ver grid-18.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -698,9 +698,9 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.4
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.4
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}

--- a/packages/kmod-6.1-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r580/Cargo.toml
@@ -21,32 +21,32 @@ url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLi
 sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-x86_64-580.95.05.run"
-sha512 = "21e8076f593ce255c8e96dd456524f700e76b230130659ed73a279432dd9f2aa60735411c6fc906e9f60882e905cc1c5b91aaf80d5d5e64d317b1dd27f6e4c13"
+url = "https://us.download.nvidia.com/tesla/580.126.09/NVIDIA-Linux-x86_64-580.126.09.run"
+sha512 = "d5c41131304b29d55d0caf8cd84c95b454d81e68d7b23ca893504c63d84dd78726e2dbd7f076b7f12be518e641d110d131ac178336d61a00bcc81b7a1890799d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-aarch64-580.95.05.run"
-sha512 = "e07b31824f7e6dd485df5c73e3a58f85962239ea20a92f18d82b9c55564d69309fe5bb279f39ed8ef152ccdbffc6d0fdf7bccfa3c794e4ecd9fac83bcfbb91a9"
+url = "https://us.download.nvidia.com/tesla/580.126.09/NVIDIA-Linux-aarch64-580.126.09.run"
+sha512 = "7ec0fd917bade1eb14b135bab2ade17a5116546190c3011379be7105404485016e26a5fb1ece5a4800eea39ac10c1abea19cc40be6f8f31188b3eeb78344a6c7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-580.95.05-1.x86_64.rpm"
-sha512 = "38cb3a7cbe5aa687f396809c4a43511a7f6885b22f2c08c5c2c82cd2dc33103340d0771248b3150f797123294b564323525ed51b46d84584d29f7f4307f74490"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-580.126.09-1.x86_64.rpm"
+sha512 = "17dce541c27a445b062e30f907236a5135b7f1a85cb2f9962a9fd6ca25c7a6a990b7b78b6b07d12f63b78c9a06934c6c24738920ef5f4bd12d9d4df0d36be271"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabricmanager-580.95.05-1.aarch64.rpm"
-sha512 = "333cd4e54df830e59a7a2507b64d626b29d78aafd88ffc1da4ee24739abcea93885ee524119ea930100dd3dce395b71049905389858ddae1ab0dbb74b97a6bfa"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabricmanager-580.126.09-1.aarch64.rpm"
+sha512 = "dc6c9cd706426e379d0fefe8e5073149226fc6b69bda691c45b25faec7b3739c452325c32bbed225e51f2365abf4748d33ee67496aadf3ed93b12768b65ca419"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-19.2/NVIDIA-Linux-x86_64-580.95.05-grid-aws.run"
-sha512 = "fdc8279a147a491a2cfed6a7883515ddd824108b4003d70b97b43a70ab5912285d832ccd8102f7d2c7bf88911e507f1bab6a770bd40e45dacd9a7e1855716457"
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-19.4/NVIDIA-Linux-x86_64-580.126.09-grid-aws.run"
+sha512 = "4c8a189a1871354b8036c9831968877e9634b69aca3417ad2672e7515da9e8e84c9b1496ea29ea25b4be7062aa36508bf69d82afec1af0ed3d8ee2dec6a07741"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.95.05/COPYING"
+url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.126.09/COPYING"
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 

--- a/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
+++ b/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
@@ -1,8 +1,8 @@
 %global tesla_major 580
-%global tesla_minor 95
-%global tesla_patch 05
+%global tesla_minor 126
+%global tesla_patch 09
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
-%global grid_ver grid-19.2
+%global grid_ver grid-19.4
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -703,12 +703,12 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/nvidia_drv.so
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.3
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.4
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.4
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"

--- a/packages/kmod-6.12-nvidia-r570/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r570/Cargo.toml
@@ -21,38 +21,38 @@ url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLi
 sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-x86_64-570.195.03.run"
-sha512 = "77041ef60bd4c637a53750b6ef5c5121e3eb299c5b2859d65fd0a3683c4fb32b5fd34ae419cfdb982588992706264c839338d1ff02850cae2c88fd67f7cda27d"
+url = "https://us.download.nvidia.com/tesla/570.211.01/NVIDIA-Linux-x86_64-570.211.01.run"
+sha512 = "3e751d90a8f126e369c5167e2d5ba8b218dd306ccf00907290ae70fb1c3f752f0ad0b973ce356a1a24cd0f19c31a07169cfd5705613a6bbb5918881635650839"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/570.195.03/NVIDIA-Linux-aarch64-570.195.03.run"
-sha512 = "4ed4c4863dce0ec53a9fa1a7e3cdc7ce3e915db4ec014b2c5030e8a6c961d4e58c99c42b6c6b17020d8c31acf95e14254bca446c2a56ce29b10067730910e2a0"
+url = "https://us.download.nvidia.com/tesla/570.211.01/NVIDIA-Linux-aarch64-570.211.01.run"
+sha512 = "22816d8f798d6ce141ff2ce750b5df1ca4fef9b1ba79762157fd7f93c1ea905c74f421dc6ac2b7bf5b383192d2baa735d7a7d240523be815defb68be54c4a6be"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-570.195.03-1.x86_64.rpm"
-sha512 = "2b26abd802e4360cc51b4990e1925732437817e6e9fac94fd2c629f2b74dffe04ea913771a61d77957a4791610d90288c7ac6a474d634b63173e3f11dce299ac"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabric-manager-570.211.01-1.x86_64.rpm"
+sha512 = "21be6fdfbda1fabad20cc9a0bdabb1fdbf104e0627bb7cf5b51ca7e5da0608240d665bc8a4f5bf9cde5adc16526c195999f47d4ed79130e7c65cc972f92a5182"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.195.03-1.aarch64.rpm"
-sha512 = "99ffb000ebc59d2e501ed4a38913dd9a1669a94edbc45c730a9d34b743590da726fa094cd08aef96c4cc147f238183098d09c9fe5234e14c1f26f8d3d8e7e1d2"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabric-manager-570.211.01-1.aarch64.rpm"
+sha512 = "8e89fd4e7983b2ea430a884bd53e58827020c22e604161501570e21d33128431f14a43b05091f401977ed4da046ceb8f0c5015a200d2ad8877870b426b106398"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-18.5/NVIDIA-Linux-x86_64-570.195.03-grid-aws.run"
-sha512 = "7b824cf7ddcde4739cadf99dad136a6cb90f19cc759c907e8f856574abf2bb513efb19d2b564f44403f1662e9978e1cbcdbb92d3ed49d6d048088c9fdf27de8f"
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-18.6/NVIDIA-Linux-x86_64-570.211.01-grid-aws.run"
+sha512 = "940e96ddc744e76a17f7eb196553264b3aaba16bd2f7e20bbd608b4f9958173d24644b7bcba303b8889c875658ce948c07c55d00cf5709bc69b9e21a86188845"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-570-570.195.03-1.x86_64.rpm"
-sha512 = "15d8a8653520994204e345d589f84c750b38924b9e4e3bb949d43c2a702bd04c946b993da158145f38dea1cf459aa2d9cec0f16828aad8e2b95a3b27f85d629a"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-570-570.211.01-1.x86_64.rpm"
+sha512 = "608fc066214e0c160067d2c5ba8a5568b094003cd2c054252fb2822fa0742ec52811ce5a05a14d9bfffe32a8070211455cbd70b8d64bf2099cf49cbba0cf7fec"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-570-570.195.03-1.aarch64.rpm"
-sha512 = "d620a3f02ce673cd27f96d9a3206c04d13a047c03da03ebb2a93db7335b2c620c249f826d80885783f3f0a676ce622ca882f6e1144afd7258351c5b79ccbeba9"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-570-570.211.01-1.aarch64.rpm"
+sha512 = "a42e4fa0d306ee6ea8ffd527f678dfc9b25078e12a4438c77e4f8b57ecd7cdf44ea5e97ddb1500013c32907bf0a21284796ae33f1c383f0c224f20fc07058749"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
+++ b/packages/kmod-6.12-nvidia-r570/kmod-6.12-nvidia-r570.spec
@@ -1,8 +1,8 @@
 %global tesla_major 570
-%global tesla_minor 195
-%global tesla_patch 03
+%global tesla_minor 211
+%global tesla_patch 01
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
-%global grid_ver grid-18.5
+%global grid_ver grid-18.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -727,9 +727,9 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.4
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.4
 %if "%{_cross_arch}" == "x86_64"
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}

--- a/packages/kmod-6.12-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r580/Cargo.toml
@@ -21,42 +21,42 @@ url = "https://aws-nvidia-license-agreement.s3.amazonaws.com/NvidiaGridAWSUserLi
 sha512 = "915d76bc26f7b39202883b6f902ebde1194d1f3e45e6c858ee42ac48615e4b315c658ba78d24bd72a3011289c2ea888ee17089f674497f1cba58d0e0c8f37c7a"
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-x86_64-580.95.05.run"
-sha512 = "21e8076f593ce255c8e96dd456524f700e76b230130659ed73a279432dd9f2aa60735411c6fc906e9f60882e905cc1c5b91aaf80d5d5e64d317b1dd27f6e4c13"
+url = "https://us.download.nvidia.com/tesla/580.126.09/NVIDIA-Linux-x86_64-580.126.09.run"
+sha512 = "d5c41131304b29d55d0caf8cd84c95b454d81e68d7b23ca893504c63d84dd78726e2dbd7f076b7f12be518e641d110d131ac178336d61a00bcc81b7a1890799d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://us.download.nvidia.com/tesla/580.95.05/NVIDIA-Linux-aarch64-580.95.05.run"
-sha512 = "e07b31824f7e6dd485df5c73e3a58f85962239ea20a92f18d82b9c55564d69309fe5bb279f39ed8ef152ccdbffc6d0fdf7bccfa3c794e4ecd9fac83bcfbb91a9"
+url = "https://us.download.nvidia.com/tesla/580.126.09/NVIDIA-Linux-aarch64-580.126.09.run"
+sha512 = "7ec0fd917bade1eb14b135bab2ade17a5116546190c3011379be7105404485016e26a5fb1ece5a4800eea39ac10c1abea19cc40be6f8f31188b3eeb78344a6c7"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-580.95.05-1.x86_64.rpm"
-sha512 = "38cb3a7cbe5aa687f396809c4a43511a7f6885b22f2c08c5c2c82cd2dc33103340d0771248b3150f797123294b564323525ed51b46d84584d29f7f4307f74490"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-fabricmanager-580.126.09-1.x86_64.rpm"
+sha512 = "17dce541c27a445b062e30f907236a5135b7f1a85cb2f9962a9fd6ca25c7a6a990b7b78b6b07d12f63b78c9a06934c6c24738920ef5f4bd12d9d4df0d36be271"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabricmanager-580.95.05-1.aarch64.rpm"
-sha512 = "333cd4e54df830e59a7a2507b64d626b29d78aafd88ffc1da4ee24739abcea93885ee524119ea930100dd3dce395b71049905389858ddae1ab0dbb74b97a6bfa"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-fabricmanager-580.126.09-1.aarch64.rpm"
+sha512 = "dc6c9cd706426e379d0fefe8e5073149226fc6b69bda691c45b25faec7b3739c452325c32bbed225e51f2365abf4748d33ee67496aadf3ed93b12768b65ca419"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-580.95.05-1.x86_64.rpm"
-sha512 = "8bc09565558404366382d81d02db8f4f5dfe16556200846ea7e1d8f43d408b7a02627995b3a73bbf6b74a26067f30500b7c9f3f9ecabca789d296722bccfd2d7"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/nvidia-imex-580.126.09-1.x86_64.rpm"
+sha512 = "ff4f10a4654c837106c44c98ef888178be5eda53996fba1e3223352188bb1b94c18aeb7fec17426891a3439fc4233bec37c9811f97c7d6964e0baa6503aff24d"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-580.95.05-1.aarch64.rpm"
-sha512 = "7cdfbaab907fc64d3f58a85fffd8fc47d137be70d62274fbbbe15bf6f27b5ad17eee3d78e506437f391fd448a918176890293c212eaea94390668c4ac531673c"
+url = "https://developer.download.nvidia.com/compute/cuda/repos/amzn2023/sbsa/nvidia-imex-580.126.09-1.aarch64.rpm"
+sha512 = "7eaf9bddc2786d5c38318d80882de729e03aef252f9bdd265afaac4a2c7d58bc4eab39b37c65538ec4d195857623c7b13dca75d946b61ab1a73f73f8a1f09d10"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-19.2/NVIDIA-Linux-x86_64-580.95.05-grid-aws.run"
-sha512 = "fdc8279a147a491a2cfed6a7883515ddd824108b4003d70b97b43a70ab5912285d832ccd8102f7d2c7bf88911e507f1bab6a770bd40e45dacd9a7e1855716457"
+url = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-19.4/NVIDIA-Linux-x86_64-580.126.09-grid-aws.run"
+sha512 = "4c8a189a1871354b8036c9831968877e9634b69aca3417ad2672e7515da9e8e84c9b1496ea29ea25b4be7062aa36508bf69d82afec1af0ed3d8ee2dec6a07741"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.95.05/COPYING"
+url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.126.09/COPYING"
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -1,8 +1,8 @@
 %global tesla_major 580
-%global tesla_minor 95
-%global tesla_patch 05
+%global tesla_minor 126
+%global tesla_patch 09
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
-%global grid_ver grid-19.2
+%global grid_ver grid-19.4
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -729,12 +729,12 @@ popd
 %exclude %{_cross_libdir}/nvidia/tesla/nvidia_drv.so
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.2
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-gbm.so.1.1.3
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-wayland.so.1.1.20
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xcb.so.1.0.4
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1
-%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.3
+%exclude %{_cross_libdir}/nvidia/tesla/libnvidia-egl-xlib.so.1.0.4
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.1
 %exclude %{_cross_libdir}/nvidia/tesla/libnvidia-sandboxutils.so.%{tesla_ver}
 %if "%{_cross_arch}" == "x86_64"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->


  Description of changes:

  Update NVIDIA Tesla drivers to the latest versions:
  - r570: 570.211.01
  - r580: 580.126.09

  Release notes:
  - https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-570-211-01/index.html
  - https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-580-126-09/index.html

  Testing done:

  Tested on EKS clusters with Bottlerocket NVIDIA variants:
  - Kernel 6.1 with r570 (570.211.01) - EKS 1.32
  - Kernel 6.1 with r580 (580.126.09) - EKS 1.32
  - Kernel 6.12 with r570 (570.211.01) - EKS 1.34
  - Kernel 6.12 with r580 (580.126.09) - EKS 1.34

- Details for `Kernel 6.12 with r580 (580.126.09)`
```
##############################################
# CLUSTER 1.34 - KERNEL 6.12
# Bottlerocket: aws-k8s-1.34-nvidia
##############################################

=== NVIDIA-SMI ===
Mon Jan 19 11:29:21 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA A100-SXM4-40GB          On  |   00000000:10:1C.0 Off |                    0 |
| N/A   34C    P0             52W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   1  NVIDIA A100-SXM4-40GB          On  |   00000000:10:1D.0 Off |                    0 |
| N/A   34C    P0             55W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   2  NVIDIA A100-SXM4-40GB          On  |   00000000:20:1C.0 Off |                    0 |
| N/A   34C    P0             51W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   3  NVIDIA A100-SXM4-40GB          On  |   00000000:20:1D.0 Off |                    0 |
| N/A   33C    P0             54W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   4  NVIDIA A100-SXM4-40GB          On  |   00000000:90:1C.0 Off |                    0 |
| N/A   35C    P0             54W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   5  NVIDIA A100-SXM4-40GB          On  |   00000000:90:1D.0 Off |                    0 |
| N/A   33C    P0             53W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   6  NVIDIA A100-SXM4-40GB          On  |   00000000:A0:1C.0 Off |                    0 |
| N/A   35C    P0             53W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+
|   7  NVIDIA A100-SXM4-40GB          On  |   00000000:A0:1D.0 Off |                    0 |
| N/A   34C    P0             53W /  400W |       0MiB /  40960MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+

=== NVIDIA Driver Version ===
NVRM version: NVIDIA UNIX Open Kernel Module for x86_64  580.126.09  Release Build  (dvs-builder@U22-I3-AM02-24-3)  Wed Jan  7 22:51:36 UTC 2026
GCC version:  gcc version 13.3.0 (Buildroot 2024.11.1)

=== Kernel Version ===
Linux version 6.12.63 (builder@buildkitsandbox) (x86_64-bottlerocket-linux-gnu-gcc (Buildroot 2024.11.1) 13.3.0, GNU ld (GNU Binutils) 2.43.1) #1 SMP PREEMPT_DYNAMIC Thu Jan 15 20:20:06 UTC 2026

=== Loaded NVIDIA Modules ===
nvidia_modeset 1757184 0 - Live 0xffffffffc1bd2000 (OE)
video 77824 1 nvidia_modeset, Live 0xffffffffc0b6b000
nvidia_uvm 1998848 4 - Live 0xffffffffc19bd000 (OE)
nvidia 13967360 195 nvidia_modeset,nvidia_uvm, Live 0xffffffffc0b8d000 (OE)
drm 753664 1 nvidia, Live 0xffffffffc088e000
i2c_core 122880 4 nvidia,i2c_piix4,i2c_smbus,drm, Live 0xffffffffc07fd000
backlight 28672 3 nvidia_modeset,video,drm, Live 0xffffffffc0799000

=== NVIDIA kmod files ===
/host/lib/modules/6.12.63/kernel/drivers/extra/video/nvidia/open-gpu/nvidia-modeset.ko
/host/lib/modules/6.12.63/kernel/drivers/extra/video/nvidia/open-gpu/nvidia-uvm.ko
/host/lib/modules/6.12.63/kernel/drivers/extra/video/nvidia/open-gpu/nvidia.ko
/host/lib/modules/6.12.63/kernel/drivers/extra/video/nvidia/open-gpu/nvidia-peermem.ko
/host/lib/modules/6.12.63/kernel/drivers/extra/video/nvidia/open-gpu/nvidia-drm.ko
```

  Verified:
  - nvidia-smi reports correct driver version
  - NVIDIA kernel modules load successfully
  - GPUs detected and operational

  Terms of contribution:

  By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
