### PR TITLE
Provide 2.x.8586.0 and 2.x.8732.0 Neuron kernel modules

### DIFF
--- a/packages/kmod-6.1-neuron/kmod-6.1-neuron.spec
+++ b/packages/kmod-6.1-neuron/kmod-6.1-neuron.spec
@@ -2,17 +2,18 @@
 %global kernel_sources %{_builddir}/kernel-devel
 %global _cross_kmoddir %{_cross_libdir}/modules/%{kmajor}
 %global neuron_ver 2.26.10
+%global neuron_inf1_ver 2.24.13
 
 Name: %{_cross_os}kmod-6.1-neuron
 Version: %{neuron_ver}
 Release: 1%{?dist}
 Epoch: 1
-Summary: Modules for the Linux kernel with Neuron hardware
+Summary: Neuron drivers for the 6.1 kernel
 License: Apache-2.0 OR MIT
 URL: https://aws.amazon.com/ai/machine-learning/neuron/
 
 # Use latest-2.24-neuron-srpm-url.sh to get this.
-Source1: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
+Source1: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_inf1_ver}.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_ver}.0.noarch.rpm
 Source3: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
@@ -36,7 +37,7 @@ Conflicts: %{_cross_os}variant-flavor(nvidia-fips)
 %{summary}.
 
 %package latest
-Summary: Modules for the Linux kernel with Neuron hardware
+Summary: Neuron %{version} driver
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 
@@ -44,8 +45,8 @@ Requires: %{name}
 %{summary}.
 
 %package inf1
-Version: 2.24.13
-Summary: Modules for the Linux kernel with Neuron hardware (inf1)
+Version: %{neuron_inf1_ver}
+Summary: Neuron %{neuron_inf1_ver} driver
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 

--- a/packages/kmod-6.12-neuron/kmod-6.12-neuron.spec
+++ b/packages/kmod-6.12-neuron/kmod-6.12-neuron.spec
@@ -3,17 +3,18 @@
 %global _cross_kmoddir %{_cross_libdir}/modules/%{kmajor}
 %global _ko ko
 %global neuron_ver 2.26.10
+%global neuron_inf1_ver 2.24.13
 
 Name: %{_cross_os}kmod-6.12-neuron
 Version: %{neuron_ver}
 Release: 1%{?dist}
 Epoch: 1
-Summary: Modules for the Linux kernel with Neuron hardware
+Summary: Neuron drivers for the 6.12 kernel
 License: Apache-2.0 OR MIT
 URL: https://aws.amazon.com/ai/machine-learning/neuron/
 
 # Use latest-2.24-neuron-srpm-url.sh to get this.
-Source1: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
+Source1: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_inf1_ver}.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_ver}.0.noarch.rpm
 # Neuron driver 2.x.7372.0
@@ -43,7 +44,7 @@ Conflicts: %{_cross_os}variant-flavor(nvidia-fips)
 %{summary}.
 
 %package latest
-Summary: Modules for the Linux kernel with Neuron hardware
+Summary: Neuron %{version} driver
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 
@@ -51,8 +52,8 @@ Requires: %{name}
 %{summary}.
 
 %package inf1
-Version: 2.24.13
-Summary: Modules for the Linux kernel with Neuron hardware (inf1)
+Version: %{neuron_inf1_ver}
+Summary: Neuron %{neuron_inf1_ver} driver
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 
@@ -60,7 +61,7 @@ Requires: %{name}
 %{summary}.
 
 %package extras
-Summary: Extra Neuron driver modules for the Linux kernel
+Summary: Extra Neuron drivers
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 

