### PR TITLE
Neuron update

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -23,9 +23,9 @@ url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.
 sha512 = "ba2234e3aa8f5fb15a36304d811043abbed27e79bbd34bf2e0789f2f9a72d8f4c25c701be56622fc1cfdb70966d70b6bfa9d5f77127e76eec382fd0c9477f4ed"
 
 [[package.metadata.build-package.external-files]]
-# Use latest-neuron-srpm.url.sh to get this
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm"
-sha512 = "8e7aa38d5015cdca0274469d217bf3b5441494ef31959851113c788b147fc6f2225864d390f7f31a93bd740b5599c3dfad305893b4ad6d549656a9ed7d32e853"
+# Use latest-neuron-srpm-url.sh to get this.
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.10.0.noarch.rpm"
+sha512 = "ee49ab3aa9f4273a91aef305f30ed213c90c46317e72cfe46dd1d0e7088f0758039f998589ffc1080523f0af8f3348f9db4fe763b6fe8a0fd7d3119546cb1936"
 
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -18,9 +18,9 @@ sha512 = "eb1a38f186ae9e285c27a93b75d86f8344dc2283ed630fdbfb7e0ca8c55602b6d311b4
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-# Use latest-2.21-neuron-srpm-url.sh to get this.
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm"
-sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5e94fd564e1d9898f52a8cbd960a6a65435b90ba7d7839c807e7ca8736d"
+# Use latest-2.24-neuron-srpm-url.sh to get this.
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm"
+sha512 = "ba2234e3aa8f5fb15a36304d811043abbed27e79bbd34bf2e0789f2f9a72d8f4c25c701be56622fc1cfdb70966d70b6bfa9d5f77127e76eec382fd0c9477f4ed"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm.url.sh to get this

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -13,7 +13,7 @@ Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.24-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
-Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.10.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -10,8 +10,8 @@ URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
 Source0: https://cdn.amazonlinux.com/al2023/blobstore/5345c8e36a653c0013bb38f8973f652a2d1958438662b44dc22efc0972ab647b/kernel-6.1.163-186.299.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
-# Use latest-2.21-neuron-srpm-url.sh to get this.
-Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
+# Use latest-2.24-neuron-srpm-url.sh to get this.
+Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
 Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm
 Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
