### PR TITLE
Provide nvidia-imex system service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v5.5.0 (TBD)
+
+## OS Changes
+* Backport patch to prevent a race in neighbor resolution for RDMA workloads ([#427])
+* Provide inactive nvidia-imex systemd service ([#428])
+* Provide NVIDIA modprobe override to create a default IMEX channel ([#428])
+
+[#427]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/427
+[#428]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/428
+
 # v5.4.2 (2026-05-05)
 
 ## OS Changes

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -61,6 +61,9 @@ Source211: grid-license-check.timer
 Source212: open-gpu-license-fallback.service
 Source213: tesla-license-fallback.service
 Source214: grid-license-file-check.conf
+Source215: nvidia-imex.service
+Source216: nvidia-imex.cfg
+Source217: nvidia-imex-tmpfiles.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -503,6 +506,12 @@ install -p -m 0755 usr/bin/nvidia-imex-ctl %{buildroot}%{_cross_bindir}
 
 popd
 
+# NVIDIA IMEX service, config, and tmpfiles
+install -p -m 0644 %{S:215} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex
+install -p -m 0644 %{S:216} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex/config.cfg
+install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -786,6 +795,9 @@ popd
 %files imex
 %{_cross_bindir}/nvidia-imex
 %{_cross_bindir}/nvidia-imex-ctl
+%{_cross_unitdir}/nvidia-imex.service
+%{_cross_factorydir}/etc/nvidia-imex/config.cfg
+%{_cross_tmpfilesdir}/nvidia-imex.conf
 
 %files mps
 %{_cross_bindir}/nvidia-cuda-mps-control

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -64,6 +64,7 @@ Source214: grid-license-file-check.conf
 Source215: nvidia-imex.service
 Source216: nvidia-imex.cfg
 Source217: nvidia-imex-tmpfiles.conf
+Source218: nvidia-imex-default-channel.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -113,6 +114,13 @@ Summary: NVIDIA IMEX config and service files
 Requires: %{name}
 
 %description imex
+%{summary}.
+
+%package imex-config
+Summary: NVIDIA IMEX modprobe configuration
+Requires: %{name}-imex
+
+%description imex-config
 %{summary}.
 
 %package open-gpu
@@ -512,6 +520,10 @@ install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex
 install -p -m 0644 %{S:216} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex/config.cfg
 install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
 
+# NVIDIA IMEX modprobe config
+install -d %{buildroot}%{_cross_libdir}/modprobe.d
+install -p -m 0644 %{S:218} %{buildroot}%{_cross_libdir}/modprobe.d/10-nvidia-default-imex-channel.conf
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -798,6 +810,9 @@ install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
 %{_cross_unitdir}/nvidia-imex.service
 %{_cross_factorydir}/etc/nvidia-imex/config.cfg
 %{_cross_tmpfilesdir}/nvidia-imex.conf
+
+%files imex-config
+%{_cross_libdir}/modprobe.d/10-nvidia-default-imex-channel.conf
 
 %files mps
 %{_cross_bindir}/nvidia-cuda-mps-control

--- a/packages/kmod-6.12-nvidia-r580/nvidia-imex-default-channel.conf
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-imex-default-channel.conf
@@ -1,0 +1,1 @@
+options nvidia NVreg_CreateImexChannel0=1

--- a/packages/kmod-6.12-nvidia-r580/nvidia-imex-tmpfiles.conf
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-imex-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/nvidia-imex 0755 root root -
+C /etc/nvidia-imex/config.cfg 0644 root root -

--- a/packages/kmod-6.12-nvidia-r580/nvidia-imex.cfg
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-imex.cfg
@@ -1,0 +1,140 @@
+# NVIDIA IMEX configuration file.
+# Note: This configuration file is read during IMEX startup. So, IMEX
+# service restart is required for new settings to take effect.
+ 
+#   Description: IMEX logging levels
+#   Possible Values:
+#           0  - All the logging is disabled
+#           1  - Set log level to CRITICAL and above
+#           2  - Set log level to ERROR and above
+#           3  - Set log level to WARNING and above
+#           4  - Set log level to INFO and above
+#       Default Value: 4
+LOG_LEVEL=3
+  
+#   Description: Filename for IMEX logs
+#   Possible Values:
+#       Full path/filename string (max length of 256). Logs will be redirected
+#       to console(stderr). If the specified log file can't be opened or the
+#       path is empty.
+#   Default Value: /var/log/nvidia-imex.log
+LOG_FILE_NAME=
+
+#   Description: Filename for IMEX stats logging
+#   Possible Values:
+#       Full path/filename string (max length of 256). Stats will be redirected
+#       to console(stderr), if the specified stats file can't be opened or the
+#       path is empty.
+#   Default Value: /var/log/nvidia-imex-stats.log
+#   Note: If STATS_FILE_NAME is configured same as LOG_FILE_NAME, then stats will
+#       be redirected to the path/filename specified by LOG_FILE_NAME.
+STATS_FILE_NAME=
+
+#   Description: Append to an existing log file or overwrite the logs
+#   Possible Values:
+#           0  - No  (Log file will be overwritten)
+#           1  - Yes (Append to existing log)
+#   Default Value: 1
+LOG_APPEND_TO_LOG=1
+     
+#   Description: Max size of log file (in MB)
+#   Possible Values:
+#           Any Integer values
+#   Default Value: 1024
+LOG_FILE_MAX_SIZE=1024
+
+#   Description: Number of times the IMEX log is rotated once it reaches LOG_FILE_MAX_SIZE
+#   Possible Values:
+#       0                - Log is not rotated. Logging is stopped once the IMEX log file reaches
+#                          the size specified in LOG_FILE_MAX_SIZE
+#       Non-zero Integer - Log is rotated upto the number of times specified in LOG_MAX_ROTATE_COUNT,
+#                          after the size of the log file reaches the size specified in LOG_FILE_MAX_SIZE.
+#                          Combined IMEX log size is LOG_FILE_MAX_SIZE multipled by LOG_MAX_ROTATE_COUNT+1
+#                          Once this threshold is reached, the oldest log file is purged and reused.
+LOG_MAX_ROTATE_COUNT=3
+
+#   Description: Redirect all the logs to syslog instead of logging to file
+#   Possible Values:
+#           0  - No
+#           1  - Yes
+#   Default Value: 0
+LOG_USE_SYSLOG=1
+       
+#   Description: daemonize IMEX on start-up
+#   Possible Values:
+#       0  - No (Do not daemonize and run IMEX as a normal process)
+#       1  - Yes (Run IMEX process as Unix daemon
+#   Default Value: 1
+DAEMONIZE=0
+        
+#   Description: Network interface to listen for IMEX peer communication.
+#                OPTIONAL - empty value will determine the bind IP from the node config file.
+#   Possible Values:
+#           A valid IPv4 address
+#           A valid IPv6 address
+#           No value - Determine bind IP from the node configuration file.
+#   Default Value: 
+BIND_INTERFACE_IP=
+           
+#   Description: Starting TCP port number for IMEX peer communication
+#   Possible Values:
+#           Any value between 0 and 65535
+#   Default Value: 50000
+SERVER_PORT=50000
+            
+#   Description: Name of file containing IP addresses of nodes
+#   Possible Values:
+#       Full path/filename string (max length of 256).
+#       Default Value: /etc/nvidia-imex/nodes_config.cfg
+IMEX_NODE_CONFIG_FILE=/etc/nvidia-imex/nodes_config.cfg
+
+#  Description: Name of the network interface used for communication.
+#               OPTIONAL - If empty, network interface will be determined by matching bind IP to
+#                          node configuration file.  Only necessary to configure if the bind IP
+#                          is IPv6 link-local and on multiple network interfaces.
+#  Possible Values:
+#      A valid interface name. e.g. eth0, ens32 .. etc
+#  Default Value: 
+NETWORK_INTERFACE=
+
+#  Description: Name of the network interface used for outgoing connections.
+#               OPTIONAL - If empty, outgoing network interface will be determined automatically.
+#                          Only necessary if user desires to force all
+#                          outgoing connections to use a particular interface.
+#  Possible Values:
+#      A valid interface name. e.g. eth0, ens32 .. etc
+#  Default Value: 
+OUTGOING_NETWORK_INTERFACE=
+
+#  Description:  Controls whether IMEX should complete initialization without establishing quorum
+#  Possible values:
+#       NONE: Do not wait for any quorum with other nodes.
+#   RECOVERY: In case of unsafe IMEX termination, wait until all nodes that had previously imported
+#             have connected, allowing them time to safely clean up any potentially hanging references
+#  Default value: RECOVERY
+IMEX_WAIT_FOR_QUORUM=RECOVERY
+
+#  Description: Enabled the command/control service to allow for querying information from the IMEX daemon.
+#               Must be used with IMEX_CMD_PORT (optionally IMEX_CMD_BIND_INTERFACE_IP) and/or
+#               IMEX_CMD_UNIX_DOMAIN_PATH
+IMEX_CMD_ENABLED=1
+
+#  Description:  Unix domain socket path to attach to for the command/control service. Ignored if IMEX_CMD_ENABLED=0
+IMEX_CMD_UNIX_DOMAIN_PATH=/run/nvidia/nvidia-imex-cmd.sock
+
+#  Description:  Determines how long to wait after detecting that the IMEX daemon has lost connection to another
+#                node before triggering clean up imports and exports from that node.  If a connection is reestablished
+#                before the grace period expires, and IMEX is able to identify that it is the same instance previously
+#                connected, then no clean up is required.  If a connection is established and IMEX detects that it is
+#                a new instance (i.e. someone restarted the IMEX daemon), then clean up will be immediately triggered
+#                regardless of grace period.
+#                -1: Default - Wait indefinitely
+#                 0: Immediately trigger clean up
+#                >0: Number of seconds to wait before triggering clean up
+IMEX_NODE_DISCONNECTED_GRACE_TIME=-1
+
+#  Description:  Optionally configure the DSCP value for both the listening server socket and the outgoing client 
+#                connections.
+#                0: Default
+#                1-63: Custom DSCP setting
+IMEX_GRPC_DSCP_OVERRIDE=0

--- a/packages/kmod-6.12-nvidia-r580/nvidia-imex.service
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-imex.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NVIDIA IMEX service
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/nvidia-imex -c /etc/nvidia-imex/config.cfg
+StandardOutput=journal
+StandardError=journal
+LimitCORE=infinity

--- a/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
+++ b/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
@@ -61,6 +61,9 @@ Source211: grid-license-check.timer
 Source212: open-gpu-license-fallback.service
 Source213: tesla-license-fallback.service
 Source214: grid-license-file-check.conf
+Source215: nvidia-imex.service
+Source216: nvidia-imex.cfg
+Source217: nvidia-imex-tmpfiles.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -503,6 +506,12 @@ install -p -m 0755 usr/bin/nvidia-imex-ctl %{buildroot}%{_cross_bindir}
 
 popd
 
+# NVIDIA IMEX service, config, and tmpfiles
+install -p -m 0644 %{S:215} %{buildroot}%{_cross_unitdir}
+install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex
+install -p -m 0644 %{S:216} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex/config.cfg
+install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -786,6 +795,9 @@ popd
 %files imex
 %{_cross_bindir}/nvidia-imex
 %{_cross_bindir}/nvidia-imex-ctl
+%{_cross_unitdir}/nvidia-imex.service
+%{_cross_factorydir}/etc/nvidia-imex/config.cfg
+%{_cross_tmpfilesdir}/nvidia-imex.conf
 
 %files mps
 %{_cross_bindir}/nvidia-cuda-mps-control

--- a/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
+++ b/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
@@ -64,6 +64,7 @@ Source214: grid-license-file-check.conf
 Source215: nvidia-imex.service
 Source216: nvidia-imex.cfg
 Source217: nvidia-imex-tmpfiles.conf
+Source218: nvidia-imex-default-channel.conf
 
 # NVIDIA tesla conf files from 300 to 399
 Source300: nvidia-tesla-tmpfiles.conf
@@ -113,6 +114,13 @@ Summary: NVIDIA IMEX config and service files
 Requires: %{name}
 
 %description imex
+%{summary}.
+
+%package imex-config
+Summary: NVIDIA IMEX modprobe configuration
+Requires: %{name}-imex
+
+%description imex-config
 %{summary}.
 
 %package open-gpu
@@ -512,6 +520,10 @@ install -d %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex
 install -p -m 0644 %{S:216} %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/nvidia-imex/config.cfg
 install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
 
+# NVIDIA IMEX modprobe config
+install -d %{buildroot}%{_cross_libdir}/modprobe.d
+install -p -m 0644 %{S:218} %{buildroot}%{_cross_libdir}/modprobe.d/10-nvidia-default-imex-channel.conf
+
 %files
 %{_cross_attribution_file}
 %dir %{_cross_libexecdir}/nvidia
@@ -798,6 +810,9 @@ install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
 %{_cross_unitdir}/nvidia-imex.service
 %{_cross_factorydir}/etc/nvidia-imex/config.cfg
 %{_cross_tmpfilesdir}/nvidia-imex.conf
+
+%files imex-config
+%{_cross_libdir}/modprobe.d/10-nvidia-default-imex-channel.conf
 
 %files mps
 %{_cross_bindir}/nvidia-cuda-mps-control

--- a/packages/kmod-6.18-nvidia-r580/nvidia-imex-default-channel.conf
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-imex-default-channel.conf
@@ -1,0 +1,1 @@
+options nvidia NVreg_CreateImexChannel0=1

--- a/packages/kmod-6.18-nvidia-r580/nvidia-imex-tmpfiles.conf
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-imex-tmpfiles.conf
@@ -1,0 +1,2 @@
+d /etc/nvidia-imex 0755 root root -
+C /etc/nvidia-imex/config.cfg 0644 root root -

--- a/packages/kmod-6.18-nvidia-r580/nvidia-imex.cfg
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-imex.cfg
@@ -1,0 +1,140 @@
+# NVIDIA IMEX configuration file.
+# Note: This configuration file is read during IMEX startup. So, IMEX
+# service restart is required for new settings to take effect.
+ 
+#   Description: IMEX logging levels
+#   Possible Values:
+#           0  - All the logging is disabled
+#           1  - Set log level to CRITICAL and above
+#           2  - Set log level to ERROR and above
+#           3  - Set log level to WARNING and above
+#           4  - Set log level to INFO and above
+#       Default Value: 4
+LOG_LEVEL=3
+  
+#   Description: Filename for IMEX logs
+#   Possible Values:
+#       Full path/filename string (max length of 256). Logs will be redirected
+#       to console(stderr). If the specified log file can't be opened or the
+#       path is empty.
+#   Default Value: /var/log/nvidia-imex.log
+LOG_FILE_NAME=
+
+#   Description: Filename for IMEX stats logging
+#   Possible Values:
+#       Full path/filename string (max length of 256). Stats will be redirected
+#       to console(stderr), if the specified stats file can't be opened or the
+#       path is empty.
+#   Default Value: /var/log/nvidia-imex-stats.log
+#   Note: If STATS_FILE_NAME is configured same as LOG_FILE_NAME, then stats will
+#       be redirected to the path/filename specified by LOG_FILE_NAME.
+STATS_FILE_NAME=
+
+#   Description: Append to an existing log file or overwrite the logs
+#   Possible Values:
+#           0  - No  (Log file will be overwritten)
+#           1  - Yes (Append to existing log)
+#   Default Value: 1
+LOG_APPEND_TO_LOG=1
+     
+#   Description: Max size of log file (in MB)
+#   Possible Values:
+#           Any Integer values
+#   Default Value: 1024
+LOG_FILE_MAX_SIZE=1024
+
+#   Description: Number of times the IMEX log is rotated once it reaches LOG_FILE_MAX_SIZE
+#   Possible Values:
+#       0                - Log is not rotated. Logging is stopped once the IMEX log file reaches
+#                          the size specified in LOG_FILE_MAX_SIZE
+#       Non-zero Integer - Log is rotated upto the number of times specified in LOG_MAX_ROTATE_COUNT,
+#                          after the size of the log file reaches the size specified in LOG_FILE_MAX_SIZE.
+#                          Combined IMEX log size is LOG_FILE_MAX_SIZE multipled by LOG_MAX_ROTATE_COUNT+1
+#                          Once this threshold is reached, the oldest log file is purged and reused.
+LOG_MAX_ROTATE_COUNT=3
+
+#   Description: Redirect all the logs to syslog instead of logging to file
+#   Possible Values:
+#           0  - No
+#           1  - Yes
+#   Default Value: 0
+LOG_USE_SYSLOG=1
+       
+#   Description: daemonize IMEX on start-up
+#   Possible Values:
+#       0  - No (Do not daemonize and run IMEX as a normal process)
+#       1  - Yes (Run IMEX process as Unix daemon
+#   Default Value: 1
+DAEMONIZE=0
+        
+#   Description: Network interface to listen for IMEX peer communication.
+#                OPTIONAL - empty value will determine the bind IP from the node config file.
+#   Possible Values:
+#           A valid IPv4 address
+#           A valid IPv6 address
+#           No value - Determine bind IP from the node configuration file.
+#   Default Value: 
+BIND_INTERFACE_IP=
+           
+#   Description: Starting TCP port number for IMEX peer communication
+#   Possible Values:
+#           Any value between 0 and 65535
+#   Default Value: 50000
+SERVER_PORT=50000
+            
+#   Description: Name of file containing IP addresses of nodes
+#   Possible Values:
+#       Full path/filename string (max length of 256).
+#       Default Value: /etc/nvidia-imex/nodes_config.cfg
+IMEX_NODE_CONFIG_FILE=/etc/nvidia-imex/nodes_config.cfg
+
+#  Description: Name of the network interface used for communication.
+#               OPTIONAL - If empty, network interface will be determined by matching bind IP to
+#                          node configuration file.  Only necessary to configure if the bind IP
+#                          is IPv6 link-local and on multiple network interfaces.
+#  Possible Values:
+#      A valid interface name. e.g. eth0, ens32 .. etc
+#  Default Value: 
+NETWORK_INTERFACE=
+
+#  Description: Name of the network interface used for outgoing connections.
+#               OPTIONAL - If empty, outgoing network interface will be determined automatically.
+#                          Only necessary if user desires to force all
+#                          outgoing connections to use a particular interface.
+#  Possible Values:
+#      A valid interface name. e.g. eth0, ens32 .. etc
+#  Default Value: 
+OUTGOING_NETWORK_INTERFACE=
+
+#  Description:  Controls whether IMEX should complete initialization without establishing quorum
+#  Possible values:
+#       NONE: Do not wait for any quorum with other nodes.
+#   RECOVERY: In case of unsafe IMEX termination, wait until all nodes that had previously imported
+#             have connected, allowing them time to safely clean up any potentially hanging references
+#  Default value: RECOVERY
+IMEX_WAIT_FOR_QUORUM=RECOVERY
+
+#  Description: Enabled the command/control service to allow for querying information from the IMEX daemon.
+#               Must be used with IMEX_CMD_PORT (optionally IMEX_CMD_BIND_INTERFACE_IP) and/or
+#               IMEX_CMD_UNIX_DOMAIN_PATH
+IMEX_CMD_ENABLED=1
+
+#  Description:  Unix domain socket path to attach to for the command/control service. Ignored if IMEX_CMD_ENABLED=0
+IMEX_CMD_UNIX_DOMAIN_PATH=/run/nvidia/nvidia-imex-cmd.sock
+
+#  Description:  Determines how long to wait after detecting that the IMEX daemon has lost connection to another
+#                node before triggering clean up imports and exports from that node.  If a connection is reestablished
+#                before the grace period expires, and IMEX is able to identify that it is the same instance previously
+#                connected, then no clean up is required.  If a connection is established and IMEX detects that it is
+#                a new instance (i.e. someone restarted the IMEX daemon), then clean up will be immediately triggered
+#                regardless of grace period.
+#                -1: Default - Wait indefinitely
+#                 0: Immediately trigger clean up
+#                >0: Number of seconds to wait before triggering clean up
+IMEX_NODE_DISCONNECTED_GRACE_TIME=-1
+
+#  Description:  Optionally configure the DSCP value for both the listening server socket and the outgoing client 
+#                connections.
+#                0: Default
+#                1-63: Custom DSCP setting
+IMEX_GRPC_DSCP_OVERRIDE=0

--- a/packages/kmod-6.18-nvidia-r580/nvidia-imex.service
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-imex.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NVIDIA IMEX service
+After=network-online.target
+Requires=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/nvidia-imex -c /etc/nvidia-imex/config.cfg
+StandardOutput=journal
+StandardError=journal
+LimitCORE=infinity


### PR DESCRIPTION
**Description of changes:**

This series adds a new inactive systemd service for nvidia-imex. The service is inactive (not started on boot) because downstreams are expected to manage its lifecycle, as nvidia-imex requires a configuration file with the IPs of the nodes that will belong to the same cluster which are only known by the control plan and the capacity provider. In Kubernetes, nvidia-imex channels are managed by the NVIDIA DRA driver, so this service is intended to be used by other orchestrators.

As part of this change, a new modprobe override was added that allows the NVIDIA kmods to create a default IMEX channel. This configuration is opt-in, as enabling by default in all variants could interfere with the IMEX channels management performed by the NVIDIA DRA driver.

No API will be provided for the time being, but one might be needed if we decide to extend the support of nvidia-imex beyond what we currently have.

The systemd service was based off the `nvidia-imex.service` provided by the run archives, I just adapt it slightly

A default configuration file is provided with sensible defaults:

<details>

`LOG_LEVEL=3`: log info messages
`LOG_FILE_NAME`: empty to log to STDOUT and get the logs to the journal
`STATS_FILE_NAME`: same as above
`DAEMONIZE=0`: run as an actual process (don't fork)
`BIND_INTERFACE_IP=`: set through `nodes_config.cfg`, managed by the downstreams
`SERVER_PORT=50000`: default port, but make it explicit
`IMEX_NODE_CONFIG_FILE=/etc/nvidia-imex/nodes_config.cfg`: default path, but make it explicit
`NETWORK_INTERFACE=` set through `nodes_config.cfg`, managed by the downstreams
`OUTGOING_NETWORK_INTERFACE=`
`IMEX_WAIT_FOR_QUORUM=RECOVERY`: safe default (wait for quorum)
`IMEX_CMD_ENABLED=1`
`IMEX_CMD_UNIX_DOMAIN_PATH=/run/nvidia/nvidia-imex-cmd.sock`: socket to send commands to the service
`IMEX_NODE_DISCONNECTED_GRACE_TIME=-1`: Wait indefinitely 
`IMEX_GRPC_DSCP_OVERRIDE=0`: 

NO-OP configurations but since I don't have access to the source code nor to instances that can connect through IMEX, I decided to keep them.
 
`LOG_APPEND_TO_LOG=1`:
`LOG_FILE_MAX_SIZE=1024`
`LOG_MAX_ROTATE_COUNT=3`
`LOG_USE_SYSLOG=1`

</details>


**Testing done:**

- Confirmed the `nvidia-imex` service doesn't start on boot:

<details>

```bash
bash-5.2# systemctl status nvidia-imex.service
○ nvidia-imex.service - NVIDIA IMEX service
     Loaded: loaded (/x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/nvidia-imex.service; static)
    Drop-In: /x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/systemd/system/service.d
             └─00-aws-config.conf, 10-requires-tmp.conf
     Active: inactive (dead)
```

</details>

- Confirmed kernel module loaded successfully even with the new config:

<details>

```bash
bash-5.2# lsmod | grep nvidia
nvidia_uvm           1990656  0
nvidia_modeset       1753088  0
nvidia              13963264  7 nvidia_uvm,nvidia_modeset
video                  81920  1 nvidia_modeset
drm                   794624  1 nvidia
i2c_core              122880  4 nvidia,i2c_smbus,i2c_piix4,drm
backlight              28672  3 video,drm,nvidia_modeset
bash-5.2# nvidia-smi
Wed May  6 22:58:47 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
| N/A   35C    P8             13W /   70W |       0MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
```

</details>

- Confirmed default IMEX channel was created:

<details>

```bash
bash-5.2# ls /dev/nvidia-caps-imex-channels/
channel0
bash-5.2#
```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
