### PR TITLE
docker-run: replace yq with grep/cut

### DIFF
--- a/tools/docker-run.sh
+++ b/tools/docker-run.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-YQ_IMAGE=mikefarah/yq:4.53.2
-
 bail() {
     if [[ $# -gt 0 ]]; then
         >&2 echo "Error: $*"
@@ -11,12 +9,7 @@ bail() {
 }
 
 find_sdk() {
-  docker run --rm \
-      -v "$(pwd):/bottlerocket-kernel-kit:ro" \
-      --user "$(id -u):$(id -g)" \
-      --network none \
-      "${YQ_IMAGE}" \
-      -p toml -oy '.sdk.source' /bottlerocket-kernel-kit/Twoliter.lock
+  grep -A5 '^\[sdk\]' Twoliter.lock | grep '^source' | cut -d'"' -f2
 }
 
 SCRIPT_PATH="$1"


### PR DESCRIPTION
**Description of changes:**

To reduce dependencies on external tooling and repositories, simplify the SDK source fetch using core utilities such as `grep` and `cut`.

**Testing done:**

`make full-config`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