--- a/packages/kmod-6.18-neuron/Cargo.toml
+++ b/packages/kmod-6.18-neuron/Cargo.toml
@@ -41,5 +41,15 @@ sha512 = "d96bd0fe73482684c97faae6f779bfa8a84e9b9ca09f796031d409322550fb1744a38e
 url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8689.0.noarch.rpm/5d3ce7f81858d5aae62279369bce72e041dd321f71146a4ab8e61f9230f3965323f9c9230547476614f1c334b84c59edbd892524e2a87c35b46960a044502e9f/aws-neuronx-dkms-2.x.8689.0.noarch.rpm"
 sha512 = "5d3ce7f81858d5aae62279369bce72e041dd321f71146a4ab8e61f9230f3965323f9c9230547476614f1c334b84c59edbd892524e2a87c35b46960a044502e9f"
 
+[[package.metadata.build-package.external-files]]
+# Neuron driver 2.x.8586.0
+url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8586.0.noarch.rpm/0c5bf7f6ffd9d1ef3585aad48c8bb9a1f3f242e32af63755c3f914d9d000dc1f999b53ea90718dfbbfb8c3318ac80c0c90fc68a4962ea25ce4948183d62eb732/aws-neuronx-dkms-2.x.8586.0.noarch.rpm"
+sha512 = "0c5bf7f6ffd9d1ef3585aad48c8bb9a1f3f242e32af63755c3f914d9d000dc1f999b53ea90718dfbbfb8c3318ac80c0c90fc68a4962ea25ce4948183d62eb732"
+
+[[package.metadata.build-package.external-files]]
+# Neuron driver 2.x.8732.0
+url = "https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8732.0.noarch.rpm/089caa0289ff37219583a2fcb7f947520da0c130595ff2a5917a04eed3d6272064332deb48a4b401fa0385b5450cc5fc3195991ca59b42a321d5706641f435e5/aws-neuronx-dkms-2.x.8732.0.noarch.rpm"
+sha512 = "089caa0289ff37219583a2fcb7f947520da0c130595ff2a5917a04eed3d6272064332deb48a4b401fa0385b5450cc5fc3195991ca59b42a321d5706641f435e5"
+
 [build-dependencies]
 kernel-6_18 = { path = "../kernel-6.18" }

--- a/packages/kmod-6.18-neuron/kmod-6.18-neuron.spec
+++ b/packages/kmod-6.18-neuron/kmod-6.18-neuron.spec
@@ -24,7 +24,11 @@ Source4: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.7693.0.noarch.rpm/4
 Source5: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8072.0.noarch.rpm/d96bd0fe73482684c97faae6f779bfa8a84e9b9ca09f796031d409322550fb1744a38e6c54f5fcc8c1221f051cf04f518694876ea825722f5ed7895c2e8bb22a/aws-neuronx-dkms-2.x.8072.0.noarch.rpm
 # Neuron driver 2.x.8689.0
 Source6: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8689.0.noarch.rpm/5d3ce7f81858d5aae62279369bce72e041dd321f71146a4ab8e61f9230f3965323f9c9230547476614f1c334b84c59edbd892524e2a87c35b46960a044502e9f/aws-neuronx-dkms-2.x.8689.0.noarch.rpm
-Source7: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
+# Neuron driver 2.x.8586.0
+Source7: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8586.0.noarch.rpm/0c5bf7f6ffd9d1ef3585aad48c8bb9a1f3f242e32af63755c3f914d9d000dc1f999b53ea90718dfbbfb8c3318ac80c0c90fc68a4962ea25ce4948183d62eb732/aws-neuronx-dkms-2.x.8586.0.noarch.rpm
+# Neuron driver 2.x.8732.0
+Source8: https://cache.bottlerocket.aws/aws-neuronx-dkms-2.x.8732.0.noarch.rpm/089caa0289ff37219583a2fcb7f947520da0c130595ff2a5917a04eed3d6272064332deb48a4b401fa0385b5450cc5fc3195991ca59b42a321d5706641f435e5/aws-neuronx-dkms-2.x.8732.0.noarch.rpm
+Source9: gpgkey-00FA2C1079260870A76D2C285749CAD8646D9185.asc
 
 # Neuron-related configuration and unit files
 Source220: neuron-tmpfiles.conf
