### PR TITLE
Add gdrcopy subpackage to NVIDIA kmods

### DIFF
--- a/packages/kmod-6.1-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r580/Cargo.toml
@@ -50,5 +50,9 @@ url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.159.
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/gdrcopy/archive/v2.6/gdrcopy-2.6.tar.gz"
+sha512 = "3653881de4380ecf85d26a93d9e4ce66679001c9901189707fb13cb98f2ff841eb6d67b63784d1e048db7f7c1975052f22fea0f7813233d96fded2bd39031342"
+
 [build-dependencies]
 kernel-6_1 = { path = "../kernel-6.1" }

--- a/packages/kmod-6.1-nvidia-r580/copy-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.1-nvidia-r580/copy-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Copy GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
+++ b/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
@@ -3,6 +3,7 @@
 %global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global grid_ver grid-19.5
+%global gdrcopy_ver 2.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -73,6 +74,14 @@ Source503: load-open-gpu-kernel-modules.service.in
 Source504: copy-grid-kernel-modules.service.in
 Source505: load-grid-kernel-modules.service.in
 
+Source600: nvidia-gdrcopy-open-gpu-config.toml.in
+Source601: copy-gdrcopy-open-gpu-kernel-module.service.in
+Source602: load-gdrcopy-open-gpu-kernel-module.service.in
+Source603: nvidia-gdrcopy-tmpfiles.conf
+
+# GDRcopy
+Source700: https://github.com/NVIDIA/gdrcopy/archive/v%{gdrcopy_ver}/gdrcopy-%{gdrcopy_ver}.tar.gz
+
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.1-archive
@@ -136,6 +145,16 @@ Summary: NVIDIA CUDA Multi-Process Service
 Requires: %{name}
 
 %description mps
+%{summary}.
+
+%package gdrcopy
+Summary: NVIDIA GDRCopy driver
+Version: %{gdrcopy_ver}
+License: MIT AND GPL-2.0-only
+Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
+
+%description gdrcopy
 %{summary}.
 
 %prep
@@ -242,6 +261,24 @@ and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
+popd
+
+tar -xof %{S:700}
+pushd gdrcopy-%{gdrcopy_ver}/src/gdrdrv
+NVIDIA_SRC_DIR="%{_builddir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open/nvidia" \
+NVIDIA_IS_OPENSOURCE=y \
+HAVE_VM_FLAGS_SET=n \
+HAVE_PROC_OPS=y \
+make %{?_smp_mflags} \
+  -C %{kernel_sources} \
+  M="$PWD" \
+  ARCH=%{_cross_karch} \
+  CC=%{_cross_target}-gcc \
+  LD=%{_cross_target}-ld \
+  modules
+
+%{_cross_target}-strip -g --strip-unneeded gdrdrv.ko
+mv gdrdrv.ko ../../gdrdrv-open-gpu.ko
 popd
 
 %install
