### PR TITLE
Update EFA kmods to 3.0.0

### DIFF
--- a/packages/kmod-6.1-efa/Cargo.toml
+++ b/packages/kmod-6.1-efa/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "kmod-6.1-efa"
 releases-url = "https://github.com/amzn/amzn-drivers/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://efa-installer.amazonaws.com/aws-efa-installer-1.44.0.tar.gz"
-sha512 = "eaa336d8eb2affed5f5960a133af9f98b2b113c2dde17246c51947324f2318710012e7bced124e73f7113c8261748aaa0f4856063d71340b2d85a7f089551526"
+url = "https://efa-installer.amazonaws.com/aws-efa-installer-1.47.0.tar.gz"
+sha512 = "4d190358e6394d55cf93b35f34a8bf8eba0f49514af4a7bdc328dbbc9d25722e6d47bc5a471837ef8edfcbe283a7e4cbfe1607f6c8c34ebffb602ae16109f835"
 
 [[package.metadata.build-package.external-files]]
 # The installer doesn't ship with the COPYING file

--- a/packages/kmod-6.1-efa/kmod-6.1-efa.spec
+++ b/packages/kmod-6.1-efa/kmod-6.1-efa.spec
@@ -1,11 +1,11 @@
-%global efa_installer_ver 1.44.0
+%global efa_installer_ver 1.47.0
 %global kmajor 6.1
 %global kernel_sources %{_builddir}/kernel-devel
 %global _cross_kmoddir %{_cross_libdir}/modules/%{kmajor}
 %global _ko ko.gz
 
 Name: %{_cross_os}kmod-6.1-efa
-Version: 2.17.3g
+Version: 3.0.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: EFA driver for the 6.1 kernel

--- a/packages/kmod-6.12-efa/Cargo.toml
+++ b/packages/kmod-6.12-efa/Cargo.toml
@@ -13,8 +13,8 @@ package-name = "kmod-6.12-efa"
 releases-url = "https://github.com/amzn/amzn-drivers/releases"
 
 [[package.metadata.build-package.external-files]]
-url = "https://efa-installer.amazonaws.com/aws-efa-installer-1.44.0.tar.gz"
-sha512 = "eaa336d8eb2affed5f5960a133af9f98b2b113c2dde17246c51947324f2318710012e7bced124e73f7113c8261748aaa0f4856063d71340b2d85a7f089551526"
+url = "https://efa-installer.amazonaws.com/aws-efa-installer-1.47.0.tar.gz"
+sha512 = "4d190358e6394d55cf93b35f34a8bf8eba0f49514af4a7bdc328dbbc9d25722e6d47bc5a471837ef8edfcbe283a7e4cbfe1607f6c8c34ebffb602ae16109f835"
 
 [[package.metadata.build-package.external-files]]
 # The installer doesn't ship with the COPYING file

--- a/packages/kmod-6.12-efa/kmod-6.12-efa.spec
+++ b/packages/kmod-6.12-efa/kmod-6.12-efa.spec
@@ -1,11 +1,11 @@
-%global efa_installer_ver 1.44.0
+%global efa_installer_ver 1.47.0
 %global kernel_sources %{_cross_usrsrc}/kernels/6.12
 %define _kernel_version %(cat %{kernel_sources}/include/config/kernel.release)
 %global _cross_kmoddir %{_cross_libdir}/modules/%{_kernel_version}
 %global _ko ko
 
 Name: %{_cross_os}kmod-6.12-efa
-Version: 2.17.3g
+Version: 3.0.0
 Release: 1%{?dist}
 Epoch: 1
 Summary: EFA driver for the 6.12 kernel


### PR DESCRIPTION
**Description of changes:**
This updates the EFA driver to [3.0.0](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-changelog.html) which is part of the EFA installer 1.47.0 release.

**Testing done:**
Built both 6.1 and 6.12 versions and validated that RDMA tests pass with EFA.


| Variant | Kernel | EFA Driver | Test Result |
|---------|--------|------------|-------------|
| aws-k8s-1.34-nvidia | 6.12.68 | 3.0.0 (installer 1.47.0) | PASS |
| aws-k8s-1.31-nvidia | 6.1.161 | 3.0.0 (installer 1.47.0) | PASS |

`aws-k8s-1.31-nvidia` test results:
```
--- PASS: TestMPIJobPytorchTraining (345.33s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:all_reduce_perf (255.12s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:all_gather_perf (50.10s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:alltoall_perf (40.11s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 366.983s
```

`aws-k8s-1.34-nvidia` test results:
```
--- PASS: TestMPIJobPytorchTraining (290.42s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:all_reduce_perf (220.13s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:all_gather_perf (30.13s)
    --- PASS: TestMPIJobPytorchTraining/multi-node:alltoall_perf (40.16s)
PASS
ok      github.com/aws/aws-k8s-tester/test/cases/nvidia 306.817s

```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