@@ -73,13 +77,15 @@ Requires: %{name}
 %{summary}.
 
 %prep
-rpmkeys --import %{S:7} --dbpath "${PWD}/rpmdb"
+rpmkeys --import %{S:9} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:1} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:3} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:4} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:5} --dbpath "${PWD}/rpmdb"
 rpmkeys --checksig %{S:6} --dbpath "${PWD}/rpmdb"
+rpmkeys --checksig %{S:7} --dbpath "${PWD}/rpmdb"
+rpmkeys --checksig %{S:8} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 
 rpm2cpio %{S:1} | cpio -idmu './usr/src/aws-neuronx-*'
@@ -119,6 +125,16 @@ rpm2cpio %{S:6} | cpio -idmu './usr/src/aws-neuronx-*'
 find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_8689 \;
 rm -r usr
 
+# 2.x.8586.0 neuron driver
+rpm2cpio %{S:7} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_8586 \;
+rm -r usr
+
+# 2.x.8732.0 neuron driver
+rpm2cpio %{S:8} | cpio -idmu './usr/src/aws-neuronx-*'
+find usr/src/ -mindepth 1 -maxdepth 1 -type d -exec mv {} neuron_2x_8732 \;
+rm -r usr
+
 %global kmake %{shrink: \
 make -s \
   ARCH="%{_cross_karch}" \
@@ -135,6 +151,8 @@ make -s \
 %kmake -C %{kernel_sources} %{?_smp_mflags} M=%{_builddir}/neuron_2x_7693
 %kmake -C %{kernel_sources} %{?_smp_mflags} M=%{_builddir}/neuron_2x_8072
 %kmake -C %{kernel_sources} %{?_smp_mflags} M=%{_builddir}/neuron_2x_8689
+%kmake -C %{kernel_sources} %{?_smp_mflags} M=%{_builddir}/neuron_2x_8586
+%kmake -C %{kernel_sources} %{?_smp_mflags} M=%{_builddir}/neuron_2x_8732
 
 %install
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
@@ -143,18 +161,24 @@ install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7372/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7693/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8072/
 install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8689/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8586/
+install -d %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8732/
 %kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2_24 M=%{_builddir}/neuron_2_24 modules_install
 %kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_latest M=%{_builddir}/neuron_latest modules_install
 %kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2x_7372 M=%{_builddir}/neuron_2x_7372 modules_install
 %kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2x_7693 M=%{_builddir}/neuron_2x_7693 modules_install
 %kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2x_8072 M=%{_builddir}/neuron_2x_8072 modules_install
 %kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2x_8689 M=%{_builddir}/neuron_2x_8689 modules_install
+%kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2x_8586 M=%{_builddir}/neuron_2x_8586 modules_install
+%kmake -C %{kernel_sources} %{?_smp_mflags} KERNELRELEASE=%{kmajor} DEPMOD=true INSTALL_MOD_DIR=neuron_2x_8732 M=%{_builddir}/neuron_2x_8732 modules_install
 mv %{buildroot}%{_cross_kmoddir}/neuron_2_24/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2_24/
 mv %{buildroot}%{_cross_kmoddir}/neuron_latest/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_latest/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2x_7372/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7372/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2x_7693/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_7693/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2x_8072/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8072/
 mv %{buildroot}%{_cross_kmoddir}/neuron_2x_8689/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8689/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2x_8586/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8586/
+mv %{buildroot}%{_cross_kmoddir}/neuron_2x_8732/neuron.%{_ko} %{buildroot}%{_cross_libexecdir}/neuron/neuron_2x_8732/
 
 # Add Neuron-related configuration files to load the module when the hardware is present.
 install -d 0644 %{buildroot}%{_cross_tmpfilesdir}
@@ -192,6 +216,8 @@ install -p -m 0644 %{S:222} %{S:224} %{buildroot}%{_cross_unitdir}
 %{_cross_libexecdir}/neuron/neuron_2x_7372/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_2x_7693/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_2x_8072/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2x_8586/neuron.%{_ko}
 %{_cross_libexecdir}/neuron/neuron_2x_8689/neuron.%{_ko}
+%{_cross_libexecdir}/neuron/neuron_2x_8732/neuron.%{_ko}
 
 %changelog

--- a/packages/kmod-6.18-neuron/kmod-6.18-neuron.spec
+++ b/packages/kmod-6.18-neuron/kmod-6.18-neuron.spec
@@ -3,17 +3,18 @@
 %global _cross_kmoddir %{_cross_libdir}/modules/%{kmajor}
 %global _ko ko
 %global neuron_ver 2.26.10
+%global neuron_inf1_ver 2.24.13
 
 Name: %{_cross_os}kmod-6.18-neuron
 Version: %{neuron_ver}
 Release: 1%{?dist}
 Epoch: 1
-Summary: Modules for the Linux kernel with Neuron hardware
+Summary: Neuron drivers for the 6.18 kernel
 License: Apache-2.0 OR MIT
 URL: https://aws.amazon.com/ai/machine-learning/neuron/
 
 # Use latest-2.24-neuron-srpm-url.sh to get this.
-Source1: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-2.24.13.0.noarch.rpm
+Source1: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_inf1_ver}.0.noarch.rpm
 # Use latest-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_ver}.0.noarch.rpm
 # Neuron driver 2.x.7372.0
