### PR TITLE
Update kernels

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/8ce85b631ba69bc4673a25c587503054ba55bd7022091bbf6260a76e56a4d017/kernel-6.1.170-210.320.amzn2023.src.rpm"
-sha512 = "aa82f954983c7c174bfff7a136c1334f6223b121afda766559187b1d691daafdc8455ac73edee8d54a3d0ab17d8f743a410f9966e8d1a6b1e18f9804ee506850"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/95e0d820e4b079b39606fcb77a0fd773c893c6a2b0a3c92bb4246c2db7b65762/kernel-6.1.170-213.321.amzn2023.src.rpm"
+sha512 = "96db3f6e9051154f0079e009a30d6d0ecf2bd2ec3b4b718f244102a37ad072de2b954882cb5f9be6746b1af5323b3d43c9f252c7eb624027ca02d95d552a6c37"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -8,7 +8,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/8ce85b631ba69bc4673a25c587503054ba55bd7022091bbf6260a76e56a4d017/kernel-6.1.170-210.320.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/95e0d820e4b079b39606fcb77a0fd773c893c6a2b0a3c92bb4246c2db7b65762/kernel-6.1.170-213.321.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.24-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/2ee4c390ec122cf4eb359262d0e8d4f371f8eeabb67951f52c88c668c9cffc1f/kernel6.12-6.12.83-113.160.amzn2023.src.rpm"
-sha512 = "a165a6236dae310457382faa056904811e7fc6195adbe80f969452c1208fad5d0db19ef52c86e5f061b2b3e45d4ae6b73ce699efe5728cb2194b94b328c65c10"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/dbfbb0061d3c8533536dd5c9d6545ed26f5b3a5fadedd19216cf1c60dadfb236/kernel6.12-6.12.83-115.161.amzn2023.src.rpm"
+sha512 = "378f773282706f91ee8410c7c0828c22f22d1371d41ab8f109e75632ed6dcc9248c891cb7aade044fe1a7686c67fda3c2c387fe99f2ebabf1116faec93654bf3"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -10,7 +10,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/2ee4c390ec122cf4eb359262d0e8d4f371f8eeabb67951f52c88c668c9cffc1f/kernel6.12-6.12.83-113.160.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/dbfbb0061d3c8533536dd5c9d6545ed26f5b3a5fadedd19216cf1c60dadfb236/kernel6.12-6.12.83-115.161.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.24-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm

--- a/packages/kernel-6.18/Cargo.toml
+++ b/packages/kernel-6.18/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/4e330748d7ddde678d5cf13b7c32a6b3c744e87564a5257713500cc41e9d7b6c/kernel6.18-6.18.25-55.108.amzn2023.src.rpm"
-sha512 = "2aaa833eee2b077881be1c159d4d56f3b0318724a6ba20e518b37fe229e3d204dc0aca0d1ddf044abbd3eb29091e239388f8ba1ecbb091df8ba653d2f6369186"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/272f520461eeb7b66e4240303b425b5d653778f2df6389403f0273ab5e8defc6/kernel6.18-6.18.25-57.109.amzn2023.src.rpm"
+sha512 = "83e453b2a0b3e0b035304d22915e361fcb2c6350a0a3f493f62952439c92951eebc4ab511c20ff0d118375865870e1612bbda4f642208cd7c979f4761b11057a"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -12,7 +12,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/4e330748d7ddde678d5cf13b7c32a6b3c744e87564a5257713500cc41e9d7b6c/kernel6.18-6.18.25-55.108.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/272f520461eeb7b66e4240303b425b5d653778f2df6389403f0273ab5e8defc6/kernel6.18-6.18.25-57.109.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.24-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm


### PR DESCRIPTION
**Description of changes**

- Update 6.1 kernel from kernel-6.1.168-203.330 to kernel-6.1.170-213.321
- Update 6.12 kernel from 6.12.83-113.160 to 6.12.83-115.161
- Update 6.18 kernel from 6.18.25-55.108 to 6.18.25-57.109

**Testing done**

- See GH actions

<details><summary>Kernel Patch Delta Report</summary>

## Summary

All three kernel updates introduce **one new patch** each. No patches were removed or modified.

The new patch across all kernels:
> `net-skbuff-propagate-shared-frag-marker-through-frag.patch`

## Results

### kernel-6.18 (6.18.25-55.108 → 6.18.25-57.109)

| Category | Count | Details |
|----------|-------|---------|
| Added | 1 | `0108-net-skbuff-propagate-shared-frag-marker-through-frag.patch` |
| Removed | 0 | — |
| Modified | 0 | — |
| Unchanged | 107 | — |

### kernel-6.12 (6.12.83-113.160 → 6.12.83-115.161)

| Category | Count | Details |
|----------|-------|---------|
| Added | 1 | `0160-net-skbuff-propagate-shared-frag-marker-through-frag.patch` |
| Removed | 0 | — |
| Modified | 0 | — |
| Unchanged | 159 | — |

### kernel-6.1 (6.1.170-210.320 → 6.1.170-213.321)

| Category | Count | Details |
|----------|-------|---------|
| Added | 1 | `0320-net-skbuff-propagate-shared-frag-marker-through-frag.patch` |
| Removed | 0 | — |
| Modified | 0 | — |
| Unchanged | 319 | — |

</details>