### PR TITLE
Prepare for v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# v4.8.0 (2026-01-21)
+## OS Changes
+* Add MPS subpackage to NVIDIA kmod packages ([#347])
+* Update r570 NVIDIA driver to 570.211.01 ([#357])
+* Update r580 NVIDIA driver to 580.126.09 ([#357])
+* Disable ext4 debugging for 6.12 kernel ([#356])
+
+## Build Changes
+* Update the Bottlerocket SDK to v0.70.0 ([#358])
+
+[#347]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/347
+[#356]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/356
+[#357]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/357
+[#358]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/358
+
 # v4.7.1 (2026-01-07)
 ## OS Changes
 * Add dependency on the GRID license for NVIDIA k8s device plugin ([#294])

--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.66.0"
+version = "0.70.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.66.0"
-digest = "0LNg8ap1LAvV4sVA7/cpCCbLnR3HI5IbZHFr6ugJrC0="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.70.0"
+digest = "8ndrJE5YUkGs4lLbnEwmWeQ69TyLYhf7QEOCvPb2kg4="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "4.7.1"
+release-version = "4.8.0"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.66.0"
+version = "0.70.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Description of changes:**
Prepare for the v4.8.0 release and bump to v0.70.0 Bottlerocket SDK


**Testing done:**
`make` passed.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