@@ -52,7 +53,7 @@ Conflicts: %{_cross_os}variant-flavor(nvidia-fips)
 %{summary}.
 
 %package latest
-Summary: Modules for the Linux kernel with Neuron hardware
+Summary: Neuron %{version} driver
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 
@@ -60,8 +61,8 @@ Requires: %{name}
 %{summary}.
 
 %package inf1
-Version: 2.24.13
-Summary: Modules for the Linux kernel with Neuron hardware (inf1)
+Version: %{neuron_inf1_ver}
+Summary: Neuron %{neuron_inf1_ver} driver
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 
@@ -69,7 +70,7 @@ Requires: %{name}
 %{summary}.
 
 %package extras
-Summary: Extra Neuron driver modules for the Linux kernel
+Summary: Extra Neuron drivers
 License: MIT AND GPL-2.0-only AND (GPL-2.0-only OR BSD-2-Clause) AND (GPL-2.0 OR Linux-OpenIB) AND (((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause))
 Requires: %{name}
 


### PR DESCRIPTION
**Description of changes:**
Provide 2.x.8586.0 and 2.x.8732.0 Neuron kernel modules. Additionally, update summaries of kernel modules since they were a bit inconsistent with other kernel modules


**Testing done:**
Launched a inf2 instance, confirmed devices are visible and advertised with the new kernel modules:

<details>

```bash
bash-5.2# rmmod neuron
bash-5.2# insmod /usr/libexec/neuron/neuron_2x_8732/neuron.ko
```

```bash
bash-5.2# /opt/aws/neuron/bin/neuron-ls
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON |   PCI   |
| DEVICE | CORES  | MEMORY |   BDF   |
+--------+--------+--------+---------+
| 0      | 2      | 32 GB  | 00:1f.0 |
+--------+--------+--------+---------+
bash-5.2#
```

```bash
bash-5.2# rmmod neuron
bash-5.2# insmod /usr/libexec/neuron/neuron_2x_8586/neuron.ko
```

I had to re-create the device plugin pod to make sure it used the new driver, then I confirmed it worked:


```bash
bash-5.2# /opt/aws/neuron/bin/neuron-ls
+--------+--------+--------+---------+
| NEURON | NEURON | NEURON |   PCI   |
| DEVICE | CORES  | MEMORY |   BDF   |
+--------+--------+--------+---------+
| 0      | 2      | 32 GB  | 00:1f.0 |
+--------+--------+--------+---------+
bash-5.2#
```

</details>


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
