### PR TITLE
Add additional Neuron drivers to 6.18

### DIFF
--- a/packages/kernel-6.18/2001-Rename-struct-mempool-to-struct-neuron_mempool.patch
+++ b/packages/kernel-6.18/2001-Rename-struct-mempool-to-struct-neuron_mempool.patch
@@ -1,0 +1,119 @@
+From 199a6ba1eb72d6a14ad09710e40b933945be4b80 Mon Sep 17 00:00:00 2001
+From: "Patrick J.P. Culp" <jpculp@amazon.com>
+Date: Fri, 8 May 2026 23:21:26 +0000
+Subject: [PATCH] Rename struct mempool to struct neuron_mempool
+
+Avoid conflict with the kernel's struct mempool defined in
+linux/mempool.h, which collides with the neuron driver's own
+struct mempool on kernel 6.18.
+
+Signed-off-by: Patrick J.P. Culp <jpculp@amazon.com>
+---
+ neuron_mempool.c | 14 +++++++-------
+ neuron_mempool.h |  8 ++++----
+ 2 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/neuron_mempool.c b/neuron_mempool.c
+index 20e4436..b892348 100644
+--- a/neuron_mempool.c
++++ b/neuron_mempool.c
+@@ -133,7 +133,7 @@ static void mc_remove_node(struct rb_root *root, struct mem_chunk *mc)
+  * Return: 0 if pool is created, a negative error code otherwise.
+  */
+ 
+-static int mp_init_device_mem(struct mempool *mp, struct mempool_set *mpset,
++static int mp_init_device_mem(struct neuron_mempool *mp, struct mempool_set *mpset,
+ 			      u64 start_addr, size_t pool_size,	u32 dram_channel, u32 dram_region)
+ {
+ 	int ret;
+@@ -205,7 +205,7 @@ static int mp_init_device_mem(struct mempool *mp, struct mempool_set *mpset,
+  * Frees all backing pages allocated for reserved host_mem pool.
+  * Does opposite work of mp_init_hrm_pool
+  */
+-static void mp_destroy_hrm_pool(struct mempool *mp)
++static void mp_destroy_hrm_pool(struct neuron_mempool *mp)
+ {
+ 	int i = 0;
+ 	if (mp->page_va_array == NULL)
+@@ -238,7 +238,7 @@ static void mp_destroy_hrm_pool(struct mempool *mp)
+  *
+  * Return: 0 if pool is created, a negative error code otherwise.
+  */
+-static int mp_init_hrm_pool(struct mempool *mp, struct mempool_set *mpset,
++static int mp_init_hrm_pool(struct neuron_mempool *mp, struct mempool_set *mpset,
+ 			    u32 page_size, u32 page_count)
+ {
+ 	int ret;
+@@ -299,7 +299,7 @@ fail:
+ /**
+  * Frees all the chunks associated with the mempool and releases the mempool.
+  */
+-static void mp_destroy_gen_pool(struct mempool *mp)
++static void mp_destroy_gen_pool(struct neuron_mempool *mp)
+ {
+ 	BUG_ON(mp == NULL);
+ 	if (!mp->initialized)
+@@ -562,7 +562,7 @@ void mpset_free_expired_mc(struct mempool_set *mpset, enum mc_lifespan lifespan)
+ 	mpset_free_lifespan_list(head, next_head);
+ }
+ 
+-static inline u64 get_offset_for_scratchpad_alloc(const struct mempool *mp, u64 alloc_size)
++static inline u64 get_offset_for_scratchpad_alloc(const struct neuron_mempool *mp, u64 alloc_size)
+ {
+ 	/*
+ 	Contiguous scratchpad grows backwards from the end of the main genpool
+@@ -581,7 +581,7 @@ static int mc_alloc_internal(struct neuron_device *nd, enum mc_lifespan lifespan
+ 	     struct mem_chunk **result)
+ {
+ 	struct mem_chunk *mc;
+-	struct mempool *mp = NULL;
++	struct neuron_mempool *mp = NULL;
+ 	struct mempool_set *mpset = &nd->mpset;
+ 	struct gen_pool *pool = NULL;
+ 	struct gen_pool *alt_pool = NULL;
+@@ -845,7 +845,7 @@ void mc_free(struct mem_chunk **mcp)
+ 		mpset->host_mem_size -= mc->size;
+ 		nsysfsmetric_dec_counter(mpset->nd, NON_NDS_METRIC, NON_NDS_COUNTER_HOST_MEM, mc->nc_id, mc->size, false);
+ 	} else if (mc->mem_location == MEM_LOC_DEVICE) {
+-		struct mempool *mp;
++		struct neuron_mempool *mp;
+ 		mp = &mpset->mp_device[mc->dram_channel][mc->dram_region];
+ 		gen_pool_free(mc->gen_pool, (u64)mc->va, mc->size);
+ 		mp->allocated_size -= mc->size;
+diff --git a/neuron_mempool.h b/neuron_mempool.h
+index 2ad7aa9..23be9da 100644
+--- a/neuron_mempool.h
++++ b/neuron_mempool.h
+@@ -39,7 +39,7 @@ enum mem_location {
+  * Device is memory is split in to chunks and allocated.
+  * Uses genpool allocator in the backend.
+  */
+-struct mempool {
++struct neuron_mempool {
+ 	char name[32]; // friendly name
+ 	bool initialized; // True if initialized.
+ 
+@@ -82,9 +82,9 @@ struct mempool_set {
+ 
+ 	u32 mp_device_num_regions; // number of regions in the device pool
+ 	u32 num_channels; // number of regions in the device pool
+-	struct mempool mp_device[MAX_DRAM_CHANNELS][MAX_DDR_REGIONS]; // device memory pools
++	struct neuron_mempool mp_device[MAX_DRAM_CHANNELS][MAX_DDR_REGIONS]; // device memory pools
+ 
+-	struct mempool mp_hrm[MP_HOST_RESERVE_MEMORY_POOL_COUNT]; // host reserve memory pools
++	struct neuron_mempool mp_hrm[MP_HOST_RESERVE_MEMORY_POOL_COUNT]; // host reserve memory pools
+ 
+ 	// linked list head to store mem_chunk of different lifespan
+ 	struct list_head mc_lifespan_local_head;
+@@ -127,7 +127,7 @@ struct mem_chunk {
+ 
+ 	u64 size; // chunk size
+ 
+-	struct mempool *mp; // backpointer to mp
++	struct neuron_mempool *mp; // backpointer to mp
+ 	struct mempool_set *mpset; // back pointer to mpset
+ 	struct gen_pool *gen_pool; // pointer to genpool
+ 
+-- 
+2.50.1
+

--- a/packages/kernel-6.18/Cargo.toml
+++ b/packages/kernel-6.18/Cargo.toml
@@ -27,5 +27,25 @@ sha512 = "ba2234e3aa8f5fb15a36304d811043abbed27e79bbd34bf2e0789f2f9a72d8f4c25c70
 url = "https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.10.0.noarch.rpm"
 sha512 = "ee49ab3aa9f4273a91aef305f30ed213c90c46317e72cfe46dd1d0e7088f0758039f998589ffc1080523f0af8f3348f9db4fe763b6fe8a0fd7d3119546cb1936"
 
+[[package.metadata.build-package.external-files]]
+# Neuron driver 2.x.7372.0
+url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.7372.0.noarch.rpm/e82516a77ab54f1c651a1f160e3a67b1cbca8bef391d78a6c683d6fc22442c8ee17df9d3fae1392ca8cffa676bb966b7088c32e634894ba142d83bef58dd2d81/aws-neuronx-dkms-2.x.7372.0.noarch.rpm"
+sha512 = "e82516a77ab54f1c651a1f160e3a67b1cbca8bef391d78a6c683d6fc22442c8ee17df9d3fae1392ca8cffa676bb966b7088c32e634894ba142d83bef58dd2d81"
+
+[[package.metadata.build-package.external-files]]
+# Neuron driver 2.x.7693.0
+url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.7693.0.noarch.rpm/4411e3d28bc307bd096408f72f9c3d9e3edcadcbeab3ca409b0f94041ac1f589120353edfb1e11c45ff5a5421808297a308f18a6ac687459abe8c5e985653d3f/aws-neuronx-dkms-2.x.7693.0.noarch.rpm"
+sha512 = "4411e3d28bc307bd096408f72f9c3d9e3edcadcbeab3ca409b0f94041ac1f589120353edfb1e11c45ff5a5421808297a308f18a6ac687459abe8c5e985653d3f"
+
+[[package.metadata.build-package.external-files]]
+# Neuron driver 2.x.8072.0
+url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8072.0.noarch.rpm/d96bd0fe73482684c97faae6f779bfa8a84e9b9ca09f796031d409322550fb1744a38e6c54f5fcc8c1221f051cf04f518694876ea825722f5ed7895c2e8bb22a/aws-neuronx-dkms-2.x.8072.0.noarch.rpm"
+sha512 = "d96bd0fe73482684c97faae6f779bfa8a84e9b9ca09f796031d409322550fb1744a38e6c54f5fcc8c1221f051cf04f518694876ea825722f5ed7895c2e8bb22a"
+
+[[package.metadata.build-package.external-files]]
+# Neuron driver 2.x.8689.0
+url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8689.0.noarch.rpm/5d3ce7f81858d5aae62279369bce72e041dd321f71146a4ab8e61f9230f3965323f9c9230547476614f1c334b84c59edbd892524e2a87c35b46960a044502e9f/aws-neuronx-dkms-2.x.8689.0.noarch.rpm"
+sha512 = "5d3ce7f81858d5aae62279369bce72e041dd321f71146a4ab8e61f9230f3965323f9c9230547476614f1c334b84c59edbd892524e2a87c35b46960a044502e9f"
+
 [build-dependencies]
 microcode = { path = "../microcode" }

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -18,7 +18,15 @@ Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
 Source3: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.26.10.0.noarch.rpm
-Source4: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
+# Neuron driver 2.x.7372.0
+Source4: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.7372.0.noarch.rpm/e82516a77ab54f1c651a1f160e3a67b1cbca8bef391d78a6c683d6fc22442c8ee17df9d3fae1392ca8cffa676bb966b7088c32e634894ba142d83bef58dd2d81/aws-neuronx-dkms-2.x.7372.0.noarch.rpm
+# Neuron driver 2.x.7693.0
+Source5: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.7693.0.noarch.rpm/4411e3d28bc307bd096408f72f9c3d9e3edcadcbeab3ca409b0f94041ac1f589120353edfb1e11c45ff5a5421808297a308f18a6ac687459abe8c5e985653d3f/aws-neuronx-dkms-2.x.7693.0.noarch.rpm
+# Neuron driver 2.x.8072.0
+Source6: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8072.0.noarch.rpm/d96bd0fe73482684c97faae6f779bfa8a84e9b9ca09f796031d409322550fb1744a38e6c54f5fcc8c1221f051cf04f518694876ea825722f5ed7895c2e8bb22a/aws-neuronx-dkms-2.x.8072.0.noarch.rpm
+# Neuron driver 2.x.8689.0
+Source7: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8689.0.noarch.rpm/5d3ce7f81858d5aae62279369bce72e041dd321f71146a4ab8e61f9230f3965323f9c9230547476614f1c334b84c59edbd892524e2a87c35b46960a044502e9f/aws-neuronx-dkms-2.x.8689.0.noarch.rpm
+Source8: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Custom Bottlerocket kernel configurations.
 Source100: config-bottlerocket
@@ -58,6 +66,9 @@ Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
 Patch1006: 1006-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 # Fix race condition reading zero MAC in IB neighbor resolution.
 Patch1007: 1007-IB-core-Fix-zero-dmac-race-in-neighbor-resolution.patch
+
+# Neuron driver patches for kernel 6.18 compatibility.
+Patch2001: 2001-Rename-struct-mempool-to-struct-neuron_mempool.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel
@@ -190,7 +201,7 @@ for patch in ${patches[@]}; do
     patch -p1 <../"$patch"
 done
 # Patches listed in this spec (Patch0001...)
-%autopatch -p1
+%autopatch -p1 -M 1999
 
 %if "%{_cross_arch}" == "x86_64"
 microcode="$(find %{_cross_libdir}/firmware -type f -path '*/*-ucode/*' -printf '%%P\n' | sort | tr '\n' ' ')"
@@ -241,7 +252,7 @@ cd %{_builddir}
 
 %if "%{_cross_arch}" == "x86_64"
 # 2.24 for inf1 support
-rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
+rpmkeys --import %{S:8} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:2} | cpio -idmu './usr/src/aws-neuronx-*'
@@ -249,11 +260,40 @@ find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2_24 \;
 rm -r usr
 
 # latest neuron driver
-rpmkeys --import %{S:4} --dbpath "${PWD}/rpmdb"
+rpmkeys --import %{S:8} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:3} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 rpm2cpio %{S:3} | cpio -idmu './usr/src/aws-neuronx-*'
 find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_latest \;
+rm -r usr
+
+# 2.x.7372.0 neuron driver
+rpm2cpio %{S:4} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_7372 \;
+rm -r usr
+pushd neuron_2x_7372
+%patch -P 2001 -p1
+popd
+
+# 2.x.7693.0 neuron driver
+rpm2cpio %{S:5} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_7693 \;
+rm -r usr
+pushd neuron_2x_7693
+%patch -P 2001 -p1
+popd
+
+# 2.x.8072.0 neuron driver
+rpm2cpio %{S:6} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_8072 \;
+rm -r usr
+pushd neuron_2x_8072
+%patch -P 2001 -p1
+popd
+
+# 2.x.8689.0 neuron driver
+rpm2cpio %{S:7} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_8689 \;
 rm -r usr
 %endif
 
@@ -275,6 +315,10 @@ make -s \
 %if "%{_cross_arch}" == "x86_64"
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_2_24
 %kmake %{?_smp_mflags} M=%{_builddir}/neuron_latest
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2x_7372
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2x_7693
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2x_8072
+%kmake %{?_smp_mflags} M=%{_builddir}/neuron_2x_8689
 %endif
 
 make -C tools/bpf/bpftool bootstrap
@@ -287,10 +331,22 @@ make -C tools/bpf/bpftool bootstrap
 %if "%{_cross_arch}" == "x86_64"
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7372/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7693/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8072/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8689/
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2_24 M=%{_builddir}/neuron_2_24 modules_install
 %kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_latest M=%{_builddir}/neuron_latest modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_7372 M=%{_builddir}/neuron_2x_7372 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_7693 M=%{_builddir}/neuron_2x_7693 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_8072 M=%{_builddir}/neuron_2x_8072 modules_install
+%kmake %{?_smp_mflags} INSTALL_MOD_DIR=neuron_2x_8689 M=%{_builddir}/neuron_2x_8689 modules_install
 mv %{buildroot}%{_cross_kmoddir}/neuron_2_24/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2x_7372/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7372/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2x_7693/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7693/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2x_8072/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8072/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2x_8689/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8689/
 %endif
 
 install -d %{buildroot}/boot
@@ -1441,6 +1497,10 @@ install -p -m 0644 %{S:301} %{buildroot}%{_cross_bootconfigdir}/05-vmware.conf
 %files modules-neuron
 %{_cross_libexecdir}/neuron/neuron_2_24/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_latest/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2x_7372/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2x_7693/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2x_8072/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2x_8689/neuron.%{_ko}
 %{_cross_tmpfilesdir}/neuron.conf
 %{_cross_unitdir}/load-neuron-inf1-modules.service
 %{_cross_unitdir}/load-neuron-latest-modules.service


### PR DESCRIPTION
**Description of changes:**
There are situations where manually overriding the Neuron driver chosen by the PCI detection may be warranted. This provides those drivers for those times. All automatic behavior is intact, these are just present on the filesystem for those use cases.


**Testing done:**
- Launched a modified `aws-k8s-1.35` on `trn2.48xlarge` with these drivers and manually loaded the driver to show it working.

<details>

```
bash-5.2# driverdog link-modules
23:35:36 [INFO] Copied neuron.ko
23:35:36 [INFO] Copied neuron.ko
bash-5.2# ls -al /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
-rw-r--r--. 1 root root 958105 May  7 23:35 /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
bash-5.2# find . -name "neuron.ko"
./var/lib/kernel-modules/.overlay/upper/6.18.20/kernel/drivers/neuron/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2_24/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7372/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7693/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8072/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8689/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_latest/neuron.ko
bash-5.2# for ko in ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_*/neuron.ko; do echo "=== $ko ==="; rmmod neuron 2>/dev/null; cp "$ko" /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko && modprobe neuron && modinfo neuron; done
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7372/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.7372.0
license:        GPL
description:    Neuron Driver, built from SHA: ed2eca4781405ab537f14c42850ecae3fd99dad4
import_ns:      DMA_BUF
srcversion:     65499ABA5AB2A03439601DD
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           userver_pds_node_cnt:pds ultraserver node count (int)
parm:           userver_pds_server_id:pds ultraserver id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7693/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.7693.0
license:        GPL
description:    Neuron Driver, built from SHA: 559cb9bf14a5b9e98b28b11fe8c7d70d659bd308
import_ns:      DMA_BUF
srcversion:     A5AA33BD55AE2BD2B4B7BE4
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           userver_pds_node_cnt:pds ultraserver node count (int)
parm:           userver_pds_server_id:pds ultraserver id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           dma_teardown_on_exit:Reset the DMA state on user process exit (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8072/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.8072.0
license:        GPL
description:    Neuron Driver, built from SHA: 381f0e424131a6a8ab4599de7edd7170ee3388c1
import_ns:      DMA_BUF
srcversion:     614E351145FEC5E249AE9B2
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           userver_pds_node_cnt:pds ultraserver node count (int)
parm:           userver_pds_server_id:pds ultraserver id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           dma_teardown_on_exit:Reset the DMA state on user process exit (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8689/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.8689.0
license:        GPL
description:    Neuron Driver, built from SHA: 623632eb9c3d3312be233cf19079301468d42497
import_ns:      DMA_BUF
srcversion:     6575987C65645BB7D4C215D
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           pds_reservation_id:pds reservation id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           reset_top_dma:Reset top-level DMAs during TPB reset (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           dma_teardown_on_exit:Reset the DMA state on user process exit (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
```

</details>

- Launched a modified `aws-ecs-3` on `inf2.xlarge` with these drivers and manually loaded the driver to show it working.

<details>

```
bash-5.2# driverdog link-modules
00:31:32 [INFO] Copied neuron.ko
00:31:32 [INFO] Copied neuron.ko
bash-5.2# ls -al /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
-rw-r--r--. 1 root root 976289 May  8 00:31 /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
bash-5.2# find . -name "neuron.ko"
./var/lib/kernel-modules/.overlay/upper/6.18.20/kernel/drivers/neuron/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2_24/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7372/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7693/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8072/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8689/neuron.ko
./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_latest/neuron.ko
bash-5.2# for ko in ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_*/neuron.ko; do echo "=== $ko ==="; rmmod neuron 2>/dev/null; cp "$ko" /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko && modprobe neuron && modinfo neuron; done
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7372/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.7372.0
license:        GPL
description:    Neuron Driver, built from SHA: ed2eca4781405ab537f14c42850ecae3fd99dad4
import_ns:      DMA_BUF
srcversion:     65499ABA5AB2A03439601DD
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           userver_pds_node_cnt:pds ultraserver node count (int)
parm:           userver_pds_server_id:pds ultraserver id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_7693/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.7693.0
license:        GPL
description:    Neuron Driver, built from SHA: 559cb9bf14a5b9e98b28b11fe8c7d70d659bd308
import_ns:      DMA_BUF
srcversion:     A5AA33BD55AE2BD2B4B7BE4
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           userver_pds_node_cnt:pds ultraserver node count (int)
parm:           userver_pds_server_id:pds ultraserver id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           dma_teardown_on_exit:Reset the DMA state on user process exit (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8072/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.8072.0
license:        GPL
description:    Neuron Driver, built from SHA: 381f0e424131a6a8ab4599de7edd7170ee3388c1
import_ns:      DMA_BUF
srcversion:     614E351145FEC5E249AE9B2
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           userver_pds_node_cnt:pds ultraserver node count (int)
parm:           userver_pds_server_id:pds ultraserver id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           dma_teardown_on_exit:Reset the DMA state on user process exit (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
=== ./x86_64-bottlerocket-linux-gnu/sys-root/usr/libexec/neuron/neuron_2x_8689/neuron.ko ===
filename:       /lib/modules/6.18.20/kernel/drivers/neuron/neuron.ko
alias:          pci:v00001d0fd00007064sv*sd*bc*sc*i*
version:        2.x.8689.0
license:        GPL
description:    Neuron Driver, built from SHA: 623632eb9c3d3312be233cf19079301468d42497
import_ns:      DMA_BUF
srcversion:     6575987C65645BB7D4C215D
depends:
name:           neuron
retpoline:      Y
vermagic:       6.18.20 SMP preempt mod_unload modversions
sig_id:         PKCS#7
signer:
sig_key:
sig_hashalgo:   unknown
signature:
parm:           pds_reservation_id:pds reservation id (int)
parm:           userver_ctl:ultraserver election control (int)
parm:           userver_etimeout:ultraserver election timeout (int)
parm:           force_userver:Force Neuron UltraServer (int)
parm:           force_die_flip:Force Neuron Core Mapping APIs to give back DIE flip mappings (int)
parm:           nmetric_metric_post_delay:Minimum time to wait (in milliseconds) before posting metrics again (uint)
parm:           nmetric_log_posts:1: send metrics to CW, 2: send metrics to trace, 3: send metrics to both (uint)
parm:           no_reset:Dont reset device (int)
parm:           reset_top_dma:Reset top-level DMAs during TPB reset (int)
parm:           nc_per_dev_param:Number of neuron cores (int)
parm:           dev_nc_map:Map of active neuron cores (int)
parm:           dma_teardown_on_exit:Reset the DMA state on user process exit (int)
parm:           zerocopy_trn1_override:override zerocopy for trn1 (int)
parm:           mempool_min_alloc_size:Minimum size for memory allocation (int)
parm:           mempool_host_memory_size:Host memory to reserve(in bytes) (int)
parm:           mempool_small_pool_size:Size of genpool for small allocations (in bytes) (ulong)
parm:           mempool_small_alloc_max:Threshold (in bytes) for deciding if an allocation is small (ulong)
parm:           dup_helper_enable:enable duplicate routing id unload helper (int)
parm:           wc_enable:enable write combining (int)
```

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
