### PR TITLE
Fix non-root MPS by changing `/run/nvidia` mode to `0755`

### DIFF
--- a/packages/kmod-6.1-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.1-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -7,5 +7,5 @@ d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gr
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -
-d /run/nvidia 0700 root root -
+d /run/nvidia 0755 root root -
 D /var/run/nvidia-persistenced 0755 nvidia nvidia - -

--- a/packages/kmod-6.12-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -7,5 +7,5 @@ d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gr
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -
-d /run/nvidia 0700 root root -
+d /run/nvidia 0755 root root -
 D /var/run/nvidia-persistenced 0755 nvidia nvidia - -

--- a/packages/kmod-6.18-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -7,5 +7,5 @@ d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gr
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -
-d /run/nvidia 0700 root root -
+d /run/nvidia 0755 root root -
 D /var/run/nvidia-persistenced 0755 nvidia nvidia - -


### PR DESCRIPTION
**Issue number:**

Related: https://github.com/bottlerocket-os/bottlerocket/issues/4673

**Description of changes:**

Change `/run/nvidia` directory mode from `0700` to `0755` in all `nvidia-tmpfiles.conf.in` files.

The MPS control daemon forks per-UID server processes via `setuid(client_UID) + exec(nvidia-cuda-mps-server)`. With `0700`, non-root servers can't traverse `/run/nvidia` to reach their pipe directory — every access returns EACCES and the server exits immediately, causing a crash-restart loop.

`/var/run/nvidia-persistenced` already uses `0755`. This makes `/run/nvidia` consistent.

**Testing done:**

Built a custom aws-k8s-1.35-nvidia AMI with this change and tested on a g4dn.xlarge (Tesla T4, Driver 580.126.09).

Enabled MPS via Bottlerocket API:
```
apiclient set \
  'settings.kubelet-device-plugins.nvidia.device-sharing-strategy=mps' \
  'settings.kubelet-device-plugins.nvidia.mps.replicas=3'
```

Ran 3 concurrent non-root pods (UID 1000) with `nvidia/samples:nbody` requesting `nvidia.com/gpu.shared`. All 3 succeeded at ~1433 GFLOP/s each.

Verified on the host via sheltie:

```
bash-5.2# cat /run/nvidia/mps/nvidia.com/gpu.shared/log/control.log
```

MPS control log confirms per-UID server created with no crash loops:

```
[2026-04-28 18:20:41.699 Control 3511] NEW CLIENT 4267 from user 1000: Server is not ready, push client to pending list
[2026-04-28 18:20:41.701 Control 4428] Starting new server 4428 for user 1000
[2026-04-28 18:20:41.986 Control 3511] NEW SERVER 4428: Ready
[2026-04-28 18:20:41.986 Control 3511] NEW CLIENT 4281 from user 1000: Server already exists
[2026-04-28 18:20:41.986 Control 3511] NEW CLIENT 4274 from user 1000: Server already exists
[2026-04-28 18:20:42.053 Control 3511] NEW CLIENT 4267 from user 1000: Server already exists
```

<details>
<summary>Full control.log</summary>

