### PR TITLE
Default to v4 package verification for neuron kmods and Bump SDK version

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.74.0"
+version = "0.75.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.74.0"
-digest = "JkyAeKTcFAbrjNJKA9yuKbZcAP8kgv9phwX5jkFbFhk="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.75.0"
+digest = "7l4qkyh/nqq6Z+tq/4Bwh2EPba8BfsKfVlnnNwclWzM="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.74.0"
+version = "0.75.0"
 vendor = "bottlerocket"

--- a/packages/kmod-6.1-neuron/kmod-6.1-neuron.spec
+++ b/packages/kmod-6.1-neuron/kmod-6.1-neuron.spec
@@ -57,8 +57,8 @@ Requires: %{name}
 tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 
 rpmkeys --import %{S:3} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:1} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:1} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:2} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 
 rpm2cpio %{S:1} | cpio -idmu './usr/src/aws-neuronx-*'

--- a/packages/kmod-6.12-neuron/kmod-6.12-neuron.spec
+++ b/packages/kmod-6.12-neuron/kmod-6.12-neuron.spec
@@ -70,11 +70,11 @@ Requires: %{name}
 
 %prep
 rpmkeys --import %{S:6} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:1} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:3} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:4} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:5} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:1} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:2} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:3} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:4} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:5} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 
 rpm2cpio %{S:1} | cpio -idmu './usr/src/aws-neuronx-*'

--- a/packages/kmod-6.18-neuron/kmod-6.18-neuron.spec
+++ b/packages/kmod-6.18-neuron/kmod-6.18-neuron.spec
@@ -79,14 +79,14 @@ Requires: %{name}
 
 %prep
 rpmkeys --import %{S:9} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:1} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:2} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:3} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:4} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:5} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:6} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:7} --dbpath "${PWD}/rpmdb"
-rpmkeys --checksig %{S:8} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:1} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:2} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:3} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:4} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:5} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:6} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:7} --dbpath "${PWD}/rpmdb"
+rpmkeys --define "_pkgverify_flags 0x0" --checksig %{S:8} --dbpath "${PWD}/rpmdb"
 rm -rf "${PWD}/rpmdb"
 
 rpm2cpio %{S:1} | cpio -idmu './usr/src/aws-neuronx-*'


### PR DESCRIPTION
**Description of changes:**
- Default to v4 package verification for Neuron kmods


**Testing done:**
- AMIs build for x86_64 and aarch64


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
