### PR TITLE
twoliter: bump sdk to v0.76.0

### DIFF
--- a/Twoliter.lock
+++ b/Twoliter.lock
@@ -4,7 +4,7 @@ project-vendor = "Bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.75.0"
+version = "0.76.0"
 vendor = "bottlerocket"
-source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.75.0"
-digest = "7l4qkyh/nqq6Z+tq/4Bwh2EPba8BfsKfVlnnNwclWzM="
+source = "public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.76.0"
+digest = "9cSjjYDqIrlIjnOjLYbHGG5khRYA+wCek8I0BqP3sII="

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -7,5 +7,5 @@ registry = "public.ecr.aws/bottlerocket"
 
 [sdk]
 name = "bottlerocket-sdk"
-version = "0.75.0"
+version = "0.76.0"
 vendor = "bottlerocket"


### PR DESCRIPTION
**Description of changes:**
* Bump bottlerocket-sdk to v0.76.0

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
