### PR TITLE
Update to Neuron driver 2.26.5 from the 2.28 SDK release

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -24,8 +24,8 @@ sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm.url.sh to get this
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.25.4.0.noarch.rpm"
-sha512 = "aa0611880d14a17c01d9221b20305f95565ea54f74574f077e62dff200c8e5f8369ebc2d4039baebdcf5abe99b86c74c714d39a4aec049d02a7264a84275cce3"
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm"
+sha512 = "8e7aa38d5015cdca0274469d217bf3b5441494ef31959851113c788b147fc6f2225864d390f7f31a93bd740b5599c3dfad305893b4ad6d549656a9ed7d32e853"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -13,7 +13,7 @@ Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.21-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
-Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.25.4.0.noarch.rpm
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -24,8 +24,8 @@ sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm.url.sh to get this.
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.25.4.0.noarch.rpm"
-sha512 = "aa0611880d14a17c01d9221b20305f95565ea54f74574f077e62dff200c8e5f8369ebc2d4039baebdcf5abe99b86c74c714d39a4aec049d02a7264a84275cce3"
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm"
+sha512 = "8e7aa38d5015cdca0274469d217bf3b5441494ef31959851113c788b147fc6f2225864d390f7f31a93bd740b5599c3dfad305893b4ad6d549656a9ed7d32e853"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -15,7 +15,7 @@ Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.21-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
-Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.25.4.0.noarch.rpm
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.


### PR DESCRIPTION
**Description of changes:**
This updates [the driver](https://github.com/aws-neuron/aws-neuron-driver/releases) from the latest [Neuron SDK release](https://awsdocs-neuron.readthedocs-hosted.com/en/latest/release-notes/releasecontent.html#id1). 


**Testing done:**
Build a variant and confirm the driver loads properly.

Module loads
```
filename:       /lib/modules/6.1.161/kernel/drivers/neuron/neuron.ko.gz
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.26.5.0
license:        GPL
description:    Neuron Driver, built from SHA: 6670442319042643165ab7986e5184496ea4407c
import_ns:      DMA_BUF
srcversion:     8818F61F4109E2E9CE9BA2E
depends:
retpoline:      Y
name:           neuron
vermagic:       6.1.161 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
```
Can see the device:
```
instance-type: trn1.2xlarge
instance-id: i-####
+--------+--------+----------+--------+--------------+----------+------+
| NEURON | NEURON |  NEURON  | NEURON |     PCI      |   CPU    | NUMA |
| DEVICE | CORES  | CORE IDS | MEMORY |     BDF      | AFFINITY | NODE |
+--------+--------+----------+--------+--------------+----------+------+
| 0      | 2      | 0-1      | 32 GB  | 0000:00:1e.0 | 0-7      | -1   |
+--------+--------+----------+--------+--------------+----------+------+
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