@@ -264,12 +264,12 @@ rm -f ../config-* ../*.patch
 cd %{_builddir}
 
 %if "%{_cross_arch}" == "x86_64"
-# 2.21 for inf1 support
+# 2.24 for inf1 support
 rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:2} | cpio -idmu './usr/src/aws-neuronx-*'
-find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_21 \;
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_24 \;
 rm -r usr
 
 # latest neuron driver
@@ -297,7 +297,7 @@ make -s \
 %kmake %{?_smp_mflags} modules
 
 %if "%{_cross_arch}" == "x86_64"
-%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_21
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_24
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
 %endif
 
@@ -306,11 +306,11 @@ make -s \
 %kmake %{?_smp_mflags} modules_install
 
 %if "%{_cross_arch}" == "x86_64"
-install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
-%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_21 M=%{_builddir}/neuron_2_21 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_24 M=%{_builddir}/neuron_2_24 modules_install
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_latest M=%{_builddir}/neuron_latest modules_install
-mv %{buildroot}%{_cross_kmoddir}/neuron_2_21/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2_24/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.ko.gz %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 %endif
 
@@ -1551,7 +1551,7 @@ install -p -m 0644 %{S:302} %{buildroot}%{_cross_bootconfigdir}/05-metal.conf
 
 %if "%{_cross_arch}" == "x86_64"
 %files modules-neuron
-%{_cross_libexecdir}/neuron/neuron_2_21/neuron.ko.gz
+%{_cross_libexecdir}/neuron/neuron_2_24/neuron.ko.gz
 %{_cross_libexecdir}/neuron/neuron_latest/neuron.ko.gz
 %{_cross_tmpfilesdir}/neuron.conf
 %{_cross_unitdir}/load-neuron-inf1-modules.service

--- a/packages/kernel-6.1/latest-2.24-neuron-srpms-url.sh
+++ b/packages/kernel-6.1/latest-2.24-neuron-srpms-url.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cmd="
 dnf install -q -y --releasever=latest yum-utils &&
-dnf download -q --repofrompath neuron,https://yum.repos.neuron.amazonaws.com --repo=neuron --urls aws-neuronx-dkms-2.21*
+dnf download -q --repofrompath neuron,https://yum.repos.neuron.amazonaws.com --repo=neuron --urls aws-neuronx-dkms-2.24*
 "
 docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2023 sh -c "${cmd}" \
     | grep '^http' \

--- a/packages/kernel-6.1/neuron-inf1.toml.in
+++ b/packages/kernel-6.1/neuron-inf1.toml.in
@@ -2,4 +2,4 @@
 lib-modules-path = "kernel/drivers/neuron"
 
 [neuron-inf1.kernel-modules."neuron.ko.gz"]
-copy-source = "__NEURON_MODULES__/neuron_2_21"
+copy-source = "__NEURON_MODULES__/neuron_2_24"

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -18,9 +18,9 @@ sha512 = "4f4d82f5d782e82706d799529806bf0602fafaeb4ec2388aff7a7d4183e3d85d0c2b21
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]
-# Use latest-2.21-neuron-srpm-url.sh to get this.
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm"
-sha512 = "4bdb01d846f12a04bdbe6902c3008ebadbcb50d4d94e8f81b524c02a4e94da7041cdb5e94fd564e1d9898f52a8cbd960a6a65435b90ba7d7839c807e7ca8736d"
+# Use latest-2.24-neuron-srpm-url.sh to get this.
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm"
+sha512 = "ba2234e3aa8f5fb15a36304d811043abbed27e79bbd34bf2e0789f2f9a72d8f4c25c701be56622fc1cfdb70966d70b6bfa9d5f77127e76eec382fd0c9477f4ed"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-neuron-srpm.url.sh to get this.

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -23,9 +23,9 @@ url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.
 sha512 = "ba2234e3aa8f5fb15a36304d811043abbed27e79bbd34bf2e0789f2f9a72d8f4c25c701be56622fc1cfdb70966d70b6bfa9d5f77127e76eec382fd0c9477f4ed"
 
 [[package.metadata.build-package.external-files]]
-# Use latest-neuron-srpm.url.sh to get this.
-url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm"
-sha512 = "8e7aa38d5015cdca0274469d217bf3b5441494ef31959851113c788b147fc6f2225864d390f7f31a93bd740b5599c3dfad305893b4ad6d549656a9ed7d32e853"
+# Use latest-neuron-srpm-url.sh to get this.
+url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.10.0.noarch.rpm"
+sha512 = "ee49ab3aa9f4273a91aef305f30ed213c90c46317e72cfe46dd1d0e7088f0758039f998589ffc1080523f0af8f3348f9db4fe763b6fe8a0fd7d3119546cb1936"
 
 [[package.metadata.build-package.external-files]]
 # Neuron driver 2.x.7372.0

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -12,8 +12,8 @@ URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
 Source0: https://cdn.amazonlinux.com/al2023/blobstore/668b5471c0600699f7ce4891c9e8f039444b11c7235640e94d7f9f9f07ff2d2d/kernel6.12-6.12.73-95.123.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
-# Use latest-2.21-neuron-srpm-url.sh to get this.
-Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.21.37.0.noarch.rpm
+# Use latest-2.24-neuron-srpm-url.sh to get this.
+Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
 Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm
 # Neuron driver 2.x.7372.0
@@ -245,12 +245,12 @@ rm -f ../config-* ../*.patch
 cd %{_builddir}
 
 %if "%{_cross_arch}" == "x86_64"
-# 2.21 for inf1 support
+# 2.24 for inf1 support
 rpmkeys --import %{S:7} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:2} | cpio -idmu './usr/src/aws-neuronx-*'
-find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_21 \;
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_24 \;
 rm -r usr
 
 # latest neuron driver
@@ -293,7 +293,7 @@ make -s \
 %kmake %{?_smp_mflags} modules
 
 %if "%{_cross_arch}" == "x86_64"
-%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_21
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_24
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_2x_7372
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_2x_7693
@@ -308,17 +308,17 @@ make -C tools/bpf/bpftool bootstrap
 %kmake %{?_smp_mflags} modules_install
 
 %if "%{_cross_arch}" == "x86_64"
-install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7372/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7693/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8072/
-%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_21 M=%{_builddir}/neuron_2_21 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_24 M=%{_builddir}/neuron_2_24 modules_install
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_latest M=%{_builddir}/neuron_latest modules_install
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_7372 M=%{_builddir}/neuron_2x_7372 modules_install
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_7693 M=%{_builddir}/neuron_2x_7693 modules_install
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_8072 M=%{_builddir}/neuron_2x_8072 modules_install
-mv %{buildroot}%{_cross_kmoddir}/neuron_2_21/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_21/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2_24/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2x_7372/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7372/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2x_7693/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7693/
@@ -1516,7 +1516,7 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 
 %if "%{_cross_arch}" == "x86_64"
 %files modules-neuron
-%{_cross_libexecdir}/neuron/neuron_2_21/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2_24/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_latest/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_2x_7372/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_2x_7693/neuron.%{_ko}

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -15,7 +15,7 @@ Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.24-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
-Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.5.0.noarch.rpm
+Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.10.0.noarch.rpm
 # Neuron driver 2.x.7372.0
 Source4: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.7372.0.noarch.rpm/e82516a77ab54f1c651a1f160e3a67b1cbca8bef391d78a6c683d6fc22442c8ee17df9d3fae1392ca8cffa676bb966b7088c32e634894ba142d83bef58dd2d81/aws-neuronx-dkms-2.x.7372.0.noarch.rpm
 # Neuron driver 2.x.7693.0

--- a/packages/kernel-6.12/latest-2.24-neuron-srpms-url.sh
+++ b/packages/kernel-6.12/latest-2.24-neuron-srpms-url.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 cmd="
 dnf install -q -y --releasever=latest yum-utils &&
-dnf download -q --repofrompath neuron,https://yum.repos.neuron.amazonaws.com --repo=neuron --urls aws-neuronx-dkms-2.21*
+dnf download -q --repofrompath neuron,https://yum.repos.neuron.amazonaws.com --repo=neuron --urls aws-neuronx-dkms-2.24*
 "
 docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2023 sh -c "${cmd}" \
     | grep '^http' \

--- a/packages/kernel-6.12/neuron-inf1.toml
+++ b/packages/kernel-6.12/neuron-inf1.toml
@@ -2,4 +2,4 @@
 lib-modules-path = "kernel/drivers/neuron"
 
 [neuron-inf1.kernel-modules."neuron.ko"]
-copy-source = "__NEURON_MODULES__/neuron_2_21"
+copy-source = "__NEURON_MODULES__/neuron_2_24"


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**

  Update neuron drivers for kernel 6.1 and 6.12:
  - Update neuron inf1 driver from 2.21.37.0 to 2.24.13.0
  - Update neuron latest driver from 2.26.5.0 to 2.26.10.0

**Testing done:**

### neuron-ls on inf1.xlarge

```bash
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON |   PCI   |
| DEVICE | CORES  | MEMORY |   BDF   |
+--------+--------+--------+---------+
| 0      | 4      | 8 GB   | 00:1f.0 |
+--------+--------+--------+---------+
```


### modinfo neuron:
filename:       /lib/modules/6.12.73/kernel/drivers/neuron/neuron.ko
version:        2.24.13.0
license:        GPL
description:    Neuron Driver, built from SHA: f3d11aaca3951440c7e47a8c74361815fc8ddee7
vermagic:       6.12.73 SMP preempt mod_unload modversions


### neuron-ls on inf2.xlarge
```bash
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON |   PCI   |
| DEVICE | CORES  | MEMORY |   BDF   |
+--------+--------+--------+---------+
| 0      | 2      | 32 GB  | 00:1f.0 |
+--------+--------+--------+---------+
```

### modinfo neuron:
filename:       /lib/modules/6.12.73/kernel/drivers/neuron/neuron.ko
version:        2.26.10.0
license:        GPL
description:    Neuron Driver, built from SHA: dd4b234dc87473b76914082d9dc25785149c978a
vermagic:       6.12.73 SMP preempt mod_unload modversions

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