```
[2026-04-28 18:19:45.384 Control 3511] Starting control daemon using socket /run/nvidia/mps/nvidia.com/gpu.shared/pipe/control
[2026-04-28 18:19:45.384 Control 3511] To connect CUDA applications to this daemon, set env CUDA_MPS_PIPE_DIRECTORY=/run/nvidia/mps/nvidia.com/gpu.shared/pipe
[2026-04-28 18:19:45.384 Control 3511] CUDA MPS Control binary version: 13000
[2026-04-28 18:19:45.386 Control 3511] Accepting connection...
[2026-04-28 18:19:45.387 Control 3511] NEW UI
[2026-04-28 18:19:45.387 Control 3511] Cmd:set_default_device_pinned_mem_limit 0 5120M
[2026-04-28 18:19:45.387 Control 3511] set_default_device_pinned_mem_limit 0 5120M.
[2026-04-28 18:19:45.387 Control 3511] UI closed
[2026-04-28 18:19:45.388 Control 3511] Accepting connection...
[2026-04-28 18:19:45.388 Control 3511] NEW UI
[2026-04-28 18:19:45.388 Control 3511] Cmd:set_default_active_thread_percentage 33
[2026-04-28 18:19:45.388 Control 3511] 33.0
[2026-04-28 18:19:45.388 Control 3511] UI closed
[2026-04-28 18:19:45.485 Control 3511] Accepting connection...
[2026-04-28 18:19:45.485 Control 3511] NEW UI
[2026-04-28 18:19:45.485 Control 3511] Cmd:get_default_active_thread_percentage
[2026-04-28 18:19:45.485 Control 3511] 33.0
[2026-04-28 18:19:45.485 Control 3511] UI closed
[2026-04-28 18:20:41.699 Control 3511] Accepting connection...
[2026-04-28 18:20:41.699 Control 3511] User did not send valid credentials
[2026-04-28 18:20:41.699 Control 3511] Accepting connection...
[2026-04-28 18:20:41.699 Control 3511] NEW CLIENT 4267 from user 1000: Server is not ready, push client to pending list
[2026-04-28 18:20:41.701 Control 4428] Starting new server 4428 for user 1000
[2026-04-28 18:20:41.704 Control 3511] Accepting connection...
[2026-04-28 18:20:41.986 Control 3511] NEW SERVER 4428: Ready
[2026-04-28 18:20:41.986 Control 3511] Accepting connection...
[2026-04-28 18:20:41.986 Control 3511] User did not send valid credentials
[2026-04-28 18:20:41.986 Control 3511] Accepting connection...
[2026-04-28 18:20:41.986 Control 3511] User did not send valid credentials
[2026-04-28 18:20:41.986 Control 3511] Accepting connection...
[2026-04-28 18:20:41.986 Control 3511] NEW CLIENT 4281 from user 1000: Server already exists
[2026-04-28 18:20:41.986 Control 3511] Accepting connection...
[2026-04-28 18:20:41.986 Control 3511] NEW CLIENT 4274 from user 1000: Server already exists
[2026-04-28 18:20:42.053 Control 3511] Accepting connection...
[2026-04-28 18:20:42.053 Control 3511] NEW CLIENT 4267 from user 1000: Server already exists
[2026-04-28 18:20:42.111 Control 3511] Accepting connection...
[2026-04-28 18:20:42.111 Control 3511] NEW CLIENT 4281 from user 1000: Server already exists
[2026-04-28 18:20:42.112 Control 3511] Accepting connection...
[2026-04-28 18:20:42.112 Control 3511] NEW CLIENT 4274 from user 1000: Server already exists
```

</details>

<details>
<summary>Full server.log</summary>

