### PR TITLE
Update kernel-kit to v5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v5.4.1 (2026-04-30)
+
+## OS Changes
+* Backport patches to revert algif_aead to out-of-place operation ([#416])
+
+[#416]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/416
+
 # v5.4.0 (2026-04-23)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "5.4.0"
+release-version = "5.4.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/packages/kernel-6.1/1008-crypto-scatterwalk-Backport-memcpy_sglist.patch
+++ b/packages/kernel-6.1/1008-crypto-scatterwalk-Backport-memcpy_sglist.patch
@@ -1,0 +1,167 @@
+From: Eric Biggers <ebiggers@kernel.org>
+Date: Wed, 29 Apr 2026 23:27:23 -0700
+Subject: crypto: scatterwalk - Backport memcpy_sglist()
+
+This backports the current implementation of memcpy_sglist() from
+upstream commit 4dffc9bbffb9ccfcda730d899c97c553599e7ca8.
+
+This function was rewritten twice.  The earlier implementations had many
+prerequisite commits, while the latest implementation is standalone.
+It's much easier to just backport the latest code directly.
+
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-2-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/scatterwalk.c b/crypto/scatterwalk.c
+--- a/crypto/scatterwalk.c
++++ b/crypto/scatterwalk.c
+@@ -69,6 +69,100 @@ void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+ }
+ EXPORT_SYMBOL_GPL(scatterwalk_map_and_copy);
+ 
++/**
++ * memcpy_sglist() - Copy data from one scatterlist to another
++ * @dst: The destination scatterlist.  Can be NULL if @nbytes == 0.
++ * @src: The source scatterlist.  Can be NULL if @nbytes == 0.
++ * @nbytes: Number of bytes to copy
++ *
++ * The scatterlists can describe exactly the same memory, in which case this
++ * function is a no-op.  No other overlaps are supported.
++ *
++ * Context: Any context
++ */
++void memcpy_sglist(struct scatterlist *dst, struct scatterlist *src,
++		   unsigned int nbytes)
++{
++	unsigned int src_offset, dst_offset;
++
++	if (unlikely(nbytes == 0)) /* in case src and/or dst is NULL */
++		return;
++
++	src_offset = src->offset;
++	dst_offset = dst->offset;
++	for (;;) {
++		/* Compute the length to copy this step. */
++		unsigned int len = min3(src->offset + src->length - src_offset,
++					dst->offset + dst->length - dst_offset,
++					nbytes);
++		struct page *src_page = sg_page(src);
++		struct page *dst_page = sg_page(dst);
++		const void *src_virt;
++		void *dst_virt;
++
++		if (IS_ENABLED(CONFIG_HIGHMEM)) {
++			/* HIGHMEM: we may have to actually map the pages. */
++			const unsigned int src_oip = offset_in_page(src_offset);
++			const unsigned int dst_oip = offset_in_page(dst_offset);
++			const unsigned int limit = PAGE_SIZE;
++
++			/* Further limit len to not cross a page boundary. */
++			len = min3(len, limit - src_oip, limit - dst_oip);
++
++			/* Compute the source and destination pages. */
++			src_page += src_offset / PAGE_SIZE;
++			dst_page += dst_offset / PAGE_SIZE;
++
++			if (src_page != dst_page) {
++				/* Copy between different pages. */
++				memcpy_page(dst_page, dst_oip,
++					    src_page, src_oip, len);
++				flush_dcache_page(dst_page);
++			} else if (src_oip != dst_oip) {
++				/* Copy between different parts of same page. */
++				dst_virt = kmap_local_page(dst_page);
++				memcpy(dst_virt + dst_oip, dst_virt + src_oip,
++				       len);
++				kunmap_local(dst_virt);
++				flush_dcache_page(dst_page);
++			} /* Else, it's the same memory.  No action needed. */
++		} else {
++			/*
++			 * !HIGHMEM: no mapping needed.  Just work in the linear
++			 * buffer of each sg entry.  Note that we can cross page
++			 * boundaries, as they are not significant in this case.
++			 */
++			src_virt = page_address(src_page) + src_offset;
++			dst_virt = page_address(dst_page) + dst_offset;
++			if (src_virt != dst_virt) {
++				memcpy(dst_virt, src_virt, len);
++				if (ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE)
++					__scatterwalk_flush_dcache_pages(
++						dst_page, dst_offset, len);
++			} /* Else, it's the same memory.  No action needed. */
++		}
++		nbytes -= len;
++		if (nbytes == 0) /* No more to copy? */
++			break;
++
++		/*
++		 * There's more to copy.  Advance the offsets by the length
++		 * copied this step, and advance the sg entries as needed.
++		 */
++		src_offset += len;
++		if (src_offset >= src->offset + src->length) {
++			src = sg_next(src);
++			src_offset = src->offset;
++		}
++		dst_offset += len;
++		if (dst_offset >= dst->offset + dst->length) {
++			dst = sg_next(dst);
++			dst_offset = dst->offset;
++		}
++	}
++}
++EXPORT_SYMBOL_GPL(memcpy_sglist);
++
+ struct scatterlist *scatterwalk_ffwd(struct scatterlist dst[2],
+ 				     struct scatterlist *src,
+ 				     unsigned int len)
+diff --git a/include/crypto/scatterwalk.h b/include/crypto/scatterwalk.h
+--- a/include/crypto/scatterwalk.h
++++ b/include/crypto/scatterwalk.h
+@@ -83,6 +83,34 @@ static inline void scatterwalk_pagedone(struct scatter_walk *walk, int out,
+ 		scatterwalk_start(walk, sg_next(walk->sg));
+ }
+ 
++/*
++ * Flush the dcache of any pages that overlap the region
++ * [offset, offset + nbytes) relative to base_page.
++ *
++ * This should be called only when ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE, to ensure
++ * that all relevant code (including the call to sg_page() in the caller, if
++ * applicable) gets fully optimized out when !ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE.
++ */
++static inline void __scatterwalk_flush_dcache_pages(struct page *base_page,
++						    unsigned int offset,
++						    unsigned int nbytes)
++{
++	unsigned int num_pages;
++
++	base_page += offset / PAGE_SIZE;
++	offset %= PAGE_SIZE;
++
++	/*
++	 * This is an overflow-safe version of
++	 * num_pages = DIV_ROUND_UP(offset + nbytes, PAGE_SIZE).
++	 */
++	num_pages = nbytes / PAGE_SIZE;
++	num_pages += DIV_ROUND_UP(offset + (nbytes % PAGE_SIZE), PAGE_SIZE);
++
++	for (unsigned int i = 0; i < num_pages; i++)
++		flush_dcache_page(base_page + i);
++}
++
+ static inline void scatterwalk_done(struct scatter_walk *walk, int out,
+ 				    int more)
+ {
+@@ -95,6 +123,9 @@ void scatterwalk_copychunks(void *buf, struct scatter_walk *walk,
+ 			    size_t nbytes, int out);
+ void *scatterwalk_map(struct scatter_walk *walk);
+ 
++void memcpy_sglist(struct scatterlist *dst, struct scatterlist *src,
++		   unsigned int nbytes);
++
+ void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+ 			      unsigned int start, unsigned int nbytes, int out);
+ 

--- a/packages/kernel-6.1/1009-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
+++ b/packages/kernel-6.1/1009-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
@@ -1,0 +1,236 @@
+From: Eric Biggers <ebiggers@google.com>
+Date: Wed, 29 Apr 2026 23:27:24 -0700
+Subject: crypto: algif_aead - use memcpy_sglist() instead of null skcipher
+
+commit f2804d0eee8ddd57aa79d0b82872b74c21e1b69b upstream.
+
+For copying data between two scatterlists, just use memcpy_sglist()
+instead of the so-called "null skcipher".  This is much simpler.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-3-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/Kconfig b/crypto/Kconfig
+--- a/crypto/Kconfig
++++ b/crypto/Kconfig
+@@ -1371,7 +1371,6 @@ config CRYPTO_USER_API_AEAD
+ 	depends on NET
+ 	select CRYPTO_AEAD
+ 	select CRYPTO_SKCIPHER
+-	select CRYPTO_NULL
+ 	select CRYPTO_USER_API
+ 	help
+ 	  Enable the userspace interface for AEAD cipher algorithms.
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -27,7 +27,6 @@
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+ #include <crypto/skcipher.h>
+-#include <crypto/null.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -36,19 +35,13 @@
+ #include <linux/net.h>
+ #include <net/sock.h>
+ 
+-struct aead_tfm {
+-	struct crypto_aead *aead;
+-	struct crypto_sync_skcipher *null_tfm;
+-};
+-
+ static inline bool aead_sufficient_data(struct sock *sk)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
+ 
+ 	/*
+@@ -64,27 +57,12 @@ static int aead_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 
+ 	return af_alg_sendmsg(sock, msg, size, ivsize);
+ }
+ 
+-static int crypto_aead_copy_sgl(struct crypto_sync_skcipher *null_tfm,
+-				struct scatterlist *src,
+-				struct scatterlist *dst, unsigned int len)
+-{
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, null_tfm);
+-
+-	skcipher_request_set_sync_tfm(skreq, null_tfm);
+-	skcipher_request_set_callback(skreq, CRYPTO_TFM_REQ_MAY_SLEEP,
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, src, dst, len, NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 			 size_t ignored, int flags)
+ {
+@@ -93,9 +71,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
+-	struct crypto_sync_skcipher *null_tfm = aeadc->null_tfm;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int i, as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct af_alg_tsgl *tsgl, *tmp;
+@@ -223,10 +199,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		 *	    v	   v
+ 		 * RX SGL: AAD || PT || Tag
+ 		 */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sg, processed);
+-		if (err)
+-			goto free;
++		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, processed);
+ 		af_alg_pull_tsgl(sk, processed, NULL, 0);
+ 	} else {
+ 		/*
+@@ -240,11 +213,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		 * RX SGL: AAD || CT ----+
+ 		 */
+ 
+-		 /* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sg, outlen);
+-		if (err)
+-			goto free;
++		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
++		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, outlen);
+ 
+ 		/* Create TX SGL for tag and chain it to RX SGL. */
+ 		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+@@ -378,7 +348,7 @@ static int aead_check_key(struct socket *sock)
+ 	int err = 0;
+ 	struct sock *psk;
+ 	struct alg_sock *pask;
+-	struct aead_tfm *tfm;
++	struct crypto_aead *tfm;
+ 	struct sock *sk = sock->sk;
+ 	struct alg_sock *ask = alg_sk(sk);
+ 
+@@ -392,7 +362,7 @@ static int aead_check_key(struct socket *sock)
+ 
+ 	err = -ENOKEY;
+ 	lock_sock_nested(psk, SINGLE_DEPTH_NESTING);
+-	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
++	if (crypto_aead_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		goto unlock;
+ 
+ 	atomic_dec(&pask->nokey_refcnt);
+@@ -466,54 +436,22 @@ static struct proto_ops algif_aead_ops_nokey = {
+ 
+ static void *aead_bind(const char *name, u32 type, u32 mask)
+ {
+-	struct aead_tfm *tfm;
+-	struct crypto_aead *aead;
+-	struct crypto_sync_skcipher *null_tfm;
+-
+-	tfm = kzalloc(sizeof(*tfm), GFP_KERNEL);
+-	if (!tfm)
+-		return ERR_PTR(-ENOMEM);
+-
+-	aead = crypto_alloc_aead(name, type, mask);
+-	if (IS_ERR(aead)) {
+-		kfree(tfm);
+-		return ERR_CAST(aead);
+-	}
+-
+-	null_tfm = crypto_get_default_null_skcipher();
+-	if (IS_ERR(null_tfm)) {
+-		crypto_free_aead(aead);
+-		kfree(tfm);
+-		return ERR_CAST(null_tfm);
+-	}
+-
+-	tfm->aead = aead;
+-	tfm->null_tfm = null_tfm;
+-
+-	return tfm;
++	return crypto_alloc_aead(name, type, mask);
+ }
+ 
+ static void aead_release(void *private)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	crypto_free_aead(tfm->aead);
+-	crypto_put_default_null_skcipher();
+-	kfree(tfm);
++	crypto_free_aead(private);
+ }
+ 
+ static int aead_setauthsize(void *private, unsigned int authsize)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	return crypto_aead_setauthsize(tfm->aead, authsize);
++	return crypto_aead_setauthsize(private, authsize);
+ }
+ 
+ static int aead_setkey(void *private, const u8 *key, unsigned int keylen)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	return crypto_aead_setkey(tfm->aead, key, keylen);
++	return crypto_aead_setkey(private, key, keylen);
+ }
+ 
+ static void aead_sock_destruct(struct sock *sk)
+@@ -522,8 +460,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+ 	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
+@@ -536,10 +473,9 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ {
+ 	struct af_alg_ctx *ctx;
+ 	struct alg_sock *ask = alg_sk(sk);
+-	struct aead_tfm *tfm = private;
+-	struct crypto_aead *aead = tfm->aead;
++	struct crypto_aead *tfm = private;
+ 	unsigned int len = sizeof(*ctx);
+-	unsigned int ivlen = crypto_aead_ivsize(aead);
++	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+ 	ctx = sock_kmalloc(sk, len, GFP_KERNEL);
+ 	if (!ctx)
+@@ -566,9 +502,9 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ 
+ static int aead_accept_parent(void *private, struct sock *sk)
+ {
+-	struct aead_tfm *tfm = private;
++	struct crypto_aead *tfm = private;
+ 
+-	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
++	if (crypto_aead_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		return -ENOKEY;
+ 
+ 	return aead_accept_parent_nokey(private, sk);

--- a/packages/kernel-6.1/1010-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+++ b/packages/kernel-6.1/1010-crypto-algif_aead-Revert-to-operating-out-of-place.patch
@@ -1,0 +1,308 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:27:25 -0700
+Subject: crypto: algif_aead - Revert to operating out-of-place
+
+commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 upstream.
+
+This mostly reverts commit 72548b093ee3 except for the copying of
+the associated data.
+
+There is no benefit in operating in-place in algif_aead since the
+source and destination come from different mappings.  Get rid of
+all the complexity added for in-place operation and just copy the
+AD directly.
+
+Fixes: 72548b093ee3 ("crypto: algif_aead - copy AAD from src to dst")
+Reported-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-4-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -526,15 +526,13 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	const struct alg_sock *ask = alg_sk(sk);
+ 	const struct af_alg_ctx *ctx = ask->private;
+@@ -549,25 +547,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		const struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -579,19 +563,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -616,18 +595,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -26,7 +26,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -72,9 +71,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -154,23 +152,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -179,75 +178,15 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sg;
+ 
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, processed);
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		memcpy_sglist(areq->first_rsgl.sgl.sg, tsgl_src, outlen);
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-
+-			sg_unmark_end(sgl_prev->sg + sgl_prev->npages - 1);
+-			sg_chain(sgl_prev->sg, sgl_prev->npages + 1,
+-				 areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	memcpy_sglist(rsgl_src, tsgl_src, ctx->aead_assoclen);
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sg, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -463,7 +402,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -89,7 +89,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -100,7 +100,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -313,7 +313,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -230,9 +230,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ 	return PAGE_SIZE <= af_alg_rcvbuf(sk);
+ }
+ 
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
+ void af_alg_wmem_wakeup(struct sock *sk);
+ int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,

--- a/packages/kernel-6.1/1011-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+++ b/packages/kernel-6.1/1011-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
@@ -1,0 +1,70 @@
+From: Douya Le <ldy3087146292@gmail.com>
+Date: Wed, 29 Apr 2026 23:27:26 -0700
+Subject: crypto: algif_aead - snapshot IV for async AEAD requests
+
+commit 5aa58c3a572b3e3b6c786953339f7978b845cc52 upstream.
+
+AF_ALG AEAD AIO requests currently use the socket-wide IV buffer during
+request processing.  For async requests, later socket activity can
+update that shared state before the original request has fully
+completed, which can lead to inconsistent IV handling.
+
+Snapshot the IV into per-request storage when preparing the AEAD
+request, so in-flight operations no longer depend on mutable socket
+state.
+
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Cc: stable@kernel.org
+Reported-by: Yuan Tan <yuantan098@gmail.com>
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Reported-by: Xin Liu <bird@lzu.edu.cn>
+Co-developed-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Signed-off-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Tested-by: Yucheng Lu <kanolyc@gmail.com>
+Signed-off-by: Douya Le <ldy3087146292@gmail.com>
+Signed-off-by: Ren Wei <n05ec@lzu.edu.cn>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-5-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -72,8 +72,10 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
++	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
++	void *iv;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+ 	size_t outlen = 0;		/* [out] RX bufs produced by kernel */
+@@ -125,10 +127,14 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Allocate cipher request for current operation. */
+ 	areq = af_alg_alloc_areq(sk, sizeof(struct af_alg_async_req) +
+-				     crypto_aead_reqsize(tfm));
++				     crypto_aead_reqsize(tfm) + ivsize);
+ 	if (IS_ERR(areq))
+ 		return PTR_ERR(areq);
+ 
++	iv = (u8 *)aead_request_ctx(&areq->cra_u.aead_req) +
++	     crypto_aead_reqsize(tfm);
++	memcpy(iv, ctx->iv, ivsize);
++
+ 	/* convert iovecs of output buffers into RX SGL */
+ 	err = af_alg_get_rsgl(sk, msg, flags, areq, outlen, &usedpages);
+ 	if (err)
+@@ -187,7 +193,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Initialize the crypto operation */
+ 	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+-			       areq->first_rsgl.sgl.sg, used, ctx->iv);
++			       areq->first_rsgl.sgl.sg, used, iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+ 

