### PR TITLE
advisories: add BRSAs for Kernel Kit v5.0.0

### DIFF
--- a/advisories/5.0.0/BRSA-0pbpswtwamzs.toml
+++ b/advisories/5.0.0/BRSA-0pbpswtwamzs.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "BRSA-0pbpswtwamzs"
+title = "Bottlerocket Kernel 6.12 Updates"
+severity = "high"
+description = "Kernel version 6.12.68 is now available with important fixes. All users must upgrade. Advisory information for kernel is often published after new kernels become available. Bottlerocket recommends that you consume the latest kernel release for your LTS version."
+
+[[advisory.products]]
+package-name = "kernel-6.12"
+patched-version = "6.12.68"
+patched-epoch = "0"
+
+[updateinfo]
+author = "mgsharm"
+issue-date = 2026-02-19T05:44:59Z
+arches = ["x86_64", "aarch64"]
+version = "5.0.0"

--- a/advisories/5.0.0/BRSA-sjm54txjduoa.toml
+++ b/advisories/5.0.0/BRSA-sjm54txjduoa.toml
@@ -19,4 +19,4 @@ patched-epoch = "2"
 author = "mgsharm"
 issue-date = 2026-02-12T23:30:55Z
 arches = ["x86_64", "aarch64"]
-version = "staging"
+version = "5.0.0"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
- Adding advisories for the v5.0.0 release.
- Moves the kmod-nvidia-r570 EOL advisory from staging to 5.0.0.

**Testing done:**

- N/A

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