```
[2026-04-28 18:20:41.704 Other 4428] Startup
[2026-04-28 18:20:41.704 Other 4428] Connecting to control daemon on socket: /run/nvidia/mps/nvidia.com/gpu.shared/pipe/control
[2026-04-28 18:20:41.704 Other 4428] Initializing server process
[2026-04-28 18:20:41.855 Server 4428] Creating server context on device 0 (Tesla T4)
[2026-04-28 18:20:41.985 Server 4428] Created anonymous shared memory region mps.shm.1000.4428
[2026-04-28 18:20:41.986 Server 4428] CUDA MPS Server for Linux/Unix. Binary version: 13000
[2026-04-28 18:20:41.986 Server 4428] Display Driver version: 580
[2026-04-28 18:20:41.986 Server 4428] Active Threads Percentage set to 33.0
[2026-04-28 18:20:41.986 Server 4428] Device pinned memory limit for device 0 set to 0x140000000 bytes
[2026-04-28 18:20:41.986 Server 4428] Server Priority set to 0
[2026-04-28 18:20:41.986 Server 4428] Server has started
[2026-04-28 18:20:41.986 Server 4428] Received new client request for {PID: 1073741824, Context ID: 1}
[2026-04-28 18:20:41.986 Server 4428] Client {PID: 4267, Context ID: 0} connected
[2026-04-28 18:20:41.986 Server 4428] Creating worker thread for client {PID: 4267, Context ID: 0}
[2026-04-28 18:20:41.986 Server 4428] Received new client request for {PID: 4267, Context ID: 0}
[2026-04-28 18:20:41.986 Server 4428] Client {PID: 4281, Context ID: 0} connected
[2026-04-28 18:20:41.986 Server 4428] Creating worker thread for client {PID: 4281, Context ID: 0}
[2026-04-28 18:20:41.986 Server 4428] Received new client request for {PID: 4281, Context ID: 0}
[2026-04-28 18:20:41.987 Server 4428] Client {PID: 4274, Context ID: 0} connected
[2026-04-28 18:20:41.987 Server 4428] Creating worker thread for client {PID: 4274, Context ID: 0}
[2026-04-28 18:20:42.053 Server 4428] Received new client request for {PID: 4274, Context ID: 0}
[2026-04-28 18:20:42.111 Server 4428] Client {PID: 4267, Context ID: 1} connected
[2026-04-28 18:20:42.111 Server 4428] Creating worker thread for client {PID: 4267, Context ID: 1}
[2026-04-28 18:20:42.111 Server 4428] Device Tesla T4 (uuid GPU-4e2af2c5-107c-46c0-103b-0dfecc2330d2) is associated
[2026-04-28 18:20:42.111 Server 4428] Status of client {PID: 4267, Context ID: 1} is ACTIVE
[2026-04-28 18:20:42.111 Server 4428] Received new client request for {PID: 4267, Context ID: 1}
[2026-04-28 18:20:42.112 Server 4428] Client {PID: 4281, Context ID: 1} connected
[2026-04-28 18:20:42.112 Server 4428] Creating worker thread for client {PID: 4281, Context ID: 1}
[2026-04-28 18:20:42.112 Server 4428] Device Tesla T4 (uuid GPU-4e2af2c5-107c-46c0-103b-0dfecc2330d2) is associated
[2026-04-28 18:20:42.112 Server 4428] Status of client {PID: 4281, Context ID: 1} is ACTIVE
[2026-04-28 18:20:42.112 Server 4428] Received new client request for {PID: 4281, Context ID: 1}
[2026-04-28 18:20:42.112 Server 4428] Creating worker thread for client {PID: 4274, Context ID: 1}
[2026-04-28 18:20:42.112 Server 4428] Device Tesla T4 (uuid GPU-4e2af2c5-107c-46c0-103b-0dfecc2330d2) is associated
[2026-04-28 18:20:42.112 Server 4428] Client {PID: 4274, Context ID: 1} connected
[2026-04-28 18:20:42.112 Server 4428] Status of client {PID: 4274, Context ID: 1} is ACTIVE
[2026-04-28 18:20:46.114 Server 4428] Server failed to recevie command with status 806, assuming client {PID: 4281, Context ID: 1} exit
[2026-04-28 18:20:46.115 Server 4428] Client {PID: 4281, Context ID: 1} exiting. Number of active client contexts is 2.
[2026-04-28 18:20:46.144 Server 4428] Server failed to recevie command with status 806, assuming client {PID: 4281, Context ID: 0} exit
[2026-04-28 18:20:46.144 Server 4428] Client process 4281 disconnected
[2026-04-28 18:20:46.182 Server 4428] Server failed to recevie command with status 806, assuming client {PID: 4267, Context ID: 1} exit
[2026-04-28 18:20:46.182 Server 4428] Client {PID: 4267, Context ID: 1} exiting. Number of active client contexts is 1.
[2026-04-28 18:20:46.187 Server 4428] Server failed to recevie command with status 806, assuming client {PID: 4274, Context ID: 1} exit
[2026-04-28 18:20:46.187 Server 4428] Client {PID: 4274, Context ID: 1} exiting. Number of active client contexts is 0.
[2026-04-28 18:20:46.211 Server 4428] Server failed to recevie command with status 806, assuming client {PID: 4267, Context ID: 0} exit
[2026-04-28 18:20:46.211 Server 4428] Client process 4267 disconnected
[2026-04-28 18:20:46.251 Server 4428] Server failed to recevie command with status 806, assuming client {PID: 4274, Context ID: 0} exit
[2026-04-28 18:20:46.251 Server 4428] Client process 4274 disconnected
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