--- a/packages/kernel-6.1/1012-crypto-authenc-use-memcpy_sglist-instead-of-null-skcipher.patch
+++ b/packages/kernel-6.1/1012-crypto-authenc-use-memcpy_sglist-instead-of-null-skcipher.patch
@@ -1,0 +1,225 @@
+From: Eric Biggers <ebiggers@google.com>
+Date: Wed, 29 Apr 2026 23:27:27 -0700
+Subject: crypto: authenc - use memcpy_sglist() instead of null skcipher
+
+commit dbc4b1458e931e47198c3165ff5853bc1ad6bd7a upstream.
+
+For copying data between two scatterlists, just use memcpy_sglist()
+instead of the so-called "null skcipher".  This is much simpler.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-6-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/Kconfig b/crypto/Kconfig
+--- a/crypto/Kconfig
++++ b/crypto/Kconfig
+@@ -216,7 +216,6 @@ config CRYPTO_AUTHENC
+ 	select CRYPTO_SKCIPHER
+ 	select CRYPTO_MANAGER
+ 	select CRYPTO_HASH
+-	select CRYPTO_NULL
+ 	help
+ 	  Authenc: Combined mode wrapper for IPsec.
+ 
+diff --git a/crypto/authenc.c b/crypto/authenc.c
+--- a/crypto/authenc.c
++++ b/crypto/authenc.c
+@@ -9,7 +9,6 @@
+ #include <crypto/internal/hash.h>
+ #include <crypto/internal/skcipher.h>
+ #include <crypto/authenc.h>
+-#include <crypto/null.h>
+ #include <crypto/scatterwalk.h>
+ #include <linux/err.h>
+ #include <linux/init.h>
+@@ -28,7 +27,6 @@ struct authenc_instance_ctx {
+ struct crypto_authenc_ctx {
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_request_ctx {
+@@ -174,21 +172,6 @@ static void crypto_authenc_encrypt_done(struct crypto_async_request *req,
+ 	authenc_request_complete(areq, err);
+ }
+ 
+-static int crypto_authenc_copy_assoc(struct aead_request *req)
+-{
+-	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+-	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(authenc);
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+-
+-	skcipher_request_set_sync_tfm(skreq, ctx->null);
+-	skcipher_request_set_callback(skreq, aead_request_flags(req),
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, req->src, req->dst, req->assoclen,
+-				   NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int crypto_authenc_encrypt(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+@@ -207,10 +190,7 @@ static int crypto_authenc_encrypt(struct aead_request *req)
+ 	dst = src;
+ 
+ 	if (req->src != req->dst) {
+-		err = crypto_authenc_copy_assoc(req);
+-		if (err)
+-			return err;
+-
++		memcpy_sglist(req->dst, req->src, req->assoclen);
+ 		dst = scatterwalk_ffwd(areq_ctx->dst, req->dst, req->assoclen);
+ 	}
+ 
+@@ -311,7 +291,6 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+@@ -323,14 +302,8 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	if (IS_ERR(enc))
+ 		goto err_free_ahash;
+ 
+-	null = crypto_get_default_null_skcipher();
+-	err = PTR_ERR(null);
+-	if (IS_ERR(null))
+-		goto err_free_skcipher;
+-
+ 	ctx->auth = auth;
+ 	ctx->enc = enc;
+-	ctx->null = null;
+ 
+ 	crypto_aead_set_reqsize(
+ 		tfm,
+@@ -344,8 +317,6 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 
+ 	return 0;
+ 
+-err_free_skcipher:
+-	crypto_free_skcipher(enc);
+ err_free_ahash:
+ 	crypto_free_ahash(auth);
+ 	return err;
+@@ -357,7 +328,6 @@ static void crypto_authenc_exit_tfm(struct crypto_aead *tfm)
+ 
+ 	crypto_free_ahash(ctx->auth);
+ 	crypto_free_skcipher(ctx->enc);
+-	crypto_put_default_null_skcipher();
+ }
+ 
+ static void crypto_authenc_free(struct aead_instance *inst)
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -12,7 +12,6 @@
+ #include <crypto/internal/hash.h>
+ #include <crypto/internal/skcipher.h>
+ #include <crypto/authenc.h>
+-#include <crypto/null.h>
+ #include <crypto/scatterwalk.h>
+ #include <linux/err.h>
+ #include <linux/init.h>
+@@ -31,7 +30,6 @@ struct crypto_authenc_esn_ctx {
+ 	unsigned int reqoff;
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_esn_request_ctx {
+@@ -164,20 +162,6 @@ static void crypto_authenc_esn_encrypt_done(struct crypto_async_request *req,
+ 	authenc_esn_request_complete(areq, err);
+ }
+ 
+-static int crypto_authenc_esn_copy(struct aead_request *req, unsigned int len)
+-{
+-	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+-	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(authenc_esn);
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+-
+-	skcipher_request_set_sync_tfm(skreq, ctx->null);
+-	skcipher_request_set_callback(skreq, aead_request_flags(req),
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, req->src, req->dst, len, NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+@@ -199,10 +183,7 @@ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ 	dst = src;
+ 
+ 	if (req->src != req->dst) {
+-		err = crypto_authenc_esn_copy(req, assoclen);
+-		if (err)
+-			return err;
+-
++		memcpy_sglist(req->dst, req->src, assoclen);
+ 		sg_init_table(areq_ctx->dst, 2);
+ 		dst = scatterwalk_ffwd(areq_ctx->dst, req->dst, assoclen);
+ 	}
+@@ -292,11 +273,8 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 
+ 	cryptlen -= authsize;
+ 
+-	if (req->src != dst) {
+-		err = crypto_authenc_esn_copy(req, assoclen + cryptlen);
+-		if (err)
+-			return err;
+-	}
++	if (req->src != dst)
++		memcpy_sglist(dst, req->src, assoclen + cryptlen);
+ 
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+@@ -332,7 +310,6 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+@@ -344,14 +321,8 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	if (IS_ERR(enc))
+ 		goto err_free_ahash;
+ 
+-	null = crypto_get_default_null_skcipher();
+-	err = PTR_ERR(null);
+-	if (IS_ERR(null))
+-		goto err_free_skcipher;
+-
+ 	ctx->auth = auth;
+ 	ctx->enc = enc;
+-	ctx->null = null;
+ 
+ 	ctx->reqoff = ALIGN(2 * crypto_ahash_digestsize(auth),
+ 			    crypto_ahash_alignmask(auth) + 1);
+@@ -368,8 +339,6 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 
+ 	return 0;
+ 
+-err_free_skcipher:
+-	crypto_free_skcipher(enc);
+ err_free_ahash:
+ 	crypto_free_ahash(auth);
+ 	return err;
+@@ -381,7 +350,6 @@ static void crypto_authenc_esn_exit_tfm(struct crypto_aead *tfm)
+ 
+ 	crypto_free_ahash(ctx->auth);
+ 	crypto_free_skcipher(ctx->enc);
+-	crypto_put_default_null_skcipher();
+ }
+ 
+ static void crypto_authenc_esn_free(struct aead_instance *inst)

--- a/packages/kernel-6.1/1013-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
+++ b/packages/kernel-6.1/1013-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
@@ -1,0 +1,115 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:27:28 -0700
+Subject: crypto: authencesn - Do not place hiseq at end of dst for
+ out-of-place decryption
+
+commit e02494114ebf7c8b42777c6cd6982f113bfdbec7 upstream.
+
+When decrypting data that is not in-place (src != dst), there is
+no need to save the high-order sequence bits in dst as it could
+simply be re-copied from the source.
+
+However, the data to be hashed need to be rearranged accordingly.
+
+Reported-by: Taeyang Lee <0wn@theori.io>
+Fixes: 104880a6b470 ("crypto: authencesn - Convert to new AEAD interface")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-7-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -214,6 +214,7 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 			      crypto_ahash_alignmask(auth) + 1);
+ 	unsigned int cryptlen = req->cryptlen - authsize;
+ 	unsigned int assoclen = req->assoclen;
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
+ 	u32 tmp[2];
+@@ -221,23 +222,27 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 	if (!authsize)
+ 		goto decrypt;
+ 
+-	/* Move high-order bits of sequence number back. */
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	if (src == dst) {
++		/* Move high-order bits of sequence number back. */
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
++		scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	} else
++		memcpy_sglist(dst, src, assoclen);
+ 
+ 	if (crypto_memneq(ihash, ohash, authsize))
+ 		return -EBADMSG;
+ 
+ decrypt:
+ 
+-	sg_init_table(areq_ctx->dst, 2);
++	if (src != dst)
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,
+ 				      req->base.complete, req->base.data);
+-	skcipher_request_set_crypt(skreq, dst, dst, cryptlen, req->iv);
++	skcipher_request_set_crypt(skreq, src, dst, cryptlen, req->iv);
+ 
+ 	return crypto_skcipher_decrypt(skreq);
+ }
+@@ -264,6 +269,7 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	unsigned int assoclen = req->assoclen;
+ 	unsigned int cryptlen = req->cryptlen;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u32 tmp[2];
+ 	int err;
+@@ -271,24 +277,28 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	if (assoclen < 8)
+ 		return -EINVAL;
+ 
+-	cryptlen -= authsize;
+-
+-	if (req->src != dst)
+-		memcpy_sglist(dst, req->src, assoclen + cryptlen);
++	if (!authsize)
++		goto tail;
+ 
++	cryptlen -= authsize;
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+ 
+-	if (!authsize)
+-		goto tail;
+-
+ 	/* Move high-order bits of sequence number to the end. */
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
+-
+-	sg_init_table(areq_ctx->dst, 2);
+-	dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	scatterwalk_map_and_copy(tmp, src, 0, 8, 0);
++	if (src == dst) {
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	} else {
++		scatterwalk_map_and_copy(tmp, dst, 0, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen - 4, 4, 1);
++
++		src = scatterwalk_ffwd(areq_ctx->src, src, 8);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++		memcpy_sglist(dst, src, assoclen + cryptlen - 8);
++		dst = req->dst;
++	}
+ 
+ 	ahash_request_set_tfm(ahreq, auth);
+ 	ahash_request_set_crypt(ahreq, dst, ohash, assoclen + cryptlen);

--- a/packages/kernel-6.1/1014-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
+++ b/packages/kernel-6.1/1014-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
@@ -1,0 +1,33 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:27:29 -0700
+Subject: crypto: authencesn - Fix src offset when decrypting in-place
+
+commit 1f48ad3b19a9dfc947868edda0bb8e48e5b5a8fa upstream.
+
+The src SG list offset wasn't set properly when decrypting in-place,
+fix it.
+
+Reported-by: Wolfgang Walter <linux@stwm.de>
+Fixes: e02494114ebf ("crypto: authencesn - Do not place hiseq at end of dst for out-of-place decryption")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-8-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -235,9 +235,11 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 
+ decrypt:
+ 
+-	if (src != dst)
+-		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
++	if (req->src == req->dst)
++		src = dst;
++	else
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,

--- a/packages/kernel-6.1/1015-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
+++ b/packages/kernel-6.1/1015-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
@@ -1,0 +1,36 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:27:30 -0700
+Subject: crypto: af_alg - Fix page reassignment overflow in af_alg_pull_tsgl
+
+commit 31d00156e50ecad37f2cb6cbf04aaa9a260505ef upstream.
+
+When page reassignment was added to af_alg_pull_tsgl the original
+loop wasn't updated so it may try to reassign one more page than
+necessary.
+
+Add the check to the reassignment so that this does not happen.
+
+Also update the comment which still refers to the obsolete offset
+argument.
+
+Reported-by: syzbot+d23888375c2737c17ba5@syzkaller.appspotmail.com
+Fixes: e870456d8e7c ("crypto: algif_skcipher - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-9-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -594,8 +594,8 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ 			 * Assumption: caller created af_alg_count_tsgl(len)
+ 			 * SG entries in dst.
+ 			 */
+-			if (dst) {
+-				/* reassign page to dst after offset */
++			if (dst && plen) {
++				/* reassign page to dst */
+ 				get_page(page);
+ 				sg_set_page(dst + j, page, plen, sg[i].offset);
+ 				j++;

--- a/packages/kernel-6.1/1016-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
+++ b/packages/kernel-6.1/1016-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
@@ -1,0 +1,30 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:27:31 -0700
+Subject: crypto: algif_aead - Fix minimum RX size check for decryption
+
+commit 3d14bd48e3a77091cbce637a12c2ae31b4a1687c upstream.
+
+The check for the minimum receive buffer size did not take the
+tag size into account during decryption.  Fix this by adding the
+required extra length.
+
+Reported-by: syzbot+aa11561819dc42ebbc7c@syzkaller.appspotmail.com
+Reported-by: Daniel Pouzzner <douzzer@mega.nu>
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430062731.140497-10-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -150,7 +150,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	if (usedpages < outlen) {
+ 		size_t less = outlen - usedpages;
+ 
+-		if (used < less) {
++		if (used < less + (ctx->enc ? 0 : as)) {
+ 			err = -EINVAL;
+ 			goto free;
+ 		}

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -60,6 +60,24 @@ Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1007: 1007-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+# Backport memcpy_sglist() for use by algif_aead fix.
+Patch1008: 1008-crypto-scatterwalk-Backport-memcpy_sglist.patch
+# Replace null skcipher with memcpy_sglist() in algif_aead.
+Patch1009: 1009-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
+# Revert algif_aead to out-of-place operation.
+Patch1010: 1010-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+# Snapshot IV for async AEAD requests.
+Patch1011: 1011-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+# Replace null skcipher with memcpy_sglist() in authenc.
+Patch1012: 1012-crypto-authenc-use-memcpy_sglist-instead-of-null-skcipher.patch
+# Fix authencesn out-of-place decryption.
+Patch1013: 1013-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
+# Fix authencesn src offset for in-place decryption.
+Patch1014: 1014-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
+# Fix page reassignment overflow in af_alg_pull_tsgl.
+Patch1015: 1015-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
+# Fix minimum RX size check for AEAD decryption.
+Patch1016: 1016-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.12/1009-crypto-scatterwalk-Backport-memcpy_sglist.patch
+++ b/packages/kernel-6.12/1009-crypto-scatterwalk-Backport-memcpy_sglist.patch
@@ -1,0 +1,167 @@
+From: Eric Biggers <ebiggers@kernel.org>
+Date: Wed, 29 Apr 2026 23:06:55 -0700
+Subject: crypto: scatterwalk - Backport memcpy_sglist()
+
+This backports the current implementation of memcpy_sglist() from
+upstream commit 4dffc9bbffb9ccfcda730d899c97c553599e7ca8.
+
+This function was rewritten twice.  The earlier implementations had many
+prerequisite commits, while the latest implementation is standalone.
+It's much easier to just backport the latest code directly.
+
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-2-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/scatterwalk.c b/crypto/scatterwalk.c
+--- a/crypto/scatterwalk.c
++++ b/crypto/scatterwalk.c
+@@ -69,6 +69,100 @@ void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+ }
+ EXPORT_SYMBOL_GPL(scatterwalk_map_and_copy);
+ 
++/**
++ * memcpy_sglist() - Copy data from one scatterlist to another
++ * @dst: The destination scatterlist.  Can be NULL if @nbytes == 0.
++ * @src: The source scatterlist.  Can be NULL if @nbytes == 0.
++ * @nbytes: Number of bytes to copy
++ *
++ * The scatterlists can describe exactly the same memory, in which case this
++ * function is a no-op.  No other overlaps are supported.
++ *
++ * Context: Any context
++ */
++void memcpy_sglist(struct scatterlist *dst, struct scatterlist *src,
++		   unsigned int nbytes)
++{
++	unsigned int src_offset, dst_offset;
++
++	if (unlikely(nbytes == 0)) /* in case src and/or dst is NULL */
++		return;
++
++	src_offset = src->offset;
++	dst_offset = dst->offset;
++	for (;;) {
++		/* Compute the length to copy this step. */
++		unsigned int len = min3(src->offset + src->length - src_offset,
++					dst->offset + dst->length - dst_offset,
++					nbytes);
++		struct page *src_page = sg_page(src);
++		struct page *dst_page = sg_page(dst);
++		const void *src_virt;
++		void *dst_virt;
++
++		if (IS_ENABLED(CONFIG_HIGHMEM)) {
++			/* HIGHMEM: we may have to actually map the pages. */
++			const unsigned int src_oip = offset_in_page(src_offset);
++			const unsigned int dst_oip = offset_in_page(dst_offset);
++			const unsigned int limit = PAGE_SIZE;
++
++			/* Further limit len to not cross a page boundary. */
++			len = min3(len, limit - src_oip, limit - dst_oip);
++
++			/* Compute the source and destination pages. */
++			src_page += src_offset / PAGE_SIZE;
++			dst_page += dst_offset / PAGE_SIZE;
++
++			if (src_page != dst_page) {
++				/* Copy between different pages. */
++				memcpy_page(dst_page, dst_oip,
++					    src_page, src_oip, len);
++				flush_dcache_page(dst_page);
++			} else if (src_oip != dst_oip) {
++				/* Copy between different parts of same page. */
++				dst_virt = kmap_local_page(dst_page);
++				memcpy(dst_virt + dst_oip, dst_virt + src_oip,
++				       len);
++				kunmap_local(dst_virt);
++				flush_dcache_page(dst_page);
++			} /* Else, it's the same memory.  No action needed. */
++		} else {
++			/*
++			 * !HIGHMEM: no mapping needed.  Just work in the linear
++			 * buffer of each sg entry.  Note that we can cross page
++			 * boundaries, as they are not significant in this case.
++			 */
++			src_virt = page_address(src_page) + src_offset;
++			dst_virt = page_address(dst_page) + dst_offset;
++			if (src_virt != dst_virt) {
++				memcpy(dst_virt, src_virt, len);
++				if (ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE)
++					__scatterwalk_flush_dcache_pages(
++						dst_page, dst_offset, len);
++			} /* Else, it's the same memory.  No action needed. */
++		}
++		nbytes -= len;
++		if (nbytes == 0) /* No more to copy? */
++			break;
++
++		/*
++		 * There's more to copy.  Advance the offsets by the length
++		 * copied this step, and advance the sg entries as needed.
++		 */
++		src_offset += len;
++		if (src_offset >= src->offset + src->length) {
++			src = sg_next(src);
++			src_offset = src->offset;
++		}
++		dst_offset += len;
++		if (dst_offset >= dst->offset + dst->length) {
++			dst = sg_next(dst);
++			dst_offset = dst->offset;
++		}
++	}
++}
++EXPORT_SYMBOL_GPL(memcpy_sglist);
++
+ struct scatterlist *scatterwalk_ffwd(struct scatterlist dst[2],
+ 				     struct scatterlist *src,
+ 				     unsigned int len)
+diff --git a/include/crypto/scatterwalk.h b/include/crypto/scatterwalk.h
+--- a/include/crypto/scatterwalk.h
++++ b/include/crypto/scatterwalk.h
+@@ -83,6 +83,34 @@ static inline void scatterwalk_pagedone(struct scatter_walk *walk, int out,
+ 		scatterwalk_start(walk, sg_next(walk->sg));
+ }
+ 
++/*
++ * Flush the dcache of any pages that overlap the region
++ * [offset, offset + nbytes) relative to base_page.
++ *
++ * This should be called only when ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE, to ensure
++ * that all relevant code (including the call to sg_page() in the caller, if
++ * applicable) gets fully optimized out when !ARCH_IMPLEMENTS_FLUSH_DCACHE_PAGE.
++ */
++static inline void __scatterwalk_flush_dcache_pages(struct page *base_page,
++						    unsigned int offset,
++						    unsigned int nbytes)
++{
++	unsigned int num_pages;
++
++	base_page += offset / PAGE_SIZE;
++	offset %= PAGE_SIZE;
++
++	/*
++	 * This is an overflow-safe version of
++	 * num_pages = DIV_ROUND_UP(offset + nbytes, PAGE_SIZE).
++	 */
++	num_pages = nbytes / PAGE_SIZE;
++	num_pages += DIV_ROUND_UP(offset + (nbytes % PAGE_SIZE), PAGE_SIZE);
++
++	for (unsigned int i = 0; i < num_pages; i++)
++		flush_dcache_page(base_page + i);
++}
++
+ static inline void scatterwalk_done(struct scatter_walk *walk, int out,
+ 				    int more)
+ {
+@@ -94,6 +122,9 @@ static inline void scatterwalk_done(struct scatter_walk *walk, int out,
+ void scatterwalk_copychunks(void *buf, struct scatter_walk *walk,
+ 			    size_t nbytes, int out);
+ 
++void memcpy_sglist(struct scatterlist *dst, struct scatterlist *src,
++		   unsigned int nbytes);
++
+ void scatterwalk_map_and_copy(void *buf, struct scatterlist *sg,
+ 			      unsigned int start, unsigned int nbytes, int out);
+ 

--- a/packages/kernel-6.12/1010-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
+++ b/packages/kernel-6.12/1010-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
@@ -1,0 +1,239 @@
+From: Eric Biggers <ebiggers@google.com>
+Date: Wed, 29 Apr 2026 23:06:56 -0700
+Subject: crypto: algif_aead - use memcpy_sglist() instead of null skcipher
+
+commit f2804d0eee8ddd57aa79d0b82872b74c21e1b69b upstream.
+
+For copying data between two scatterlists, just use memcpy_sglist()
+instead of the so-called "null skcipher".  This is much simpler.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-3-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/Kconfig b/crypto/Kconfig
+--- a/crypto/Kconfig
++++ b/crypto/Kconfig
+@@ -1424,7 +1424,6 @@ config CRYPTO_USER_API_AEAD
+ 	depends on NET
+ 	select CRYPTO_AEAD
+ 	select CRYPTO_SKCIPHER
+-	select CRYPTO_NULL
+ 	select CRYPTO_USER_API
+ 	help
+ 	  Enable the userspace interface for AEAD cipher algorithms.
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -27,7 +27,6 @@
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+ #include <crypto/skcipher.h>
+-#include <crypto/null.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -36,19 +35,13 @@
+ #include <linux/net.h>
+ #include <net/sock.h>
+ 
+-struct aead_tfm {
+-	struct crypto_aead *aead;
+-	struct crypto_sync_skcipher *null_tfm;
+-};
+-
+ static inline bool aead_sufficient_data(struct sock *sk)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
+ 
+ 	/*
+@@ -64,27 +57,12 @@ static int aead_sendmsg(struct socket *sock, struct msghdr *msg, size_t size)
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 
+ 	return af_alg_sendmsg(sock, msg, size, ivsize);
+ }
+ 
+-static int crypto_aead_copy_sgl(struct crypto_sync_skcipher *null_tfm,
+-				struct scatterlist *src,
+-				struct scatterlist *dst, unsigned int len)
+-{
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, null_tfm);
+-
+-	skcipher_request_set_sync_tfm(skreq, null_tfm);
+-	skcipher_request_set_callback(skreq, CRYPTO_TFM_REQ_MAY_SLEEP,
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, src, dst, len, NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 			 size_t ignored, int flags)
+ {
+@@ -93,9 +71,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
+-	struct crypto_sync_skcipher *null_tfm = aeadc->null_tfm;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int i, as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct af_alg_tsgl *tsgl, *tmp;
+@@ -223,11 +199,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		 *	    v	   v
+ 		 * RX SGL: AAD || PT || Tag
+ 		 */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sgt.sgl,
+-					   processed);
+-		if (err)
+-			goto free;
++		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src,
++			      processed);
+ 		af_alg_pull_tsgl(sk, processed, NULL, 0);
+ 	} else {
+ 		/*
+@@ -241,12 +214,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		 * RX SGL: AAD || CT ----+
+ 		 */
+ 
+-		 /* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		err = crypto_aead_copy_sgl(null_tfm, tsgl_src,
+-					   areq->first_rsgl.sgl.sgt.sgl,
+-					   outlen);
+-		if (err)
+-			goto free;
++		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
++		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src, outlen);
+ 
+ 		/* Create TX SGL for tag and chain it to RX SGL. */
+ 		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+@@ -379,7 +348,7 @@ static int aead_check_key(struct socket *sock)
+ 	int err = 0;
+ 	struct sock *psk;
+ 	struct alg_sock *pask;
+-	struct aead_tfm *tfm;
++	struct crypto_aead *tfm;
+ 	struct sock *sk = sock->sk;
+ 	struct alg_sock *ask = alg_sk(sk);
+ 
+@@ -393,7 +362,7 @@ static int aead_check_key(struct socket *sock)
+ 
+ 	err = -ENOKEY;
+ 	lock_sock_nested(psk, SINGLE_DEPTH_NESTING);
+-	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
++	if (crypto_aead_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		goto unlock;
+ 
+ 	atomic_dec(&pask->nokey_refcnt);
+@@ -454,54 +423,22 @@ static struct proto_ops algif_aead_ops_nokey = {
+ 
+ static void *aead_bind(const char *name, u32 type, u32 mask)
+ {
+-	struct aead_tfm *tfm;
+-	struct crypto_aead *aead;
+-	struct crypto_sync_skcipher *null_tfm;
+-
+-	tfm = kzalloc(sizeof(*tfm), GFP_KERNEL);
+-	if (!tfm)
+-		return ERR_PTR(-ENOMEM);
+-
+-	aead = crypto_alloc_aead(name, type, mask);
+-	if (IS_ERR(aead)) {
+-		kfree(tfm);
+-		return ERR_CAST(aead);
+-	}
+-
+-	null_tfm = crypto_get_default_null_skcipher();
+-	if (IS_ERR(null_tfm)) {
+-		crypto_free_aead(aead);
+-		kfree(tfm);
+-		return ERR_CAST(null_tfm);
+-	}
+-
+-	tfm->aead = aead;
+-	tfm->null_tfm = null_tfm;
+-
+-	return tfm;
++	return crypto_alloc_aead(name, type, mask);
+ }
+ 
+ static void aead_release(void *private)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	crypto_free_aead(tfm->aead);
+-	crypto_put_default_null_skcipher();
+-	kfree(tfm);
++	crypto_free_aead(private);
+ }
+ 
+ static int aead_setauthsize(void *private, unsigned int authsize)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	return crypto_aead_setauthsize(tfm->aead, authsize);
++	return crypto_aead_setauthsize(private, authsize);
+ }
+ 
+ static int aead_setkey(void *private, const u8 *key, unsigned int keylen)
+ {
+-	struct aead_tfm *tfm = private;
+-
+-	return crypto_aead_setkey(tfm->aead, key, keylen);
++	return crypto_aead_setkey(private, key, keylen);
+ }
+ 
+ static void aead_sock_destruct(struct sock *sk)
+@@ -510,8 +447,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct sock *psk = ask->parent;
+ 	struct alg_sock *pask = alg_sk(psk);
+-	struct aead_tfm *aeadc = pask->private;
+-	struct crypto_aead *tfm = aeadc->aead;
++	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+ 	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
+@@ -524,10 +460,9 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ {
+ 	struct af_alg_ctx *ctx;
+ 	struct alg_sock *ask = alg_sk(sk);
+-	struct aead_tfm *tfm = private;
+-	struct crypto_aead *aead = tfm->aead;
++	struct crypto_aead *tfm = private;
+ 	unsigned int len = sizeof(*ctx);
+-	unsigned int ivlen = crypto_aead_ivsize(aead);
++	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+ 	ctx = sock_kmalloc(sk, len, GFP_KERNEL);
+ 	if (!ctx)
+@@ -554,9 +489,9 @@ static int aead_accept_parent_nokey(void *private, struct sock *sk)
+ 
+ static int aead_accept_parent(void *private, struct sock *sk)
+ {
+-	struct aead_tfm *tfm = private;
++	struct crypto_aead *tfm = private;
+ 
+-	if (crypto_aead_get_flags(tfm->aead) & CRYPTO_TFM_NEED_KEY)
++	if (crypto_aead_get_flags(tfm) & CRYPTO_TFM_NEED_KEY)
+ 		return -ENOKEY;
+ 
+ 	return aead_accept_parent_nokey(private, sk);

--- a/packages/kernel-6.12/1011-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+++ b/packages/kernel-6.12/1011-crypto-algif_aead-Revert-to-operating-out-of-place.patch
@@ -1,0 +1,309 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:06:57 -0700
+Subject: crypto: algif_aead - Revert to operating out-of-place
+
+commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 upstream.
+
+This mostly reverts commit 72548b093ee3 except for the copying of
+the associated data.
+
+There is no benefit in operating in-place in algif_aead since the
+source and destination come from different mappings.  Get rid of
+all the complexity added for in-place operation and just copy the
+AD directly.
+
+Fixes: 72548b093ee3 ("crypto: algif_aead - copy AAD from src to dst")
+Reported-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-4-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -635,15 +635,13 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	const struct alg_sock *ask = alg_sk(sk);
+ 	const struct af_alg_ctx *ctx = ask->private;
+@@ -658,25 +656,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		const struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -688,19 +672,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -725,18 +704,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -26,7 +26,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -72,9 +71,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -154,23 +152,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -179,76 +178,15 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sgt.sgl;
+ 
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src,
+-			      processed);
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src, outlen);
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-			struct scatterlist *sg = sgl_prev->sgt.sgl;
+-
+-			sg_unmark_end(sg + sgl_prev->sgt.nents - 1);
+-			sg_chain(sg, sgl_prev->sgt.nents + 1, areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	memcpy_sglist(rsgl_src, tsgl_src, ctx->aead_assoclen);
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -450,7 +388,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -138,7 +138,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -149,7 +149,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -363,7 +363,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	if (ctx->state)
+ 		sock_kzfree_s(sk, ctx->state, crypto_skcipher_statesize(tfm));
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -230,9 +230,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ 	return PAGE_SIZE <= af_alg_rcvbuf(sk);
+ }
+ 
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
+ void af_alg_wmem_wakeup(struct sock *sk);
+ int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,

--- a/packages/kernel-6.12/1012-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+++ b/packages/kernel-6.12/1012-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
@@ -1,0 +1,70 @@
+From: Douya Le <ldy3087146292@gmail.com>
+Date: Wed, 29 Apr 2026 23:06:58 -0700
+Subject: crypto: algif_aead - snapshot IV for async AEAD requests
+
+commit 5aa58c3a572b3e3b6c786953339f7978b845cc52 upstream.
+
+AF_ALG AEAD AIO requests currently use the socket-wide IV buffer during
+request processing.  For async requests, later socket activity can
+update that shared state before the original request has fully
+completed, which can lead to inconsistent IV handling.
+
+Snapshot the IV into per-request storage when preparing the AEAD
+request, so in-flight operations no longer depend on mutable socket
+state.
+
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Cc: stable@kernel.org
+Reported-by: Yuan Tan <yuantan098@gmail.com>
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Reported-by: Xin Liu <bird@lzu.edu.cn>
+Co-developed-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Signed-off-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Tested-by: Yucheng Lu <kanolyc@gmail.com>
+Signed-off-by: Douya Le <ldy3087146292@gmail.com>
+Signed-off-by: Ren Wei <n05ec@lzu.edu.cn>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-5-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -72,8 +72,10 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
++	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
++	void *iv;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+ 	size_t outlen = 0;		/* [out] RX bufs produced by kernel */
+@@ -125,10 +127,14 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Allocate cipher request for current operation. */
+ 	areq = af_alg_alloc_areq(sk, sizeof(struct af_alg_async_req) +
+-				     crypto_aead_reqsize(tfm));
++				     crypto_aead_reqsize(tfm) + ivsize);
+ 	if (IS_ERR(areq))
+ 		return PTR_ERR(areq);
+ 
++	iv = (u8 *)aead_request_ctx(&areq->cra_u.aead_req) +
++	     crypto_aead_reqsize(tfm);
++	memcpy(iv, ctx->iv, ivsize);
++
+ 	/* convert iovecs of output buffers into RX SGL */
+ 	err = af_alg_get_rsgl(sk, msg, flags, areq, outlen, &usedpages);
+ 	if (err)
+@@ -187,7 +193,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Initialize the crypto operation */
+ 	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+-			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
++			       areq->first_rsgl.sgl.sgt.sgl, used, iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+ 

--- a/packages/kernel-6.12/1013-crypto-authenc-use-memcpy_sglist-instead-of-null-skcipher.patch
+++ b/packages/kernel-6.12/1013-crypto-authenc-use-memcpy_sglist-instead-of-null-skcipher.patch
@@ -1,0 +1,225 @@
+From: Eric Biggers <ebiggers@google.com>
+Date: Wed, 29 Apr 2026 23:06:59 -0700
+Subject: crypto: authenc - use memcpy_sglist() instead of null skcipher
+
+commit dbc4b1458e931e47198c3165ff5853bc1ad6bd7a upstream.
+
+For copying data between two scatterlists, just use memcpy_sglist()
+instead of the so-called "null skcipher".  This is much simpler.
+
+Signed-off-by: Eric Biggers <ebiggers@google.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-6-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/Kconfig b/crypto/Kconfig
+--- a/crypto/Kconfig
++++ b/crypto/Kconfig
+@@ -222,7 +222,6 @@ config CRYPTO_AUTHENC
+ 	select CRYPTO_SKCIPHER
+ 	select CRYPTO_MANAGER
+ 	select CRYPTO_HASH
+-	select CRYPTO_NULL
+ 	help
+ 	  Authenc: Combined mode wrapper for IPsec.
+ 
+diff --git a/crypto/authenc.c b/crypto/authenc.c
+--- a/crypto/authenc.c
++++ b/crypto/authenc.c
+@@ -9,7 +9,6 @@
+ #include <crypto/internal/hash.h>
+ #include <crypto/internal/skcipher.h>
+ #include <crypto/authenc.h>
+-#include <crypto/null.h>
+ #include <crypto/scatterwalk.h>
+ #include <linux/err.h>
+ #include <linux/init.h>
+@@ -28,7 +27,6 @@ struct authenc_instance_ctx {
+ struct crypto_authenc_ctx {
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_request_ctx {
+@@ -186,21 +184,6 @@ static void crypto_authenc_encrypt_done(void *data, int err)
+ 	authenc_request_complete(areq, err);
+ }
+ 
+-static int crypto_authenc_copy_assoc(struct aead_request *req)
+-{
+-	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+-	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(authenc);
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+-
+-	skcipher_request_set_sync_tfm(skreq, ctx->null);
+-	skcipher_request_set_callback(skreq, aead_request_flags(req),
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, req->src, req->dst, req->assoclen,
+-				   NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int crypto_authenc_encrypt(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc = crypto_aead_reqtfm(req);
+@@ -219,10 +202,7 @@ static int crypto_authenc_encrypt(struct aead_request *req)
+ 	dst = src;
+ 
+ 	if (req->src != req->dst) {
+-		err = crypto_authenc_copy_assoc(req);
+-		if (err)
+-			return err;
+-
++		memcpy_sglist(req->dst, req->src, req->assoclen);
+ 		dst = scatterwalk_ffwd(areq_ctx->dst, req->dst, req->assoclen);
+ 	}
+ 
+@@ -328,7 +308,6 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+@@ -340,14 +319,8 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 	if (IS_ERR(enc))
+ 		goto err_free_ahash;
+ 
+-	null = crypto_get_default_null_skcipher();
+-	err = PTR_ERR(null);
+-	if (IS_ERR(null))
+-		goto err_free_skcipher;
+-
+ 	ctx->auth = auth;
+ 	ctx->enc = enc;
+-	ctx->null = null;
+ 
+ 	crypto_aead_set_reqsize(
+ 		tfm,
+@@ -361,8 +334,6 @@ static int crypto_authenc_init_tfm(struct crypto_aead *tfm)
+ 
+ 	return 0;
+ 
+-err_free_skcipher:
+-	crypto_free_skcipher(enc);
+ err_free_ahash:
+ 	crypto_free_ahash(auth);
+ 	return err;
+@@ -374,7 +345,6 @@ static void crypto_authenc_exit_tfm(struct crypto_aead *tfm)
+ 
+ 	crypto_free_ahash(ctx->auth);
+ 	crypto_free_skcipher(ctx->enc);
+-	crypto_put_default_null_skcipher();
+ }
+ 
+ static void crypto_authenc_free(struct aead_instance *inst)
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -12,7 +12,6 @@
+ #include <crypto/internal/hash.h>
+ #include <crypto/internal/skcipher.h>
+ #include <crypto/authenc.h>
+-#include <crypto/null.h>
+ #include <crypto/scatterwalk.h>
+ #include <linux/err.h>
+ #include <linux/init.h>
+@@ -31,7 +30,6 @@ struct crypto_authenc_esn_ctx {
+ 	unsigned int reqoff;
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ };
+ 
+ struct authenc_esn_request_ctx {
+@@ -158,20 +156,6 @@ static void crypto_authenc_esn_encrypt_done(void *data, int err)
+ 	authenc_esn_request_complete(areq, err);
+ }
+ 
+-static int crypto_authenc_esn_copy(struct aead_request *req, unsigned int len)
+-{
+-	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+-	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(authenc_esn);
+-	SYNC_SKCIPHER_REQUEST_ON_STACK(skreq, ctx->null);
+-
+-	skcipher_request_set_sync_tfm(skreq, ctx->null);
+-	skcipher_request_set_callback(skreq, aead_request_flags(req),
+-				      NULL, NULL);
+-	skcipher_request_set_crypt(skreq, req->src, req->dst, len, NULL);
+-
+-	return crypto_skcipher_encrypt(skreq);
+-}
+-
+ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ {
+ 	struct crypto_aead *authenc_esn = crypto_aead_reqtfm(req);
+@@ -193,10 +177,7 @@ static int crypto_authenc_esn_encrypt(struct aead_request *req)
+ 	dst = src;
+ 
+ 	if (req->src != req->dst) {
+-		err = crypto_authenc_esn_copy(req, assoclen);
+-		if (err)
+-			return err;
+-
++		memcpy_sglist(req->dst, req->src, assoclen);
+ 		sg_init_table(areq_ctx->dst, 2);
+ 		dst = scatterwalk_ffwd(areq_ctx->dst, req->dst, assoclen);
+ 	}
+@@ -283,11 +264,8 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 
+ 	cryptlen -= authsize;
+ 
+-	if (req->src != dst) {
+-		err = crypto_authenc_esn_copy(req, assoclen + cryptlen);
+-		if (err)
+-			return err;
+-	}
++	if (req->src != dst)
++		memcpy_sglist(dst, req->src, assoclen + cryptlen);
+ 
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+@@ -323,7 +301,6 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	struct crypto_authenc_esn_ctx *ctx = crypto_aead_ctx(tfm);
+ 	struct crypto_ahash *auth;
+ 	struct crypto_skcipher *enc;
+-	struct crypto_sync_skcipher *null;
+ 	int err;
+ 
+ 	auth = crypto_spawn_ahash(&ictx->auth);
+@@ -335,14 +312,8 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 	if (IS_ERR(enc))
+ 		goto err_free_ahash;
+ 
+-	null = crypto_get_default_null_skcipher();
+-	err = PTR_ERR(null);
+-	if (IS_ERR(null))
+-		goto err_free_skcipher;
+-
+ 	ctx->auth = auth;
+ 	ctx->enc = enc;
+-	ctx->null = null;
+ 
+ 	ctx->reqoff = 2 * crypto_ahash_digestsize(auth);
+ 
+@@ -358,8 +329,6 @@ static int crypto_authenc_esn_init_tfm(struct crypto_aead *tfm)
+ 
+ 	return 0;
+ 
+-err_free_skcipher:
+-	crypto_free_skcipher(enc);
+ err_free_ahash:
+ 	crypto_free_ahash(auth);
+ 	return err;
+@@ -371,7 +340,6 @@ static void crypto_authenc_esn_exit_tfm(struct crypto_aead *tfm)
+ 
+ 	crypto_free_ahash(ctx->auth);
+ 	crypto_free_skcipher(ctx->enc);
+-	crypto_put_default_null_skcipher();
+ }
+ 
+ static void crypto_authenc_esn_free(struct aead_instance *inst)

--- a/packages/kernel-6.12/1014-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
+++ b/packages/kernel-6.12/1014-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
@@ -1,0 +1,115 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:07:00 -0700
+Subject: crypto: authencesn - Do not place hiseq at end of dst for
+ out-of-place decryption
+
+commit e02494114ebf7c8b42777c6cd6982f113bfdbec7 upstream.
+
+When decrypting data that is not in-place (src != dst), there is
+no need to save the high-order sequence bits in dst as it could
+simply be re-copied from the source.
+
+However, the data to be hashed need to be rearranged accordingly.
+
+Reported-by: Taeyang Lee <0wn@theori.io>
+Fixes: 104880a6b470 ("crypto: authencesn - Convert to new AEAD interface")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-7-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -207,6 +207,7 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 	u8 *ohash = areq_ctx->tail;
+ 	unsigned int cryptlen = req->cryptlen - authsize;
+ 	unsigned int assoclen = req->assoclen;
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
+ 	u32 tmp[2];
+@@ -214,23 +215,27 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 	if (!authsize)
+ 		goto decrypt;
+ 
+-	/* Move high-order bits of sequence number back. */
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	if (src == dst) {
++		/* Move high-order bits of sequence number back. */
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
++		scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	} else
++		memcpy_sglist(dst, src, assoclen);
+ 
+ 	if (crypto_memneq(ihash, ohash, authsize))
+ 		return -EBADMSG;
+ 
+ decrypt:
+ 
+-	sg_init_table(areq_ctx->dst, 2);
++	if (src != dst)
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,
+ 				      req->base.complete, req->base.data);
+-	skcipher_request_set_crypt(skreq, dst, dst, cryptlen, req->iv);
++	skcipher_request_set_crypt(skreq, src, dst, cryptlen, req->iv);
+ 
+ 	return crypto_skcipher_decrypt(skreq);
+ }
+@@ -255,6 +260,7 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	unsigned int assoclen = req->assoclen;
+ 	unsigned int cryptlen = req->cryptlen;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u32 tmp[2];
+ 	int err;
+@@ -262,24 +268,28 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	if (assoclen < 8)
+ 		return -EINVAL;
+ 
+-	cryptlen -= authsize;
+-
+-	if (req->src != dst)
+-		memcpy_sglist(dst, req->src, assoclen + cryptlen);
++	if (!authsize)
++		goto tail;
+ 
++	cryptlen -= authsize;
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+ 
+-	if (!authsize)
+-		goto tail;
+-
+ 	/* Move high-order bits of sequence number to the end. */
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
+-
+-	sg_init_table(areq_ctx->dst, 2);
+-	dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	scatterwalk_map_and_copy(tmp, src, 0, 8, 0);
++	if (src == dst) {
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	} else {
++		scatterwalk_map_and_copy(tmp, dst, 0, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen - 4, 4, 1);
++
++		src = scatterwalk_ffwd(areq_ctx->src, src, 8);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++		memcpy_sglist(dst, src, assoclen + cryptlen - 8);
++		dst = req->dst;
++	}
+ 
+ 	ahash_request_set_tfm(ahreq, auth);
+ 	ahash_request_set_crypt(ahreq, dst, ohash, assoclen + cryptlen);

--- a/packages/kernel-6.12/1015-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
+++ b/packages/kernel-6.12/1015-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
@@ -1,0 +1,33 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:07:01 -0700
+Subject: crypto: authencesn - Fix src offset when decrypting in-place
+
+commit 1f48ad3b19a9dfc947868edda0bb8e48e5b5a8fa upstream.
+
+The src SG list offset wasn't set properly when decrypting in-place,
+fix it.
+
+Reported-by: Wolfgang Walter <linux@stwm.de>
+Fixes: e02494114ebf ("crypto: authencesn - Do not place hiseq at end of dst for out-of-place decryption")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-8-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -228,9 +228,11 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 
+ decrypt:
+ 
+-	if (src != dst)
+-		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
++	if (req->src == req->dst)
++		src = dst;
++	else
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,

--- a/packages/kernel-6.12/1016-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
+++ b/packages/kernel-6.12/1016-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
@@ -1,0 +1,36 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 29 Apr 2026 23:07:02 -0700
+Subject: crypto: af_alg - Fix page reassignment overflow in af_alg_pull_tsgl
+
+commit 31d00156e50ecad37f2cb6cbf04aaa9a260505ef upstream.
+
+When page reassignment was added to af_alg_pull_tsgl the original
+loop wasn't updated so it may try to reassign one more page than
+necessary.
+
+Add the check to the reassignment so that this does not happen.
+
+Also update the comment which still refers to the obsolete offset
+argument.
+
+Reported-by: syzbot+d23888375c2737c17ba5@syzkaller.appspotmail.com
+Fixes: e870456d8e7c ("crypto: algif_skcipher - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Eric Biggers <ebiggers@kernel.org>
+Link: https://lore.kernel.org/r/20260430060702.110091-9-ebiggers@kernel.org
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -703,8 +703,8 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ 			 * Assumption: caller created af_alg_count_tsgl(len)
+ 			 * SG entries in dst.
+ 			 */
+-			if (dst) {
+-				/* reassign page to dst after offset */
++			if (dst && plen) {
++				/* reassign page to dst */
+ 				get_page(page);
+ 				sg_set_page(dst + j, page, plen, sg[i].offset);
+ 				j++;

--- a/packages/kernel-6.12/1017-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
+++ b/packages/kernel-6.12/1017-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
@@ -1,0 +1,29 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Sun, 12 Apr 2026 13:32:21 +0800
+Subject: crypto: algif_aead - Fix minimum RX size check for decryption
+
+[ Upstream commit 3d14bd48e3a77091cbce637a12c2ae31b4a1687c ]
+
+The check for the minimum receive buffer size did not take the
+tag size into account during decryption.  Fix this by adding the
+required extra length.
+
+Reported-by: syzbot+aa11561819dc42ebbc7c@syzkaller.appspotmail.com
+Reported-by: Daniel Pouzzner <douzzer@mega.nu>
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -150,7 +150,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	if (usedpages < outlen) {
+ 		size_t less = outlen - usedpages;
+ 
+-		if (used < less) {
++		if (used < less + (ctx->enc ? 0 : as)) {
+ 			err = -EINVAL;
+ 			goto free;
+ 		}

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -68,6 +68,24 @@ Patch1006: 1006-Select-prerequisites-for-gpu-drivers.patch
 Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1008: 1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+# Backport memcpy_sglist() for use by algif_aead fix.
+Patch1009: 1009-crypto-scatterwalk-Backport-memcpy_sglist.patch
+# Replace null skcipher with memcpy_sglist() in algif_aead.
+Patch1010: 1010-crypto-algif_aead-use-memcpy_sglist-instead-of-null-skcipher.patch
+# Revert algif_aead to out-of-place operation.
+Patch1011: 1011-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+# Snapshot IV for async AEAD requests.
+Patch1012: 1012-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+# Replace null skcipher with memcpy_sglist() in authenc.
+Patch1013: 1013-crypto-authenc-use-memcpy_sglist-instead-of-null-skcipher.patch
+# Fix authencesn out-of-place decryption.
+Patch1014: 1014-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
+# Fix authencesn src offset for in-place decryption.
+Patch1015: 1015-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
+# Fix page reassignment overflow in af_alg_pull_tsgl.
+Patch1016: 1016-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
+# Fix minimum RX size check for AEAD decryption.
+Patch1017: 1017-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.18/1007-crypto-af-alg-fix-NULL-pointer-dereference-in-scatterwalk.patch
+++ b/packages/kernel-6.18/1007-crypto-af-alg-fix-NULL-pointer-dereference-in-scatterwalk.patch
@@ -1,0 +1,39 @@
+From: Norbert Szetei <norbert@doyensec.com>
+Date: Wed, 25 Mar 2026 18:26:13 +0100
+Subject: crypto: af-alg - fix NULL pointer dereference in scatterwalk
+
+[ Upstream commit 62397b493e14107ae82d8b80938f293d95425bcb ]
+
+The AF_ALG interface fails to unmark the end of a Scatter/Gather List (SGL)
+when chaining a new af_alg_tsgl structure. If a sendmsg() fills an SGL
+exactly to MAX_SGL_ENTS, the last entry is marked as the end. A subsequent
+sendmsg() allocates a new SGL and chains it, but fails to clear the end
+marker on the previous SGL's last data entry.
+
+This causes the crypto scatterwalk to hit a premature end, returning NULL
+on sg_next() and leading to a kernel panic during dereference.
+
+Fix this by explicitly unmarking the end of the previous SGL when
+performing sg_chain() in af_alg_alloc_tsgl().
+
+Fixes: 8ff590903d5f ("crypto: algif_skcipher - User-space interface for skcipher operations")
+Signed-off-by: Norbert Szetei <norbert@doyensec.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -623,8 +623,10 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ 		sg_init_table(sgl->sg, MAX_SGL_ENTS + 1);
+ 		sgl->cur = 0;
+ 
+-		if (sg)
++		if (sg) {
++			sg_unmark_end(sg + MAX_SGL_ENTS - 1);
+ 			sg_chain(sg, MAX_SGL_ENTS + 1, sgl->sg);
++		}
+ 
+ 		list_add_tail(&sgl->list, &ctx->tsgl_list);
+ 	}

--- a/packages/kernel-6.18/1008-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+++ b/packages/kernel-6.18/1008-crypto-algif_aead-Revert-to-operating-out-of-place.patch
@@ -1,0 +1,319 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 26 Mar 2026 15:30:20 +0900
+Subject: crypto: algif_aead - Revert to operating out-of-place
+
+[ Upstream commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 ]
+
+This mostly reverts commit 72548b093ee3 except for the copying of
+the associated data.
+
+There is no benefit in operating in-place in algif_aead since the
+source and destination come from different mappings.  Get rid of
+all the complexity added for in-place operation and just copy the
+AD directly.
+
+Fixes: 72548b093ee3 ("crypto: algif_aead - copy AAD from src to dst")
+Reported-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+[ simonlie: resolve conflict in include/crypto/if_alg.h - the upstream
+  patch removes the offset parameter from af_alg_count_tsgl() and the
+  dst_offset parameter from af_alg_pull_tsgl(). Our tree wraps these
+  declarations with DECLARE_CRYPTO_API macros (commit dc91672879922),
+  so the same parameter removal was applied to the macro-wrapped form
+  instead of the plain function declarations. ]
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -637,15 +637,13 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	const struct alg_sock *ask = alg_sk(sk);
+ 	const struct af_alg_ctx *ctx = ask->private;
+@@ -660,25 +658,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		const struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -690,19 +674,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -727,18 +706,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -26,7 +26,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -72,9 +71,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -154,23 +152,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -179,76 +178,15 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sgt.sgl;
+ 
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src,
+-			      processed);
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src, outlen);
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-			struct scatterlist *sg = sgl_prev->sgt.sgl;
+-
+-			sg_unmark_end(sg + sgl_prev->sgt.nents - 1);
+-			sg_chain(sg, sgl_prev->sgt.nents + 1, areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	memcpy_sglist(rsgl_src, tsgl_src, ctx->aead_assoclen);
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -450,7 +388,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -138,7 +138,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -149,7 +149,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -363,7 +363,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	if (ctx->state)
+ 		sock_kzfree_s(sk, ctx->state, crypto_skcipher_statesize(tfm));
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -246,12 +246,12 @@ static inline bool af_alg_readable(struct sock *sk)
+ }
+ 
+ DECLARE_CRYPTO_API(CONFIG_CRYPTO_USER_API, af_alg_count_tsgl, unsigned int,
+-	(struct sock *sk, size_t bytes, size_t offset),
+-	(sk, bytes, offset));
++	(struct sock *sk, size_t bytes),
++	(sk, bytes));
+ 
+ DECLARE_CRYPTO_API(CONFIG_CRYPTO_USER_API, af_alg_pull_tsgl, void,
+-	(struct sock *sk, size_t used, struct scatterlist *dst, size_t dst_offset),
+-	(sk, used, dst, dst_offset));
++	(struct sock *sk, size_t used, struct scatterlist *dst),
++	(sk, used, dst));
+ 
+ DECLARE_CRYPTO_API(CONFIG_CRYPTO_USER_API, af_alg_wmem_wakeup, void,
+ 	(struct sock *sk),

--- a/packages/kernel-6.18/1009-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+++ b/packages/kernel-6.18/1009-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
@@ -1,0 +1,68 @@
+From: Douya Le <ldy3087146292@gmail.com>
+Date: Sun, 19 Apr 2026 16:52:59 +0800
+Subject: crypto: algif_aead - snapshot IV for async AEAD requests
+
+[ Upstream commit f2804d0eee8ddd57aa79d0b82872b74c21e1b69b ]
+
+AF_ALG AEAD AIO requests currently use the socket-wide IV buffer during
+request processing.  For async requests, later socket activity can
+update that shared state before the original request has fully
+completed, which can lead to inconsistent IV handling.
+
+Snapshot the IV into per-request storage when preparing the AEAD
+request, so in-flight operations no longer depend on mutable socket
+state.
+
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Cc: stable@kernel.org
+Reported-by: Yuan Tan <yuantan098@gmail.com>
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Reported-by: Xin Liu <bird@lzu.edu.cn>
+Co-developed-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Signed-off-by: Luxing Yin <tr0jan@lzu.edu.cn>
+Tested-by: Yucheng Lu <kanolyc@gmail.com>
+Signed-off-by: Douya Le <ldy3087146292@gmail.com>
+Signed-off-by: Ren Wei <n05ec@lzu.edu.cn>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -72,8 +72,10 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int as = crypto_aead_authsize(tfm);
++	unsigned int ivsize = crypto_aead_ivsize(tfm);
+ 	struct af_alg_async_req *areq;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
++	void *iv;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+ 	size_t outlen = 0;		/* [out] RX bufs produced by kernel */
+@@ -125,10 +127,14 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Allocate cipher request for current operation. */
+ 	areq = af_alg_alloc_areq(sk, sizeof(struct af_alg_async_req) +
+-				     crypto_aead_reqsize(tfm));
++				     crypto_aead_reqsize(tfm) + ivsize);
+ 	if (IS_ERR(areq))
+ 		return PTR_ERR(areq);
+ 
++	iv = (u8 *)aead_request_ctx(&areq->cra_u.aead_req) +
++	     crypto_aead_reqsize(tfm);
++	memcpy(iv, ctx->iv, ivsize);
++
+ 	/* convert iovecs of output buffers into RX SGL */
+ 	err = af_alg_get_rsgl(sk, msg, flags, areq, outlen, &usedpages);
+ 	if (err)
+@@ -187,7 +193,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 
+ 	/* Initialize the crypto operation */
+ 	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+-			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
++			       areq->first_rsgl.sgl.sgt.sgl, used, iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+ 

--- a/packages/kernel-6.18/1010-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
+++ b/packages/kernel-6.18/1010-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
@@ -1,0 +1,118 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Fri, 27 Mar 2026 15:04:17 +0900
+Subject: crypto: authencesn - Do not place hiseq at end of dst for
+ out-of-place decryption
+
+[ Upstream commit e02494114ebf7c8b42777c6cd6982f113bfdbec7 ]
+
+When decrypting data that is not in-place (src != dst), there is
+no need to save the high-order sequence bits in dst as it could
+simply be re-copied from the source.
+
+However, the data to be hashed need to be rearranged accordingly.
+
+Reported-by: Taeyang Lee <0wn@theori.io>
+Fixes: 104880a6b470 ("crypto: authencesn - Convert to new AEAD interface")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+
+Thanks,
+
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -207,6 +207,7 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 	u8 *ohash = areq_ctx->tail;
+ 	unsigned int cryptlen = req->cryptlen - authsize;
+ 	unsigned int assoclen = req->assoclen;
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
+ 	u32 tmp[2];
+@@ -214,23 +215,27 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 	if (!authsize)
+ 		goto decrypt;
+ 
+-	/* Move high-order bits of sequence number back. */
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	if (src == dst) {
++		/* Move high-order bits of sequence number back. */
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 0);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 0);
++		scatterwalk_map_and_copy(tmp, dst, 0, 8, 1);
++	} else
++		memcpy_sglist(dst, src, assoclen);
+ 
+ 	if (crypto_memneq(ihash, ohash, authsize))
+ 		return -EBADMSG;
+ 
+ decrypt:
+ 
+-	sg_init_table(areq_ctx->dst, 2);
++	if (src != dst)
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,
+ 				      req->base.complete, req->base.data);
+-	skcipher_request_set_crypt(skreq, dst, dst, cryptlen, req->iv);
++	skcipher_request_set_crypt(skreq, src, dst, cryptlen, req->iv);
+ 
+ 	return crypto_skcipher_decrypt(skreq);
+ }
+@@ -255,6 +260,7 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	unsigned int assoclen = req->assoclen;
+ 	unsigned int cryptlen = req->cryptlen;
+ 	u8 *ihash = ohash + crypto_ahash_digestsize(auth);
++	struct scatterlist *src = req->src;
+ 	struct scatterlist *dst = req->dst;
+ 	u32 tmp[2];
+ 	int err;
+@@ -262,24 +268,28 @@ static int crypto_authenc_esn_decrypt(struct aead_request *req)
+ 	if (assoclen < 8)
+ 		return -EINVAL;
+ 
+-	cryptlen -= authsize;
+-
+-	if (req->src != dst)
+-		memcpy_sglist(dst, req->src, assoclen + cryptlen);
++	if (!authsize)
++		goto tail;
+ 
++	cryptlen -= authsize;
+ 	scatterwalk_map_and_copy(ihash, req->src, assoclen + cryptlen,
+ 				 authsize, 0);
+ 
+-	if (!authsize)
+-		goto tail;
+-
+ 	/* Move high-order bits of sequence number to the end. */
+-	scatterwalk_map_and_copy(tmp, dst, 0, 8, 0);
+-	scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
+-	scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
+-
+-	sg_init_table(areq_ctx->dst, 2);
+-	dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	scatterwalk_map_and_copy(tmp, src, 0, 8, 0);
++	if (src == dst) {
++		scatterwalk_map_and_copy(tmp, dst, 4, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen, 4, 1);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++	} else {
++		scatterwalk_map_and_copy(tmp, dst, 0, 4, 1);
++		scatterwalk_map_and_copy(tmp + 1, dst, assoclen + cryptlen - 4, 4, 1);
++
++		src = scatterwalk_ffwd(areq_ctx->src, src, 8);
++		dst = scatterwalk_ffwd(areq_ctx->dst, dst, 4);
++		memcpy_sglist(dst, src, assoclen + cryptlen - 8);
++		dst = req->dst;
++	}
+ 
+ 	ahash_request_set_tfm(ahreq, auth);
+ 	ahash_request_set_crypt(ahreq, dst, ohash, assoclen + cryptlen);

--- a/packages/kernel-6.18/1011-crypto-af_alg-limit-RX-SG-extraction-by-receive-buffer-budget.patch
+++ b/packages/kernel-6.18/1011-crypto-af_alg-limit-RX-SG-extraction-by-receive-buffer-budget.patch
@@ -1,0 +1,57 @@
+From: Douya Le <ldy3087146292@gmail.com>
+Date: Thu, 2 Apr 2026 23:34:55 +0800
+Subject: crypto: af_alg - limit RX SG extraction by receive buffer budget
+
+[ Upstream commit 8eceab19eba9dcbfd2a0daec72e1bf48aa100170 ]
+
+Make af_alg_get_rsgl() limit each RX scatterlist extraction to the
+remaining receive buffer budget.
+
+af_alg_get_rsgl() currently uses af_alg_readable() only as a gate
+before extracting data into the RX scatterlist. Limit each extraction
+to the remaining af_alg_rcvbuf(sk) budget so that receive-side
+accounting matches the amount of data attached to the request.
+
+If skcipher cannot obtain enough RX space for at least one chunk while
+more data remains to be processed, reject the recvmsg call instead of
+rounding the request length down to zero.
+
+Fixes: e870456d8e7c8d57c059ea479b5aadbb55ff4c3a ("crypto: algif_skcipher - overhaul memory management")
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Co-developed-by: Yuan Tan <yuantan098@gmail.com>
+Signed-off-by: Yuan Tan <yuantan098@gmail.com>
+Suggested-by: Xin Liu <bird@lzu.edu.cn>
+Signed-off-by: Douya Le <ldy3087146292@gmail.com>
+Signed-off-by: Ren Wei <n05ec@lzu.edu.cn>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -1229,6 +1229,8 @@ int af_alg_get_rsgl(struct sock *sk, struct msghdr *msg, int flags,
+ 
+ 		seglen = min_t(size_t, (maxsize - len),
+ 			       msg_data_left(msg));
++		/* Never pin more pages than the remaining RX accounting budget. */
++		seglen = min_t(size_t, seglen, af_alg_rcvbuf(sk));
+ 
+ 		if (list_empty(&areq->rsgl_list)) {
+ 			rsgl = &areq->first_rsgl;
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -130,6 +130,11 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * full block size buffers.
+ 	 */
+ 	if (ctx->more || len < ctx->used) {
++		if (len < bs) {
++			err = -EINVAL;
++			goto free;
++		}
++
+ 		len -= len % bs;
+ 		cflags |= CRYPTO_SKCIPHER_REQ_NOTFINAL;
+ 	}

--- a/packages/kernel-6.18/1012-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
+++ b/packages/kernel-6.18/1012-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
@@ -1,0 +1,35 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Sat, 4 Apr 2026 08:29:58 +0800
+Subject: crypto: af_alg - Fix page reassignment overflow in af_alg_pull_tsgl
+
+[ Upstream commit 31d00156e50ecad37f2cb6cbf04aaa9a260505ef ]
+
+When page reassignment was added to af_alg_pull_tsgl the original
+loop wasn't updated so it may try to reassign one more page than
+necessary.
+
+Add the check to the reassignment so that this does not happen.
+
+Also update the comment which still refers to the obsolete offset
+argument.
+
+Reported-by: syzbot+d23888375c2737c17ba5@syzkaller.appspotmail.com
+Fixes: e870456d8e7c ("crypto: algif_skcipher - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -705,8 +705,8 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ 			 * Assumption: caller created af_alg_count_tsgl(len)
+ 			 * SG entries in dst.
+ 			 */
+-			if (dst) {
+-				/* reassign page to dst after offset */
++			if (dst && plen) {
++				/* reassign page to dst */
+ 				get_page(page);
+ 				sg_set_page(dst + j, page, plen, sg[i].offset);
+ 				j++;

--- a/packages/kernel-6.18/1013-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
+++ b/packages/kernel-6.18/1013-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
@@ -1,0 +1,29 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Sun, 12 Apr 2026 13:32:21 +0800
+Subject: crypto: algif_aead - Fix minimum RX size check for decryption
+
+[ Upstream commit 3d14bd48e3a77091cbce637a12c2ae31b4a1687c ]
+
+The check for the minimum receive buffer size did not take the
+tag size into account during decryption.  Fix this by adding the
+required extra length.
+
+Reported-by: syzbot+aa11561819dc42ebbc7c@syzkaller.appspotmail.com
+Reported-by: Daniel Pouzzner <douzzer@mega.nu>
+Fixes: d887c52d6ae4 ("crypto: algif_aead - overhaul memory management")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -150,7 +150,7 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	if (usedpages < outlen) {
+ 		size_t less = outlen - usedpages;
+ 
+-		if (used < less) {
++		if (used < less + (ctx->enc ? 0 : as)) {
+ 			err = -EINVAL;
+ 			goto free;
+ 		}

--- a/packages/kernel-6.18/1014-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
+++ b/packages/kernel-6.18/1014-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
@@ -1,0 +1,32 @@
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Wed, 15 Apr 2026 07:39:06 +0800
+Subject: crypto: authencesn - Fix src offset when decrypting in-place
+
+commit 1f48ad3b19a9dfc947868edda0bb8e48e5b5a8fa upstream.
+
+The src SG list offset wasn't set properly when decrypting in-place,
+fix it.
+
+Reported-by: Wolfgang Walter <linux@stwm.de>
+Fixes: e02494114ebf ("crypto: authencesn - Do not place hiseq at end of dst for out-of-place decryption")
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Simon Liebold <simonlie@amazon.de>
+
+diff --git a/crypto/authencesn.c b/crypto/authencesn.c
+--- a/crypto/authencesn.c
++++ b/crypto/authencesn.c
+@@ -228,9 +228,11 @@ static int crypto_authenc_esn_decrypt_tail(struct aead_request *req,
+ 
+ decrypt:
+ 
+-	if (src != dst)
+-		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 	dst = scatterwalk_ffwd(areq_ctx->dst, dst, assoclen);
++	if (req->src == req->dst)
++		src = dst;
++	else
++		src = scatterwalk_ffwd(areq_ctx->src, src, assoclen);
+ 
+ 	skcipher_request_set_tfm(skreq, ctx->enc);
+ 	skcipher_request_set_callback(skreq, flags,

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -56,6 +56,22 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1006: 1006-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+# Fix NULL pointer dereference in scatterwalk from SGL chaining.
+Patch1007: 1007-crypto-af-alg-fix-NULL-pointer-dereference-in-scatterwalk.patch
+# Revert algif_aead to out-of-place operation.
+Patch1008: 1008-crypto-algif_aead-Revert-to-operating-out-of-place.patch
+# Snapshot IV for async AEAD requests.
+Patch1009: 1009-crypto-algif_aead-snapshot-IV-for-async-AEAD-requests.patch
+# Fix authencesn out-of-place decryption.
+Patch1010: 1010-crypto-authencesn-Do-not-place-hiseq-at-end-of-dst.patch
+# Limit RX SG extraction by receive buffer budget.
+Patch1011: 1011-crypto-af_alg-limit-RX-SG-extraction-by-receive-buffer-budget.patch
+# Fix page reassignment overflow in af_alg_pull_tsgl.
+Patch1012: 1012-crypto-af_alg-Fix-page-reassignment-overflow-in-af_alg_pull_tsgl.patch
+# Fix minimum RX size check for AEAD decryption.
+Patch1013: 1013-crypto-algif_aead-Fix-minimum-RX-size-check-for-decryption.patch
+# Fix authencesn src offset for in-place decryption.
+Patch1014: 1014-crypto-authencesn-Fix-src-offset-when-decrypting-in-place.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Issue number:**

https://github.com/bottlerocket-os/bottlerocket/issues/4821

**Description of changes:**

Backporting patches to revert `algif_aead` to out-of-place operation.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