@@ -472,6 +509,26 @@ for t in usr/share/nvidia/nvswitch/*_topology ; do
 done
 
 popd
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/gdrdrv-open-gpu.ko \
+  %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/LICENSE gdrcopy-LICENSE
+
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/|' %{S:600} > \
+  nvidia-gdrcopy-open-gpu.toml
+install -m 0644 nvidia-gdrcopy-open-gpu.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:601} > copy-gdrcopy-open-gpu-kernel-module.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:602} > load-gdrcopy-open-gpu-kernel-module.service
+install -p -m 0644 \
+  copy-gdrcopy-open-gpu-kernel-module.service \
+  load-gdrcopy-open-gpu-kernel-module.service \
+  %{buildroot}%{_cross_unitdir}
+
+install -p -m 0644 %{S:603} %{buildroot}%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
 
 %files
 %{_cross_attribution_file}
@@ -758,3 +815,14 @@ popd
 %{_cross_bindir}/nvidia-cuda-mps-server
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
+
+%files gdrcopy
+%license gdrcopy-LICENSE
+%dir %{_cross_datadir}/nvidia/gdrcopy
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-gdrcopy-open-gpu.toml
+%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
+%{_cross_unitdir}/copy-gdrcopy-open-gpu-kernel-module.service
+%{_cross_unitdir}/load-gdrcopy-open-gpu-kernel-module.service

--- a/packages/kmod-6.1-nvidia-r580/load-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.1-nvidia-r580/load-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+After=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+Requires=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu load-modules
+ExecStart=/usr/bin/ghostdog create-device gdrdrv 0 --path /dev/gdrdrv
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r580/nvidia-gdrcopy-open-gpu-config.toml.in
+++ b/packages/kmod-6.1-nvidia-r580/nvidia-gdrcopy-open-gpu-config.toml.in
@@ -1,0 +1,5 @@
+[nvidia-gdrcopy-open-gpu]
+lib-modules-path = "kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu"
+
+[nvidia-gdrcopy-open-gpu.kernel-modules."gdrdrv.ko"]
+copy-source = "__NVIDIA_MODULES__"

--- a/packages/kmod-6.1-nvidia-r580/nvidia-gdrcopy-tmpfiles.conf
+++ b/packages/kmod-6.1-nvidia-r580/nvidia-gdrcopy-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/drivers/nvidia-gdrcopy-open-gpu.toml

--- a/packages/kmod-6.1-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.1-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -4,6 +4,10 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/tesla 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -

--- a/packages/kmod-6.1-nvidia-r595/Cargo.toml
+++ b/packages/kmod-6.1-nvidia-r595/Cargo.toml
@@ -50,5 +50,9 @@ url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/595.71.0
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/gdrcopy/archive/v2.6/gdrcopy-2.6.tar.gz"
+sha512 = "3653881de4380ecf85d26a93d9e4ce66679001c9901189707fb13cb98f2ff841eb6d67b63784d1e048db7f7c1975052f22fea0f7813233d96fded2bd39031342"
+
 [build-dependencies]
 kernel-6_1 = { path = "../kernel-6.1" }

--- a/packages/kmod-6.1-nvidia-r595/copy-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.1-nvidia-r595/copy-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Copy GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r595/kmod-6.1-nvidia-r595.spec
+++ b/packages/kmod-6.1-nvidia-r595/kmod-6.1-nvidia-r595.spec
@@ -3,6 +3,7 @@
 %global tesla_patch 05
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global grid_ver grid-20.1
+%global gdrcopy_ver 2.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -73,6 +74,14 @@ Source503: load-open-gpu-kernel-modules.service.in
 Source504: copy-grid-kernel-modules.service.in
 Source505: load-grid-kernel-modules.service.in
 
+Source600: nvidia-gdrcopy-open-gpu-config.toml.in
+Source601: copy-gdrcopy-open-gpu-kernel-module.service.in
+Source602: load-gdrcopy-open-gpu-kernel-module.service.in
+Source603: nvidia-gdrcopy-tmpfiles.conf
+
+# GDRcopy
+Source700: https://github.com/NVIDIA/gdrcopy/archive/v%{gdrcopy_ver}/gdrcopy-%{gdrcopy_ver}.tar.gz
+
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.1-archive
@@ -136,6 +145,16 @@ Summary: NVIDIA CUDA Multi-Process Service
 Requires: %{name}
 
 %description mps
+%{summary}.
+
+%package gdrcopy
+Summary: NVIDIA GDRCopy driver
+Version: %{gdrcopy_ver}
+License: MIT AND GPL-2.0-only
+Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
+
+%description gdrcopy
 %{summary}.
 
 %prep
@@ -242,6 +261,24 @@ and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
+popd
+
+tar -xof %{S:700}
+pushd gdrcopy-%{gdrcopy_ver}/src/gdrdrv
+NVIDIA_SRC_DIR="%{_builddir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open/nvidia" \
+NVIDIA_IS_OPENSOURCE=y \
+HAVE_VM_FLAGS_SET=n \
+HAVE_PROC_OPS=y \
+make %{?_smp_mflags} \
+  -C %{kernel_sources} \
+  M="$PWD" \
+  ARCH=%{_cross_karch} \
+  CC=%{_cross_target}-gcc \
+  LD=%{_cross_target}-ld \
+  modules
+
+%{_cross_target}-strip -g --strip-unneeded gdrdrv.ko
+mv gdrdrv.ko ../../gdrdrv-open-gpu.ko
 popd
 
 %install
@@ -471,6 +508,26 @@ for t in usr/share/nvidia/nvswitch/*_topology ; do
 done
 
 popd
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/gdrdrv-open-gpu.ko \
+  %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/LICENSE gdrcopy-LICENSE
+
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/|' %{S:600} > \
+  nvidia-gdrcopy-open-gpu.toml
+install -m 0644 nvidia-gdrcopy-open-gpu.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:601} > copy-gdrcopy-open-gpu-kernel-module.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:602} > load-gdrcopy-open-gpu-kernel-module.service
+install -p -m 0644 \
+  copy-gdrcopy-open-gpu-kernel-module.service \
+  load-gdrcopy-open-gpu-kernel-module.service \
+  %{buildroot}%{_cross_unitdir}
+
+install -p -m 0644 %{S:603} %{buildroot}%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
 
 %files
 %{_cross_attribution_file}
@@ -760,3 +817,15 @@ popd
 %{_cross_bindir}/nvidia-cuda-mps-server
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
+
+
+%files gdrcopy
+%license gdrcopy-LICENSE
+%dir %{_cross_datadir}/nvidia/gdrcopy
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-gdrcopy-open-gpu.toml
+%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
+%{_cross_unitdir}/copy-gdrcopy-open-gpu-kernel-module.service
+%{_cross_unitdir}/load-gdrcopy-open-gpu-kernel-module.service

--- a/packages/kmod-6.1-nvidia-r595/load-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.1-nvidia-r595/load-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+After=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+Requires=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu load-modules
+ExecStart=/usr/bin/ghostdog create-device gdrdrv 0 --path /dev/gdrdrv
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.1-nvidia-r595/nvidia-gdrcopy-open-gpu-config.toml.in
+++ b/packages/kmod-6.1-nvidia-r595/nvidia-gdrcopy-open-gpu-config.toml.in
@@ -1,0 +1,5 @@
+[nvidia-gdrcopy-open-gpu]
+lib-modules-path = "kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu"
+
+[nvidia-gdrcopy-open-gpu.kernel-modules."gdrdrv.ko"]
+copy-source = "__NVIDIA_MODULES__"

--- a/packages/kmod-6.1-nvidia-r595/nvidia-gdrcopy-tmpfiles.conf
+++ b/packages/kmod-6.1-nvidia-r595/nvidia-gdrcopy-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/drivers/nvidia-gdrcopy-open-gpu.toml

--- a/packages/kmod-6.1-nvidia-r595/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.1-nvidia-r595/nvidia-tmpfiles.conf.in
@@ -4,6 +4,10 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/tesla 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -

--- a/packages/kmod-6.12-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r580/Cargo.toml
@@ -60,5 +60,9 @@ url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.159.
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/gdrcopy/archive/v2.6/gdrcopy-2.6.tar.gz"
+sha512 = "3653881de4380ecf85d26a93d9e4ce66679001c9901189707fb13cb98f2ff841eb6d67b63784d1e048db7f7c1975052f22fea0f7813233d96fded2bd39031342"
+
 [build-dependencies]
 kernel-6_12 = { path = "../kernel-6.12" }

--- a/packages/kmod-6.12-nvidia-r580/copy-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.12-nvidia-r580/copy-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Copy GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -3,6 +3,7 @@
 %global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global grid_ver grid-19.5
+%global gdrcopy_ver 2.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -84,6 +85,14 @@ Source503: load-open-gpu-kernel-modules.service.in
 Source504: copy-grid-kernel-modules.service.in
 Source505: load-grid-kernel-modules.service.in
 
+Source600: nvidia-gdrcopy-open-gpu-config.toml.in
+Source601: copy-gdrcopy-open-gpu-kernel-module.service.in
+Source602: load-gdrcopy-open-gpu-kernel-module.service.in
+Source603: nvidia-gdrcopy-tmpfiles.conf
+
+# GDRcopy
+Source700: https://github.com/NVIDIA/gdrcopy/archive/v%{gdrcopy_ver}/gdrcopy-%{gdrcopy_ver}.tar.gz
+
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.12-devel
@@ -162,6 +171,16 @@ Summary: NVIDIA CUDA Multi-Process Service
 Requires: %{name}
 
 %description mps
+%{summary}.
+
+%package gdrcopy
+Summary: NVIDIA GDRCopy driver
+Version: %{gdrcopy_ver}
+License: MIT AND GPL-2.0-only
+Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
+
+%description gdrcopy
 %{summary}.
 
 %prep
@@ -270,6 +289,24 @@ and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
+popd
+
+tar -xof %{S:700}
+pushd gdrcopy-%{gdrcopy_ver}/src/gdrdrv
+NVIDIA_SRC_DIR="%{_builddir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open/nvidia" \
+NVIDIA_IS_OPENSOURCE=y \
+HAVE_VM_FLAGS_SET=y \
+HAVE_PROC_OPS=y \
+make %{?_smp_mflags} \
+  -C %{kernel_sources} \
+  M="$PWD" \
+  ARCH=%{_cross_karch} \
+  CC=%{_cross_target}-gcc \
+  LD=%{_cross_target}-ld \
+  modules
+
+%{_cross_target}-strip -g --strip-unneeded gdrdrv.ko
+mv gdrdrv.ko ../../gdrdrv-open-gpu.ko
 popd
 
 %install
@@ -519,6 +556,26 @@ install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
 # NVIDIA IMEX modprobe config
 install -d %{buildroot}%{_cross_libdir}/modprobe.d
 install -p -m 0644 %{S:218} %{buildroot}%{_cross_libdir}/modprobe.d/10-nvidia-default-imex-channel.conf
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/gdrdrv-open-gpu.ko \
+  %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/LICENSE gdrcopy-LICENSE
+
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/|' %{S:600} > \
+  nvidia-gdrcopy-open-gpu.toml
+install -m 0644 nvidia-gdrcopy-open-gpu.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:601} > copy-gdrcopy-open-gpu-kernel-module.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:602} > load-gdrcopy-open-gpu-kernel-module.service
+install -p -m 0644 \
+  copy-gdrcopy-open-gpu-kernel-module.service \
+  load-gdrcopy-open-gpu-kernel-module.service \
+  %{buildroot}%{_cross_unitdir}
+
+install -p -m 0644 %{S:603} %{buildroot}%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
 
 %files
 %{_cross_attribution_file}
@@ -815,3 +872,14 @@ install -p -m 0644 %{S:218} %{buildroot}%{_cross_libdir}/modprobe.d/10-nvidia-de
 %{_cross_bindir}/nvidia-cuda-mps-server
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
+
+%files gdrcopy
+%license gdrcopy-LICENSE
+%dir %{_cross_datadir}/nvidia/gdrcopy
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-gdrcopy-open-gpu.toml
+%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
+%{_cross_unitdir}/copy-gdrcopy-open-gpu-kernel-module.service
+%{_cross_unitdir}/load-gdrcopy-open-gpu-kernel-module.service

--- a/packages/kmod-6.12-nvidia-r580/load-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.12-nvidia-r580/load-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+After=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+Requires=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu load-modules
+ExecStart=/usr/bin/ghostdog create-device gdrdrv 0 --path /dev/gdrdrv
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r580/nvidia-gdrcopy-open-gpu-config.toml.in
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-gdrcopy-open-gpu-config.toml.in
@@ -1,0 +1,5 @@
+[nvidia-gdrcopy-open-gpu]
+lib-modules-path = "kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu"
+
+[nvidia-gdrcopy-open-gpu.kernel-modules."gdrdrv.ko"]
+copy-source = "__NVIDIA_MODULES__"

--- a/packages/kmod-6.12-nvidia-r580/nvidia-gdrcopy-tmpfiles.conf
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-gdrcopy-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/drivers/nvidia-gdrcopy-open-gpu.toml

--- a/packages/kmod-6.12-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.12-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -4,6 +4,10 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/tesla 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -

--- a/packages/kmod-6.12-nvidia-r595/Cargo.toml
+++ b/packages/kmod-6.12-nvidia-r595/Cargo.toml
@@ -60,5 +60,9 @@ url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/595.71.0
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/gdrcopy/archive/v2.6/gdrcopy-2.6.tar.gz"
+sha512 = "3653881de4380ecf85d26a93d9e4ce66679001c9901189707fb13cb98f2ff841eb6d67b63784d1e048db7f7c1975052f22fea0f7813233d96fded2bd39031342"
+
 [build-dependencies]
 kernel-6_12 = { path = "../kernel-6.12" }

--- a/packages/kmod-6.12-nvidia-r595/copy-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.12-nvidia-r595/copy-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Copy GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r595/kmod-6.12-nvidia-r595.spec
+++ b/packages/kmod-6.12-nvidia-r595/kmod-6.12-nvidia-r595.spec
@@ -3,6 +3,7 @@
 %global tesla_patch 05
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global grid_ver grid-20.1
+%global gdrcopy_ver 2.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -80,6 +81,14 @@ Source503: load-open-gpu-kernel-modules.service.in
 Source504: copy-grid-kernel-modules.service.in
 Source505: load-grid-kernel-modules.service.in
 
+Source600: nvidia-gdrcopy-open-gpu-config.toml.in
+Source601: copy-gdrcopy-open-gpu-kernel-module.service.in
+Source602: load-gdrcopy-open-gpu-kernel-module.service.in
+Source603: nvidia-gdrcopy-tmpfiles.conf
+
+# GDRcopy
+Source700: https://github.com/NVIDIA/gdrcopy/archive/v%{gdrcopy_ver}/gdrcopy-%{gdrcopy_ver}.tar.gz
+
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.12-devel
@@ -151,6 +160,16 @@ Summary: NVIDIA CUDA Multi-Process Service
 Requires: %{name}
 
 %description mps
+%{summary}.
+
+%package gdrcopy
+Summary: NVIDIA GDRCopy driver
+Version: %{gdrcopy_ver}
+License: MIT AND GPL-2.0-only
+Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
+
+%description gdrcopy
 %{summary}.
 
 %prep
@@ -259,6 +278,24 @@ and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
+popd
+
+tar -xof %{S:700}
+pushd gdrcopy-%{gdrcopy_ver}/src/gdrdrv
+NVIDIA_SRC_DIR="%{_builddir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open/nvidia" \
+NVIDIA_IS_OPENSOURCE=y \
+HAVE_VM_FLAGS_SET=y \
+HAVE_PROC_OPS=y \
+make %{?_smp_mflags} \
+  -C %{kernel_sources} \
+  M="$PWD" \
+  ARCH=%{_cross_karch} \
+  CC=%{_cross_target}-gcc \
+  LD=%{_cross_target}-ld \
+  modules
+
+%{_cross_target}-strip -g --strip-unneeded gdrdrv.ko
+mv gdrdrv.ko ../../gdrdrv-open-gpu.ko
 popd
 
 %install
@@ -497,6 +534,26 @@ install -p -m 0755 usr/bin/nvidia-imex %{buildroot}%{_cross_bindir}
 install -p -m 0755 usr/bin/nvidia-imex-ctl %{buildroot}%{_cross_bindir}
 
 popd
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/gdrdrv-open-gpu.ko \
+  %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/LICENSE gdrcopy-LICENSE
+
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/|' %{S:600} > \
+  nvidia-gdrcopy-open-gpu.toml
+install -m 0644 nvidia-gdrcopy-open-gpu.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:601} > copy-gdrcopy-open-gpu-kernel-module.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:602} > load-gdrcopy-open-gpu-kernel-module.service
+install -p -m 0644 \
+  copy-gdrcopy-open-gpu-kernel-module.service \
+  load-gdrcopy-open-gpu-kernel-module.service \
+  %{buildroot}%{_cross_unitdir}
+
+install -p -m 0644 %{S:603} %{buildroot}%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
 
 %files
 %{_cross_attribution_file}
@@ -792,3 +849,14 @@ popd
 %{_cross_bindir}/nvidia-cuda-mps-server
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
+
+%files gdrcopy
+%license gdrcopy-LICENSE
+%dir %{_cross_datadir}/nvidia/gdrcopy
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-gdrcopy-open-gpu.toml
+%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
+%{_cross_unitdir}/copy-gdrcopy-open-gpu-kernel-module.service
+%{_cross_unitdir}/load-gdrcopy-open-gpu-kernel-module.service

--- a/packages/kmod-6.12-nvidia-r595/load-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.12-nvidia-r595/load-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+After=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+Requires=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu load-modules
+ExecStart=/usr/bin/ghostdog create-device gdrdrv 0 --path /dev/gdrdrv
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.12-nvidia-r595/nvidia-gdrcopy-open-gpu-config.toml.in
+++ b/packages/kmod-6.12-nvidia-r595/nvidia-gdrcopy-open-gpu-config.toml.in
@@ -1,0 +1,5 @@
+[nvidia-gdrcopy-open-gpu]
+lib-modules-path = "kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu"
+
+[nvidia-gdrcopy-open-gpu.kernel-modules."gdrdrv.ko"]
+copy-source = "__NVIDIA_MODULES__"

--- a/packages/kmod-6.12-nvidia-r595/nvidia-gdrcopy-tmpfiles.conf
+++ b/packages/kmod-6.12-nvidia-r595/nvidia-gdrcopy-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/drivers/nvidia-gdrcopy-open-gpu.toml

--- a/packages/kmod-6.12-nvidia-r595/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.12-nvidia-r595/nvidia-tmpfiles.conf.in
@@ -4,6 +4,10 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/tesla 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -

--- a/packages/kmod-6.18-nvidia-r580/Cargo.toml
+++ b/packages/kmod-6.18-nvidia-r580/Cargo.toml
@@ -60,5 +60,9 @@ url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/580.159.
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/gdrcopy/archive/v2.6/gdrcopy-2.6.tar.gz"
+sha512 = "3653881de4380ecf85d26a93d9e4ce66679001c9901189707fb13cb98f2ff841eb6d67b63784d1e048db7f7c1975052f22fea0f7813233d96fded2bd39031342"
+
 [build-dependencies]
 kernel-6_18 = { path = "../kernel-6.18" }

--- a/packages/kmod-6.18-nvidia-r580/copy-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.18-nvidia-r580/copy-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Copy GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
+++ b/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
@@ -3,6 +3,7 @@
 %global tesla_patch 03
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global grid_ver grid-19.5
+%global gdrcopy_ver 2.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -84,6 +85,14 @@ Source503: load-open-gpu-kernel-modules.service.in
 Source504: copy-grid-kernel-modules.service.in
 Source505: load-grid-kernel-modules.service.in
 
+Source600: nvidia-gdrcopy-open-gpu-config.toml.in
+Source601: copy-gdrcopy-open-gpu-kernel-module.service.in
+Source602: load-gdrcopy-open-gpu-kernel-module.service.in
+Source603: nvidia-gdrcopy-tmpfiles.conf
+
+# GDRcopy
+Source700: https://github.com/NVIDIA/gdrcopy/archive/v%{gdrcopy_ver}/gdrcopy-%{gdrcopy_ver}.tar.gz
+
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.18-devel
@@ -162,6 +171,16 @@ Summary: NVIDIA CUDA Multi-Process Service
 Requires: %{name}
 
 %description mps
+%{summary}.
+
+%package gdrcopy
+Summary: NVIDIA GDRCopy driver
+Version: %{gdrcopy_ver}
+License: MIT AND GPL-2.0-only
+Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
+
+%description gdrcopy
 %{summary}.
 
 %prep
@@ -270,6 +289,24 @@ and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
+popd
+
+tar -xof %{S:700}
+pushd gdrcopy-%{gdrcopy_ver}/src/gdrdrv
+NVIDIA_SRC_DIR="%{_builddir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open/nvidia" \
+NVIDIA_IS_OPENSOURCE=y \
+HAVE_VM_FLAGS_SET=y \
+HAVE_PROC_OPS=y \
+make %{?_smp_mflags} \
+  -C %{kernel_sources} \
+  M="$PWD" \
+  ARCH=%{_cross_karch} \
+  CC=%{_cross_target}-gcc \
+  LD=%{_cross_target}-ld \
+  modules
+
+%{_cross_target}-strip -g --strip-unneeded gdrdrv.ko
+mv gdrdrv.ko ../../gdrdrv-open-gpu.ko
 popd
 
 %install
@@ -519,6 +556,26 @@ install -p -m 0644 %{S:217} %{buildroot}%{_cross_tmpfilesdir}/nvidia-imex.conf
 # NVIDIA IMEX modprobe config
 install -d %{buildroot}%{_cross_libdir}/modprobe.d
 install -p -m 0644 %{S:218} %{buildroot}%{_cross_libdir}/modprobe.d/10-nvidia-default-imex-channel.conf
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/gdrdrv-open-gpu.ko \
+  %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/LICENSE gdrcopy-LICENSE
+
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/|' %{S:600} > \
+  nvidia-gdrcopy-open-gpu.toml
+install -m 0644 nvidia-gdrcopy-open-gpu.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:601} > copy-gdrcopy-open-gpu-kernel-module.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:602} > load-gdrcopy-open-gpu-kernel-module.service
+install -p -m 0644 \
+  copy-gdrcopy-open-gpu-kernel-module.service \
+  load-gdrcopy-open-gpu-kernel-module.service \
+  %{buildroot}%{_cross_unitdir}
+
+install -p -m 0644 %{S:603} %{buildroot}%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
 
 %files
 %{_cross_attribution_file}
@@ -815,3 +872,14 @@ install -p -m 0644 %{S:218} %{buildroot}%{_cross_libdir}/modprobe.d/10-nvidia-de
 %{_cross_bindir}/nvidia-cuda-mps-server
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
+
+%files gdrcopy
+%license gdrcopy-LICENSE
+%dir %{_cross_datadir}/nvidia/gdrcopy
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-gdrcopy-open-gpu.toml
+%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
+%{_cross_unitdir}/copy-gdrcopy-open-gpu-kernel-module.service
+%{_cross_unitdir}/load-gdrcopy-open-gpu-kernel-module.service

--- a/packages/kmod-6.18-nvidia-r580/load-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.18-nvidia-r580/load-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+After=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+Requires=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu load-modules
+ExecStart=/usr/bin/ghostdog create-device gdrdrv 0 --path /dev/gdrdrv
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.18-nvidia-r580/nvidia-gdrcopy-open-gpu-config.toml.in
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-gdrcopy-open-gpu-config.toml.in
@@ -1,0 +1,5 @@
+[nvidia-gdrcopy-open-gpu]
+lib-modules-path = "kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu"
+
+[nvidia-gdrcopy-open-gpu.kernel-modules."gdrdrv.ko"]
+copy-source = "__NVIDIA_MODULES__"

--- a/packages/kmod-6.18-nvidia-r580/nvidia-gdrcopy-tmpfiles.conf
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-gdrcopy-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/drivers/nvidia-gdrcopy-open-gpu.toml

--- a/packages/kmod-6.18-nvidia-r580/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.18-nvidia-r580/nvidia-tmpfiles.conf.in
@@ -4,6 +4,10 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/tesla 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -

--- a/packages/kmod-6.18-nvidia-r595/Cargo.toml
+++ b/packages/kmod-6.18-nvidia-r595/Cargo.toml
@@ -60,5 +60,9 @@ url = "https://raw.githubusercontent.com/NVIDIA/open-gpu-kernel-modules/595.71.0
 sha512 = "f9cee68cbb12095af4b4e92d01c210461789ef41c70b64efefd6719d0b88468b7a67a3629c432d4d9304c730b5d1a942228a5bcc74a03ab1c411c77c758cd938"
 force-upstream = true
 
+[[package.metadata.build-package.external-files]]
+url = "https://github.com/NVIDIA/gdrcopy/archive/v2.6/gdrcopy-2.6.tar.gz"
+sha512 = "3653881de4380ecf85d26a93d9e4ce66679001c9901189707fb13cb98f2ff841eb6d67b63784d1e048db7f7c1975052f22fea0f7813233d96fded2bd39031342"
+
 [build-dependencies]
 kernel-6_18 = { path = "../kernel-6.18" }

--- a/packages/kmod-6.18-nvidia-r595/copy-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.18-nvidia-r595/copy-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Copy GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+# Rerunning this service after the system is fully loaded will override
+# the already linked kernel modules. This doesn't affect the running system,
+# since kernel modules are linked early in the boot sequence, but we still
+# disable manual restarts to prevent unnecessary kernel modules rewrites.
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu link-modules
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.18-nvidia-r595/kmod-6.18-nvidia-r595.spec
+++ b/packages/kmod-6.18-nvidia-r595/kmod-6.18-nvidia-r595.spec
@@ -3,6 +3,7 @@
 %global tesla_patch 05
 %global tesla_ver %{tesla_major}.%{tesla_minor}.%{tesla_patch}
 %global grid_ver grid-20.1
+%global gdrcopy_ver 2.6
 %if "%{?_cross_arch}" == "aarch64"
 %global nvidia_arch sbsa
 %else
@@ -80,6 +81,14 @@ Source503: load-open-gpu-kernel-modules.service.in
 Source504: copy-grid-kernel-modules.service.in
 Source505: load-grid-kernel-modules.service.in
 
+Source600: nvidia-gdrcopy-open-gpu-config.toml.in
+Source601: copy-gdrcopy-open-gpu-kernel-module.service.in
+Source602: load-gdrcopy-open-gpu-kernel-module.service.in
+Source603: nvidia-gdrcopy-tmpfiles.conf
+
+# GDRcopy
+Source700: https://github.com/NVIDIA/gdrcopy/archive/v%{gdrcopy_ver}/gdrcopy-%{gdrcopy_ver}.tar.gz
+
 Patch001: 0001-makefile-allow-to-use-any-kernel-arch.patch
 
 BuildRequires: %{_cross_os}kernel-6.18-devel
@@ -151,6 +160,16 @@ Summary: NVIDIA CUDA Multi-Process Service
 Requires: %{name}
 
 %description mps
+%{summary}.
+
+%package gdrcopy
+Summary: NVIDIA GDRCopy driver
+Version: %{gdrcopy_ver}
+License: MIT AND GPL-2.0-only
+Requires: %{_cross_os}variant-platform(aws)
+Requires: %{name}
+
+%description gdrcopy
 %{summary}.
 
 %prep
@@ -259,6 +278,24 @@ and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes
 jq -e '."open-gpu"[] | select(."devid" == "0x2330") | ."features"| index("kernelopen")' open-gpu-supported-devices.json
+popd
+
+tar -xof %{S:700}
+pushd gdrcopy-%{gdrcopy_ver}/src/gdrdrv
+NVIDIA_SRC_DIR="%{_builddir}/NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open/nvidia" \
+NVIDIA_IS_OPENSOURCE=y \
+HAVE_VM_FLAGS_SET=y \
+HAVE_PROC_OPS=y \
+make %{?_smp_mflags} \
+  -C %{kernel_sources} \
+  M="$PWD" \
+  ARCH=%{_cross_karch} \
+  CC=%{_cross_target}-gcc \
+  LD=%{_cross_target}-ld \
+  modules
+
+%{_cross_target}-strip -g --strip-unneeded gdrdrv.ko
+mv gdrdrv.ko ../../gdrdrv-open-gpu.ko
 popd
 
 %install
@@ -497,6 +534,26 @@ install -p -m 0755 usr/bin/nvidia-imex %{buildroot}%{_cross_bindir}
 install -p -m 0755 usr/bin/nvidia-imex-ctl %{buildroot}%{_cross_bindir}
 
 popd
+
+install -d %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/gdrdrv-open-gpu.ko \
+  %{buildroot}%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+
+install -p -m 0644 gdrcopy-%{gdrcopy_ver}/LICENSE gdrcopy-LICENSE
+
+sed -e 's|__NVIDIA_MODULES__|%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/|' %{S:600} > \
+  nvidia-gdrcopy-open-gpu.toml
+install -m 0644 nvidia-gdrcopy-open-gpu.toml %{buildroot}%{_cross_factorydir}%{_cross_sysconfdir}/drivers
+
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:601} > copy-gdrcopy-open-gpu-kernel-module.service
+sed -e 's|PREFIX|%{_cross_prefix}|g' %{S:602} > load-gdrcopy-open-gpu-kernel-module.service
+install -p -m 0644 \
+  copy-gdrcopy-open-gpu-kernel-module.service \
+  load-gdrcopy-open-gpu-kernel-module.service \
+  %{buildroot}%{_cross_unitdir}
+
+install -p -m 0644 %{S:603} %{buildroot}%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
 
 %files
 %{_cross_attribution_file}
@@ -792,3 +849,15 @@ popd
 %{_cross_bindir}/nvidia-cuda-mps-server
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-control
 %{_cross_libexecdir}/nvidia/tesla/bin/nvidia-cuda-mps-server
+
+
+%files gdrcopy
+%license gdrcopy-LICENSE
+%dir %{_cross_datadir}/nvidia/gdrcopy
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu
+%dir %{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers
+%{_cross_datadir}/nvidia/gdrcopy/open-gpu/drivers/gdrdrv.ko
+%{_cross_factorydir}%{_cross_sysconfdir}/drivers/nvidia-gdrcopy-open-gpu.toml
+%{_cross_tmpfilesdir}/nvidia-gdrcopy.conf
+%{_cross_unitdir}/copy-gdrcopy-open-gpu-kernel-module.service
+%{_cross_unitdir}/load-gdrcopy-open-gpu-kernel-module.service

--- a/packages/kmod-6.18-nvidia-r595/load-gdrcopy-open-gpu-kernel-module.service.in
+++ b/packages/kmod-6.18-nvidia-r595/load-gdrcopy-open-gpu-kernel-module.service.in
@@ -1,0 +1,20 @@
+[Unit]
+Description=Load GDRCopy kernel module (open-gpu)
+RequiresMountsFor=PREFIX/lib/modules PREFIX/src/kernels
+After=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+Requires=copy-gdrcopy-open-gpu-kernel-module.service load-open-gpu-kernel-modules.service
+# Disable manual restarts to prevent loading kernel modules
+# that weren't linked by the running system
+RefuseManualStart=true
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/ghostdog match-nvidia-driver open-gpu
+ExecStart=/usr/bin/driverdog --modules-set nvidia-gdrcopy-open-gpu load-modules
+ExecStart=/usr/bin/ghostdog create-device gdrdrv 0 --path /dev/gdrdrv
+RemainAfterExit=true
+StandardError=journal+console
+
+[Install]
+RequiredBy=drivers.target

--- a/packages/kmod-6.18-nvidia-r595/nvidia-gdrcopy-open-gpu-config.toml.in
+++ b/packages/kmod-6.18-nvidia-r595/nvidia-gdrcopy-open-gpu-config.toml.in
@@ -1,0 +1,5 @@
+[nvidia-gdrcopy-open-gpu]
+lib-modules-path = "kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu"
+
+[nvidia-gdrcopy-open-gpu.kernel-modules."gdrdrv.ko"]
+copy-source = "__NVIDIA_MODULES__"

--- a/packages/kmod-6.18-nvidia-r595/nvidia-gdrcopy-tmpfiles.conf
+++ b/packages/kmod-6.18-nvidia-r595/nvidia-gdrcopy-tmpfiles.conf
@@ -1,0 +1,1 @@
+C /etc/drivers/nvidia-gdrcopy-open-gpu.toml

--- a/packages/kmod-6.18-nvidia-r595/nvidia-tmpfiles.conf.in
+++ b/packages/kmod-6.18-nvidia-r595/nvidia-tmpfiles.conf.in
@@ -4,6 +4,10 @@ R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/op
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/open-gpu 0755 root root - -
 R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid - - - - -
 d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/grid 0755 root root - -
+R __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy - - - - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/open-gpu 0755 root root - -
+d __PREFIX__/lib/modules/__KERNEL_VERSION__/kernel/drivers/extra/video/nvidia/gdrcopy/tesla 0755 root root - -
 C /etc/nvidia/fabricmanager.cfg - - - -
 C /etc/nvidia/fabricmanager.env - - - -
 C /etc/nvidia/gridd.conf - - - -


### PR DESCRIPTION
**Description of changes:**

Adds gdrcopy to all NVIDIA kmods as a new subpackage. Builds for open-gpu only as there is a problem with the tesla driver (see: https://github.com/NVIDIA/gdrcopy/issues/335#issuecomment-4857372012).

In the first iteration of the PR, there was a patch to create the device using modern kernel APIs. However those might conflict with the proprietary driver as they are GPL only.

Instead, create the devices using `mknod` through a new command introduced in `ghostdog` in this PR: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/963

**Testing done:**

<details>

In combination with: https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/963

Launched 3 AMIS, `aws-ecs-2-nvidia`, `aws-ecs-3-nvidia`, `aws-ecs-4-nvidia`, ran the suite of tests provided by `gdrcopy` and confirmed all passed:

**6.1**

```bash
root@f97863d1b02d:~/gdrcopy# for f in $(find /usr/local/bin/ -name "gdrcopy*"); do "$f" ; done
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
testing size: 131072
rounded size: 131072
gpu alloc fn: cuMemAlloc
device ptr: 1000a800000
map_d_ptr: 0x7fc5b44b5000
info.va: 1000a800000
info.mapped_size: 131072
info.page_size: 65536
info.mapped: 1
info.wc_mapping: 1
page offset: 0
user-space pointer:0x7fc5b44b5000
writing test, size=131072 offset=0 num_iters=10000
write BW: 4965.19MB/s
reading test, size=131072 offset=0 num_iters=100
read BW: 604.764MB/s
unmapping buffer
unpinning buffer
closing gdrdrv
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
device ptr: 0x1000a800000
allocated size: 16777216
gpu alloc fn: cuMemAlloc

map_d_ptr: 0x7f9d307ff000
info.va: 1000a800000
info.mapped_size: 16777216
info.page_size: 65536
info.mapped: 1
info.wc_mapping: 1
page offset: 0
user-space pointer: 0x7f9d307ff000
use cold cache: no

gdr_copy_to_mapping num iters for each size: 10000
WARNING: Measuring the API invocation overhead as observed by the CPU. Data might not be ordered all the way to the GPU internal visibility.
Test                     Size(B)         Median Time(us)         Min. Time(us)
gdr_copy_to_mapping             1             0.1108          0.1094
gdr_copy_to_mapping             2             0.1108          0.1069
gdr_copy_to_mapping             4             0.1108          0.1068
gdr_copy_to_mapping             8             0.1108          0.1066
gdr_copy_to_mapping            16             0.1108          0.1105
gdr_copy_to_mapping            32             0.1110          0.1068
gdr_copy_to_mapping            64             0.1128          0.1090
gdr_copy_to_mapping           128             0.1243          0.1207
gdr_copy_to_mapping           256             0.1259          0.1225
gdr_copy_to_mapping           512             0.1423          0.1400
gdr_copy_to_mapping          1024             0.2017          0.1999
gdr_copy_to_mapping          2048             0.3922          0.3888
gdr_copy_to_mapping          4096             0.8071          0.8045
gdr_copy_to_mapping          8192             1.5785          1.5636
gdr_copy_to_mapping         16384             3.1441          3.1195
gdr_copy_to_mapping         32768             6.2825          6.2317
gdr_copy_to_mapping         65536            12.5715         12.5154
gdr_copy_to_mapping        131072            25.1100         25.0716
gdr_copy_to_mapping        262144            50.2823         50.2094
gdr_copy_to_mapping        524288           100.5841        100.5328
gdr_copy_to_mapping       1048576           201.3512        201.2700
gdr_copy_to_mapping       2097152           402.8245        402.7032
gdr_copy_to_mapping       4194304           806.0577        805.8214
gdr_copy_to_mapping       8388608          1612.2280       1611.9027
gdr_copy_to_mapping      16777216          3224.9493       3224.0666

gdr_copy_from_mapping num iters for each size: 100
Test                     Size(B)         Median Time(us)         Min. Time(us)
gdr_copy_from_mapping           1             0.7060          0.7000
gdr_copy_from_mapping           2             0.7060          0.6980
gdr_copy_from_mapping           4             0.7060          0.6990
gdr_copy_from_mapping           8             0.7060          0.6990
gdr_copy_from_mapping          16             0.7250          0.7080
gdr_copy_from_mapping          32             0.7210          0.7080
gdr_copy_from_mapping          64             0.7290          0.7120
gdr_copy_from_mapping         128             1.4190          0.7250
gdr_copy_from_mapping         256             1.4340          0.7450
gdr_copy_from_mapping         512             2.0280          1.3150
gdr_copy_from_mapping        1024             2.6940          1.9400
gdr_copy_from_mapping        2048             3.7150          3.6880
gdr_copy_from_mapping        4096             7.1650          7.1070
gdr_copy_from_mapping        8192            14.0170         13.7080
gdr_copy_from_mapping       16384            28.3250         26.5630
gdr_copy_from_mapping       32768            52.5830         51.9770
gdr_copy_from_mapping       65536           103.8550        103.4430
gdr_copy_from_mapping      131072           221.9000        216.8900
gdr_copy_from_mapping      262144           466.5490        461.4220
gdr_copy_from_mapping      524288           933.7860        928.0800
gdr_copy_from_mapping     1048576          1871.8920       1855.2390
gdr_copy_from_mapping     2097152          3757.3580       3717.1380
gdr_copy_from_mapping     4194304          8615.6900       8453.2370
gdr_copy_from_mapping     8388608         21914.1680      19733.5430
gdr_copy_from_mapping    16777216         43926.4590      43620.8820
unmapping buffer
unpinning buffer
closing gdrdrv
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
device ptr: 0x1000a800000
allocated size: 16777216
Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
65536   45.186410       5.170990        0.640430        6.890830        28.823420
Histogram of gdr_pin_buffer latency for 65536 bytes
[42.221000      -       84.442000]      99
[84.442000      -       126.663000]     0
[126.663000     -       168.884000]     0
[168.884000     -       211.105000]     0
[211.105000     -       253.326000]     0
[253.326000     -       295.547000]     0
[295.547000     -       337.768000]     0
[337.768000     -       379.989000]     0
[379.989000     -       422.210000]     0
[422.210000     -       464.431000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
131072  43.106480       5.296740        0.641370        10.348450       28.769700
Histogram of gdr_pin_buffer latency for 131072 bytes
[42.340000      -       84.680000]      94
[84.680000      -       127.020000]     3
[127.020000     -       169.360000]     1
[169.360000     -       211.700000]     0
[211.700000     -       254.040000]     0
[254.040000     -       296.380000]     0
[296.380000     -       338.720000]     1
[338.720000     -       381.060000]     1
[381.060000     -       423.400000]     0
[423.400000     -       465.740000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
262144  43.740730       5.489290        0.640410        4.462160        29.020330
Histogram of gdr_pin_buffer latency for 262144 bytes
[42.438000      -       84.876000]      88
[84.876000      -       127.314000]     7
[127.314000     -       169.752000]     1
[169.752000     -       212.190000]     0
[212.190000     -       254.628000]     2
[254.628000     -       297.066000]     1
[297.066000     -       339.504000]     0
[339.504000     -       381.942000]     0
[381.942000     -       424.380000]     0
[424.380000     -       466.818000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
524288  44.028420       5.836290        0.639700        5.183110        28.996530
Histogram of gdr_pin_buffer latency for 524288 bytes
[42.984000      -       85.968000]      94
[85.968000      -       128.952000]     2
[128.952000     -       171.936000]     0
[171.936000     -       214.920000]     0
[214.920000     -       257.904000]     0
[257.904000     -       300.888000]     0
[300.888000     -       343.872000]     0
[343.872000     -       386.856000]     1
[386.856000     -       429.840000]     1
[429.840000     -       472.824000]     1

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
1048576 47.454040       6.458710        0.642540        6.924870        30.843180
Histogram of gdr_pin_buffer latency for 1048576 bytes
[46.298000      -       92.596000]      90
[92.596000      -       138.894000]     7
[138.894000     -       185.192000]     0
[185.192000     -       231.490000]     1
[231.490000     -       277.788000]     0
[277.788000     -       324.086000]     1
[324.086000     -       370.384000]     0
[370.384000     -       416.682000]     0
[416.682000     -       462.980000]     0
[462.980000     -       509.278000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
2097152 48.929230       8.433000        0.641500        10.967700       31.502910
Histogram of gdr_pin_buffer latency for 2097152 bytes
[47.898000      -       95.796000]      96
[95.796000      -       143.694000]     0
[143.694000     -       191.592000]     0
[191.592000     -       239.490000]     1
[239.490000     -       287.388000]     2
[287.388000     -       335.286000]     0
[335.286000     -       383.184000]     0
[383.184000     -       431.082000]     0
[431.082000     -       478.980000]     0
[478.980000     -       526.878000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
4194304 54.247330       12.070450       0.644490        17.950010       34.196730
Histogram of gdr_pin_buffer latency for 4194304 bytes
[53.118000      -       106.236000]     88
[106.236000     -       159.354000]     4
[159.354000     -       212.472000]     1
[212.472000     -       265.590000]     3
[265.590000     -       318.708000]     2
[318.708000     -       371.826000]     0
[371.826000     -       424.944000]     0
[424.944000     -       478.062000]     0
[478.062000     -       531.180000]     0
[531.180000     -       584.298000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
8388608 65.570560       17.719780       0.642210        31.293770       40.654600
Histogram of gdr_pin_buffer latency for 8388608 bytes
[64.440000      -       128.880000]     83
[128.880000     -       193.320000]     3
[193.320000     -       257.760000]     2
[257.760000     -       322.200000]     4
[322.200000     -       386.640000]     4
[386.640000     -       451.080000]     2
[451.080000     -       515.520000]     0
[515.520000     -       579.960000]     0
[579.960000     -       644.400000]     1
[644.400000     -       708.840000]     1

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
16777216        90.232900       30.830930       0.653580        59.034780       52.753510
Histogram of gdr_pin_buffer latency for 16777216 bytes
[86.598000      -       173.196000]     88
[173.196000     -       259.794000]     11
[259.794000     -       346.392000]     0
[346.392000     -       432.990000]     0
[432.990000     -       519.588000]     0
[519.588000     -       606.186000]     0
[606.186000     -       692.784000]     0
[692.784000     -       779.382000]     0
[779.382000     -       865.980000]     0
[865.980000     -       952.578000]     0

closing gdrdrv
Total: 36, Passed: 31, Failed: 0, Waived: 5

List of waived tests:
    basic_v2_forcepci_cumemalloc
    basic_v2_forcepci_vmmalloc
    basic_with_tokens
    data_validation_mix_mappings_cumemalloc
    data_validation_v2_forcepci_cumemalloc
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
We will measure the visibility of the flag value only. Setting nblocks and nthreads to 1.
Benchmark mode: CPU produces and GPU consumes
gpu alloc fn: cuMemAlloc
Measuring the visibility latency of the flag value.
Running 1000 iterations with flag size 4 bytes.

CPU writes to gpu_flag. GPU polls on the expected gpu_flag value. GPU writes back via cpu_flag. CPU polls on the expected cpu_flag value. We report the round-trip time from when CPU writes to gpu_flag until it observes the update in cpu_flag.
CPU does the time measurement.

Round-trip latency per iteration is (min) 0.941, (median) 0.9451 us
closing gdrdrv
```

**6.12**

```bash
root@febecd092824:~/gdrcopy# for f in $(find /usr/local/bin/ -name "gdrcopy*"); do "$f"; done
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
testing size: 131072
rounded size: 131072
gpu alloc fn: cuMemAlloc
device ptr: 1000a800000
map_d_ptr: 0x7fe41c034000
info.va: 1000a800000
info.mapped_size: 131072
info.page_size: 65536
info.mapped: 1
info.wc_mapping: 1
page offset: 0
user-space pointer:0x7fe41c034000
writing test, size=131072 offset=0 num_iters=10000
write BW: 4956.11MB/s
reading test, size=131072 offset=0 num_iters=100
read BW: 580.455MB/s
unmapping buffer
unpinning buffer
closing gdrdrv
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
device ptr: 0x1000a800000
allocated size: 16777216
gpu alloc fn: cuMemAlloc

map_d_ptr: 0x7f8096600000
info.va: 1000a800000
info.mapped_size: 16777216
info.page_size: 65536
info.mapped: 1
info.wc_mapping: 1
page offset: 0
user-space pointer: 0x7f8096600000
use cold cache: no

gdr_copy_to_mapping num iters for each size: 10000
WARNING: Measuring the API invocation overhead as observed by the CPU. Data might not be ordered all the way to the GPU internal visibility.
Test                     Size(B)         Median Time(us)         Min. Time(us)
gdr_copy_to_mapping             1             0.1013          0.0967
gdr_copy_to_mapping             2             0.1013          0.0967
gdr_copy_to_mapping             4             0.1013          0.0972
gdr_copy_to_mapping             8             0.1013          0.0968
gdr_copy_to_mapping            16             0.1013          0.0968
gdr_copy_to_mapping            32             0.1007          0.0987
gdr_copy_to_mapping            64             0.1009          0.0972
gdr_copy_to_mapping           128             0.1122          0.1089
gdr_copy_to_mapping           256             0.1185          0.1156
gdr_copy_to_mapping           512             0.1377          0.1357
gdr_copy_to_mapping          1024             0.2016          0.1992
gdr_copy_to_mapping          2048             0.3932          0.3897
gdr_copy_to_mapping          4096             0.7966          0.7903
gdr_copy_to_mapping          8192             1.5719          1.5590
gdr_copy_to_mapping         16384             3.1417          3.1161
gdr_copy_to_mapping         32768             6.2823          6.2326
gdr_copy_to_mapping         65536            12.5684         12.5115
gdr_copy_to_mapping        131072            25.1057         25.0715
gdr_copy_to_mapping        262144            50.3072         50.2121
gdr_copy_to_mapping        524288           100.6353        100.5619
gdr_copy_to_mapping       1048576           201.4703        201.3162
gdr_copy_to_mapping       2097152           403.1990        403.0067
gdr_copy_to_mapping       4194304           807.1025        806.5699
gdr_copy_to_mapping       8388608          1614.8678       1613.9100
gdr_copy_to_mapping      16777216          3230.9156       3229.4346

gdr_copy_from_mapping num iters for each size: 100
Test                     Size(B)         Median Time(us)         Min. Time(us)
gdr_copy_from_mapping           1             0.7030          0.6960
gdr_copy_from_mapping           2             0.6970          0.6900
gdr_copy_from_mapping           4             0.7010          0.6910
gdr_copy_from_mapping           8             0.7030          0.6910
gdr_copy_from_mapping          16             1.0390          0.6970
gdr_copy_from_mapping          32             0.8560          0.7030
gdr_copy_from_mapping          64             1.0220          0.7020
gdr_copy_from_mapping         128             1.0420          0.7210
gdr_copy_from_mapping         256             1.3790          0.7320
gdr_copy_from_mapping         512             1.3360          1.3030
gdr_copy_from_mapping        1024             1.9440          1.9240
gdr_copy_from_mapping        2048             3.6910          3.6530
gdr_copy_from_mapping        4096            10.3000          6.7130
gdr_copy_from_mapping        8192            13.3010         13.2160
gdr_copy_from_mapping       16384            25.9700         25.8600
gdr_copy_from_mapping       32768            51.6970         51.5310
gdr_copy_from_mapping       65536           102.7500        102.5820
gdr_copy_from_mapping      131072           213.4120        210.6220
gdr_copy_from_mapping      262144           469.8090        463.7740
gdr_copy_from_mapping      524288           939.3750        932.3690
gdr_copy_from_mapping     1048576          1879.6120       1864.0040
gdr_copy_from_mapping     2097152          3772.0000       3736.7080
gdr_copy_from_mapping     4194304          8769.5490       8606.2170
gdr_copy_from_mapping     8388608         22270.4570      20145.8530
gdr_copy_from_mapping    16777216         44547.9340      44232.5740
unmapping buffer
unpinning buffer
closing gdrdrv
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
device ptr: 0x1000a800000
allocated size: 16777216
Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
65536   43.235230       5.249080        0.638210        6.295480        27.685350
Histogram of gdr_pin_buffer latency for 65536 bytes
[42.557000      -       85.114000]      97
[85.114000      -       127.671000]     1
[127.671000     -       170.228000]     0
[170.228000     -       212.785000]     0
[212.785000     -       255.342000]     0
[255.342000     -       297.899000]     0
[297.899000     -       340.456000]     0
[340.456000     -       383.013000]     1
[383.013000     -       425.570000]     0
[425.570000     -       468.127000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
131072  43.101670       5.289000        0.638280        9.640780        28.173080
Histogram of gdr_pin_buffer latency for 131072 bytes
[42.551000      -       85.102000]      89
[85.102000      -       127.653000]     1
[127.653000     -       170.204000]     4
[170.204000     -       212.755000]     5
[212.755000     -       255.306000]     0
[255.306000     -       297.857000]     0
[297.857000     -       340.408000]     1
[340.408000     -       382.959000]     0
[382.959000     -       425.510000]     0
[425.510000     -       468.061000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
262144  43.338080       5.506940        0.644840        4.260080        28.437870
Histogram of gdr_pin_buffer latency for 262144 bytes
[42.725000      -       85.450000]      87
[85.450000      -       128.175000]     6
[128.175000     -       170.900000]     2
[170.900000     -       213.625000]     2
[213.625000     -       256.350000]     0
[256.350000     -       299.075000]     1
[299.075000     -       341.800000]     2
[341.800000     -       384.525000]     0
[384.525000     -       427.250000]     0
[427.250000     -       469.975000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
524288  44.132100       5.631750        0.639980        5.320220        28.648850
Histogram of gdr_pin_buffer latency for 524288 bytes
[43.002000      -       86.004000]      82
[86.004000      -       129.006000]     3
[129.006000     -       172.008000]     8
[172.008000     -       215.010000]     1
[215.010000     -       258.012000]     0
[258.012000     -       301.014000]     0
[301.014000     -       344.016000]     2
[344.016000     -       387.018000]     0
[387.018000     -       430.020000]     1
[430.020000     -       473.022000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
1048576 46.653550       5.759790        0.638980        7.529760        29.855310
Histogram of gdr_pin_buffer latency for 1048576 bytes
[46.227000      -       92.454000]      99
[92.454000      -       138.681000]     1
[138.681000     -       184.908000]     0
[184.908000     -       231.135000]     0
[231.135000     -       277.362000]     0
[277.362000     -       323.589000]     0
[323.589000     -       369.816000]     0
[369.816000     -       416.043000]     0
[416.043000     -       462.270000]     0
[462.270000     -       508.497000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
2097152 48.343730       7.438380        0.639170        13.249150       30.843720
Histogram of gdr_pin_buffer latency for 2097152 bytes
[47.571000      -       95.142000]      78
[95.142000      -       142.713000]     3
[142.713000     -       190.284000]     9
[190.284000     -       237.855000]     10
[237.855000     -       285.426000]     0
[285.426000     -       332.997000]     0
[332.997000     -       380.568000]     0
[380.568000     -       428.139000]     0
[428.139000     -       475.710000]     0
[475.710000     -       523.281000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
4194304 55.287450       9.720010        0.642910        22.327620       33.481760
Histogram of gdr_pin_buffer latency for 4194304 bytes
[52.309000      -       104.618000]     99
[104.618000     -       156.927000]     0
[156.927000     -       209.236000]     0
[209.236000     -       261.545000]     0
[261.545000     -       313.854000]     0
[313.854000     -       366.163000]     0
[366.163000     -       418.472000]     0
[418.472000     -       470.781000]     0
[470.781000     -       523.090000]     0
[523.090000     -       575.399000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
8388608 62.328730       14.037300       0.638470        40.623420       38.498700
Histogram of gdr_pin_buffer latency for 8388608 bytes
[61.715000      -       123.430000]     95
[123.430000     -       185.145000]     2
[185.145000     -       246.860000]     0
[246.860000     -       308.575000]     0
[308.575000     -       370.290000]     0
[370.290000     -       432.005000]     0
[432.005000     -       493.720000]     0
[493.720000     -       555.435000]     2
[555.435000     -       617.150000]     0
[617.150000     -       678.865000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
16777216        82.941430       23.053140       0.642190        77.942010       48.708140
Histogram of gdr_pin_buffer latency for 16777216 bytes
[80.905000      -       161.810000]     91
[161.810000     -       242.715000]     4
[242.715000     -       323.620000]     2
[323.620000     -       404.525000]     0
[404.525000     -       485.430000]     0
[485.430000     -       566.335000]     2
[566.335000     -       647.240000]     0
[647.240000     -       728.145000]     0
[728.145000     -       809.050000]     0
[809.050000     -       889.955000]     0

closing gdrdrv
Total: 36, Passed: 31, Failed: 0, Waived: 5

List of waived tests:
    basic_v2_forcepci_cumemalloc
    basic_v2_forcepci_vmmalloc
    basic_with_tokens
    data_validation_mix_mappings_cumemalloc
    data_validation_v2_forcepci_cumemalloc
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
We will measure the visibility of the flag value only. Setting nblocks and nthreads to 1.
Benchmark mode: CPU produces and GPU consumes
gpu alloc fn: cuMemAlloc
Measuring the visibility latency of the flag value.
Running 1000 iterations with flag size 4 bytes.

CPU writes to gpu_flag. GPU polls on the expected gpu_flag value. GPU writes back via cpu_flag. CPU polls on the expected cpu_flag value. We report the round-trip time fromwhen CPU writes to gpu_flag until it observes the update in cpu_flag.
CPU does the time measurement.

Round-trip latency per iteration is (min) 0.9366, (median) 0.941 us
closing gdrdrv
```

**6.18**

```bash
root@21418686cde5:~# for f in $(find /usr/local/bin/ -name "gdrcopy_*"); do $f; done
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
testing size: 131072
rounded size: 131072
gpu alloc fn: cuMemAlloc
device ptr: 1000a800000
map_d_ptr: 0x7f1d1873b000
info.va: 1000a800000
info.mapped_size: 131072
info.page_size: 65536
info.mapped: 1
info.wc_mapping: 1
page offset: 0
user-space pointer:0x7f1d1873b000
writing test, size=131072 offset=0 num_iters=10000
write BW: 4957.14MB/s
reading test, size=131072 offset=0 num_iters=100
read BW: 597.053MB/s
unmapping buffer
unpinning buffer
closing gdrdrv
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
device ptr: 0x1000a800000
allocated size: 16777216
gpu alloc fn: cuMemAlloc

map_d_ptr: 0x7fcd9e7ff000
info.va: 1000a800000
info.mapped_size: 16777216
info.page_size: 65536
info.mapped: 1
info.wc_mapping: 1
page offset: 0
user-space pointer: 0x7fcd9e7ff000
use cold cache: no

gdr_copy_to_mapping num iters for each size: 10000
WARNING: Measuring the API invocation overhead as observed by the CPU. Data might not be ordered all the way to the GPU internal visibility.
Test                     Size(B)         Median Time(us)         Min. Time(us)
gdr_copy_to_mapping             1             0.1155          0.1097
gdr_copy_to_mapping             2             0.1151          0.1106
gdr_copy_to_mapping             4             0.1151          0.1099
gdr_copy_to_mapping             8             0.1151          0.1101
gdr_copy_to_mapping            16             0.1149          0.1126
gdr_copy_to_mapping            32             0.1147          0.1108
gdr_copy_to_mapping            64             0.1156          0.1115
gdr_copy_to_mapping           128             0.1259          0.1226
gdr_copy_to_mapping           256             0.1295          0.1265
gdr_copy_to_mapping           512             0.1466          0.1439
gdr_copy_to_mapping          1024             0.2087          0.2044
gdr_copy_to_mapping          2048             0.3937          0.3916
gdr_copy_to_mapping          4096             0.8009          0.7940
gdr_copy_to_mapping          8192             1.5750          1.5637
gdr_copy_to_mapping         16384             3.1478          3.1221
gdr_copy_to_mapping         32768             6.2829          6.2342
gdr_copy_to_mapping         65536            12.5761         12.5181
gdr_copy_to_mapping        131072            25.1142         25.0734
gdr_copy_to_mapping        262144            50.3127         50.2230
gdr_copy_to_mapping        524288           100.6545        100.5611
gdr_copy_to_mapping       1048576           201.4786        201.3180
gdr_copy_to_mapping       2097152           403.4672        403.0828
gdr_copy_to_mapping       4194304           807.7034        806.8644
gdr_copy_to_mapping       8388608          1616.5109       1615.3007
gdr_copy_to_mapping      16777216          3232.6448       3229.9686

gdr_copy_from_mapping num iters for each size: 100
Test                     Size(B)         Median Time(us)         Min. Time(us)
gdr_copy_from_mapping           1             0.7080          0.6980
gdr_copy_from_mapping           2             1.0390          0.6990
gdr_copy_from_mapping           4             0.7140          0.6980
gdr_copy_from_mapping           8             1.0380          0.7000
gdr_copy_from_mapping          16             0.7170          0.7030
gdr_copy_from_mapping          32             0.7220          0.7030
gdr_copy_from_mapping          64             0.7380          0.7090
gdr_copy_from_mapping         128             0.7380          0.7220
gdr_copy_from_mapping         256             0.7600          0.7400
gdr_copy_from_mapping         512             1.9960          1.3120
gdr_copy_from_mapping        1024             2.6180          1.9420
gdr_copy_from_mapping        2048             4.9770          3.6950
gdr_copy_from_mapping        4096             6.8060          6.7480
gdr_copy_from_mapping        8192            13.3830         13.3230
gdr_copy_from_mapping       16384            26.7230         26.0670
gdr_copy_from_mapping       32768            52.1540         51.9770
gdr_copy_from_mapping       65536           106.4560        103.8630
gdr_copy_from_mapping      131072           225.6440        220.0220
gdr_copy_from_mapping      262144           472.0400        464.9060
gdr_copy_from_mapping      524288           946.3420        933.6790
gdr_copy_from_mapping     1048576          1906.1090       1868.9790
gdr_copy_from_mapping     2097152          3817.3320       3748.7350
gdr_copy_from_mapping     4194304          9002.2110       8659.9360
gdr_copy_from_mapping     8388608         22483.5250      20235.6930
gdr_copy_from_mapping    16777216         44995.7970      44509.3360
unmapping buffer
unpinning buffer
closing gdrdrv
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
device ptr: 0x1000a800000
allocated size: 16777216
Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
65536   41.642910       5.100330        0.652410        7.264620        25.412010
Histogram of gdr_pin_buffer latency for 65536 bytes
[41.259000      -       82.518000]      98
[82.518000      -       123.777000]     1
[123.777000     -       165.036000]     0
[165.036000     -       206.295000]     0
[206.295000     -       247.554000]     0
[247.554000     -       288.813000]     0
[288.813000     -       330.072000]     0
[330.072000     -       371.331000]     0
[371.331000     -       412.590000]     0
[412.590000     -       453.849000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
131072  42.657070       5.255250        0.657450        10.498540       25.855820
Histogram of gdr_pin_buffer latency for 131072 bytes
[41.267000      -       82.534000]      90
[82.534000      -       123.801000]     4
[123.801000     -       165.068000]     1
[165.068000     -       206.335000]     0
[206.335000     -       247.602000]     0
[247.602000     -       288.869000]     2
[288.869000     -       330.136000]     1
[330.136000     -       371.403000]     1
[371.403000     -       412.670000]     0
[412.670000     -       453.937000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
262144  42.691320       5.508170        0.652600        4.823600        25.785410
Histogram of gdr_pin_buffer latency for 262144 bytes
[41.708000      -       83.416000]      93
[83.416000      -       125.124000]     1
[125.124000     -       166.832000]     1
[166.832000     -       208.540000]     0
[208.540000     -       250.248000]     2
[250.248000     -       291.956000]     0
[291.956000     -       333.664000]     2
[333.664000     -       375.372000]     0
[375.372000     -       417.080000]     0
[417.080000     -       458.788000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
524288  42.856900       5.723840        0.657290        6.029350        26.332350
Histogram of gdr_pin_buffer latency for 524288 bytes
[42.104000      -       84.208000]      89
[84.208000      -       126.312000]     4
[126.312000     -       168.416000]     2
[168.416000     -       210.520000]     0
[210.520000     -       252.624000]     0
[252.624000     -       294.728000]     0
[294.728000     -       336.832000]     1
[336.832000     -       378.936000]     1
[378.936000     -       421.040000]     1
[421.040000     -       463.144000]     2

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
1048576 46.207480       6.204500        0.655590        8.242400        27.794940
Histogram of gdr_pin_buffer latency for 1048576 bytes
[45.521000      -       91.042000]      96
[91.042000      -       136.563000]     0
[136.563000     -       182.084000]     1
[182.084000     -       227.605000]     1
[227.605000     -       273.126000]     1
[273.126000     -       318.647000]     0
[318.647000     -       364.168000]     0
[364.168000     -       409.689000]     0
[409.689000     -       455.210000]     0
[455.210000     -       500.731000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
2097152 47.098730       9.135360        0.652100        13.768190       28.450790
Histogram of gdr_pin_buffer latency for 2097152 bytes
[46.445000      -       92.890000]      90
[92.890000      -       139.335000]     3
[139.335000     -       185.780000]     0
[185.780000     -       232.225000]     4
[232.225000     -       278.670000]     0
[278.670000     -       325.115000]     0
[325.115000     -       371.560000]     1
[371.560000     -       418.005000]     1
[418.005000     -       464.450000]     1
[464.450000     -       510.895000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
4194304 51.775190       12.290500       0.652620        23.261030       30.615460
Histogram of gdr_pin_buffer latency for 4194304 bytes
[51.214000      -       102.428000]     94
[102.428000     -       153.642000]     3
[153.642000     -       204.856000]     0
[204.856000     -       256.070000]     0
[256.070000     -       307.284000]     1
[307.284000     -       358.498000]     0
[358.498000     -       409.712000]     0
[409.712000     -       460.926000]     0
[460.926000     -       512.140000]     0
[512.140000     -       563.354000]     1

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
8388608 62.312690       18.628790       0.658770        42.224660       35.749800
Histogram of gdr_pin_buffer latency for 8388608 bytes
[60.716000      -       121.432000]     80
[121.432000     -       182.148000]     4
[182.148000     -       242.864000]     7
[242.864000     -       303.580000]     4
[303.580000     -       364.296000]     3
[364.296000     -       425.012000]     0
[425.012000     -       485.728000]     1
[485.728000     -       546.444000]     0
[546.444000     -       607.160000]     0
[607.160000     -       667.876000]     0

Size(B) pin.Time(us)    map.Time(us)    get_info.Time(us)       unmap.Time(us)  unpin.Time(us)
16777216        81.506680       32.257910       0.656050        80.319200       47.888360
Histogram of gdr_pin_buffer latency for 16777216 bytes
[79.929000      -       159.858000]     74
[159.858000     -       239.787000]     10
[239.787000     -       319.716000]     1
[319.716000     -       399.645000]     3
[399.645000     -       479.574000]     2
[479.574000     -       559.503000]     0
[559.503000     -       639.432000]     2
[639.432000     -       719.361000]     1
[719.361000     -       799.290000]     2
[799.290000     -       879.219000]     2

closing gdrdrv
Total: 36, Passed: 31, Failed: 0, Waived: 5

List of waived tests:
    basic_v2_forcepci_cumemalloc
    basic_v2_forcepci_vmmalloc
    basic_with_tokens
    data_validation_mix_mappings_cumemalloc
    data_validation_v2_forcepci_cumemalloc
GPU id:0; name: Tesla T4; Bus id: 0000:00:1e
selecting device 0
We will measure the visibility of the flag value only. Setting nblocks and nthreads to 1.
Benchmark mode: CPU produces and GPU consumes
gpu alloc fn: cuMemAlloc
Measuring the visibility latency of the flag value.
Running 1000 iterations with flag size 4 bytes.

CPU writes to gpu_flag. GPU polls on the expected gpu_flag value. GPU writes back via cpu_flag. CPU polls on the expected cpu_flag value. We report the round-trip time from when CPU writes to gpu_flag until it observes the update in cpu_flag.
CPU does the time measurement.

Round-trip latency per iteration is (min) 0.9413, (median) 0.9447 us
closing gdrdrv
root@21418686cde5:~#
``` 

</details>

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
