### PR TITLE
Fix nvidia fallback services failing to start

### DIFF
--- a/packages/kmod-6.1-nvidia-r580/grid-license-check.service
+++ b/packages/kmod-6.1-nvidia-r580/grid-license-check.service
@@ -14,6 +14,3 @@ ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-licen
 ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
 ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 StandardOutput=append:/tmp/.nvidia-gridd-license
-
-[Install]
-WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
+++ b/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
@@ -188,6 +188,8 @@ tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
 
+%build
+
 # Begin open driver build
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 

--- a/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
+++ b/packages/kmod-6.1-nvidia-r580/kmod-6.1-nvidia-r580.spec
@@ -258,7 +258,7 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
-and .devid != "0x1DEB8"
+and .devid != "0x1EB8"
 and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes

--- a/packages/kmod-6.1-nvidia-r580/open-gpu-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r580/open-gpu-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.1-nvidia-r580/tesla-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r580/tesla-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.1-nvidia-r595/grid-license-check.service
+++ b/packages/kmod-6.1-nvidia-r595/grid-license-check.service
@@ -14,6 +14,3 @@ ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-licen
 ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
 ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 StandardOutput=append:/tmp/.nvidia-gridd-license
-
-[Install]
-WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.1-nvidia-r595/kmod-6.1-nvidia-r595.spec
+++ b/packages/kmod-6.1-nvidia-r595/kmod-6.1-nvidia-r595.spec
@@ -188,6 +188,8 @@ tar -xf %{_cross_datadir}/bottlerocket/kernel-devel.tar.xz
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
 
+%build
+
 # Begin open driver build
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 

--- a/packages/kmod-6.1-nvidia-r595/kmod-6.1-nvidia-r595.spec
+++ b/packages/kmod-6.1-nvidia-r595/kmod-6.1-nvidia-r595.spec
@@ -258,7 +258,7 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
-and .devid != "0x1DEB8"
+and .devid != "0x1EB8"
 and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes

--- a/packages/kmod-6.1-nvidia-r595/open-gpu-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r595/open-gpu-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.1-nvidia-r595/tesla-license-fallback.service
+++ b/packages/kmod-6.1-nvidia-r595/tesla-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.12-nvidia-r580/grid-license-check.service
+++ b/packages/kmod-6.12-nvidia-r580/grid-license-check.service
@@ -14,6 +14,3 @@ ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-licen
 ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
 ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 StandardOutput=append:/tmp/.nvidia-gridd-license
-
-[Install]
-WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -216,6 +216,8 @@ rpm2cpio %{_sourcedir}/nvidia-imex-%{tesla_ver}-1.amzn2023.%{_cross_arch}.rpm | 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
 
+%build
+
 # Begin open driver build
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 

--- a/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
+++ b/packages/kmod-6.12-nvidia-r580/kmod-6.12-nvidia-r580.spec
@@ -286,7 +286,7 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
-and .devid != "0x1DEB8"
+and .devid != "0x1EB8"
 and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes

--- a/packages/kmod-6.12-nvidia-r580/open-gpu-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r580/open-gpu-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.12-nvidia-r580/tesla-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r580/tesla-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.12-nvidia-r595/grid-license-check.service
+++ b/packages/kmod-6.12-nvidia-r595/grid-license-check.service
@@ -14,6 +14,3 @@ ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-licen
 ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
 ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 StandardOutput=append:/tmp/.nvidia-gridd-license
-
-[Install]
-WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.12-nvidia-r595/kmod-6.12-nvidia-r595.spec
+++ b/packages/kmod-6.12-nvidia-r595/kmod-6.12-nvidia-r595.spec
@@ -205,6 +205,8 @@ rpm2cpio %{_sourcedir}/nvidia-imex-%{tesla_ver}-1.amzn2023.%{_cross_arch}.rpm | 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
 
+%build
+
 # Begin open driver build
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 

--- a/packages/kmod-6.12-nvidia-r595/kmod-6.12-nvidia-r595.spec
+++ b/packages/kmod-6.12-nvidia-r595/kmod-6.12-nvidia-r595.spec
@@ -275,7 +275,7 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
-and .devid != "0x1DEB8"
+and .devid != "0x1EB8"
 and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes

--- a/packages/kmod-6.12-nvidia-r595/open-gpu-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r595/open-gpu-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.12-nvidia-r595/tesla-license-fallback.service
+++ b/packages/kmod-6.12-nvidia-r595/tesla-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.18-nvidia-r580/grid-license-check.service
+++ b/packages/kmod-6.18-nvidia-r580/grid-license-check.service
@@ -14,6 +14,3 @@ ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-licen
 ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
 ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 StandardOutput=append:/tmp/.nvidia-gridd-license
-
-[Install]
-WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
+++ b/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
@@ -216,6 +216,8 @@ rpm2cpio %{_sourcedir}/nvidia-imex-%{tesla_ver}-1.amzn2023.%{_cross_arch}.rpm | 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
 
+%build
+
 # Begin open driver build
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 

--- a/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
+++ b/packages/kmod-6.18-nvidia-r580/kmod-6.18-nvidia-r580.spec
@@ -286,7 +286,7 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
-and .devid != "0x1DEB8"
+and .devid != "0x1EB8"
 and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes

--- a/packages/kmod-6.18-nvidia-r580/open-gpu-license-fallback.service
+++ b/packages/kmod-6.18-nvidia-r580/open-gpu-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.18-nvidia-r580/tesla-license-fallback.service
+++ b/packages/kmod-6.18-nvidia-r580/tesla-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.18-nvidia-r595/grid-license-check.service
+++ b/packages/kmod-6.18-nvidia-r595/grid-license-check.service
@@ -14,6 +14,3 @@ ExecStart=/usr/bin/grep -q "License Status.*: Licensed" /tmp/.nvidia-gridd-licen
 ExecStart=/usr/bin/touch /etc/drivers/.grid-licensed
 ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 StandardOutput=append:/tmp/.nvidia-gridd-license
-
-[Install]
-WantedBy=nvidia-k8s-device-plugin.service

--- a/packages/kmod-6.18-nvidia-r595/kmod-6.18-nvidia-r595.spec
+++ b/packages/kmod-6.18-nvidia-r595/kmod-6.18-nvidia-r595.spec
@@ -205,6 +205,8 @@ rpm2cpio %{_sourcedir}/nvidia-imex-%{tesla_ver}-1.amzn2023.%{_cross_arch}.rpm | 
 # This recipe was based in the NVIDIA yum/dnf specs:
 # https://github.com/NVIDIA/yum-packaging-precompiled-kmod
 
+%build
+
 # Begin open driver build
 pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/kernel-open
 

--- a/packages/kmod-6.18-nvidia-r595/kmod-6.18-nvidia-r595.spec
+++ b/packages/kmod-6.18-nvidia-r595/kmod-6.18-nvidia-r595.spec
@@ -275,7 +275,7 @@ pushd NVIDIA-Linux-%{_cross_arch}-%{tesla_ver}/supported-gpus
 jq -r '.chips[] | select(.features[] | contains("kernelopen")) |
 select(.devid != "0x1DB1"
 and .devid != "0x1DB5"
-and .devid != "0x1DEB8"
+and .devid != "0x1EB8"
 and .devid != "0x1EB4"
 and .devid != "0x2237")' supported-gpus.json | jq -s '{"open-gpu": .}' > open-gpu-supported-devices.json
 # confirm "NVIDIA H100" is in the resulting file to catch shape changes

--- a/packages/kmod-6.18-nvidia-r595/open-gpu-license-fallback.service
+++ b/packages/kmod-6.18-nvidia-r595/open-gpu-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service

--- a/packages/kmod-6.18-nvidia-r595/tesla-license-fallback.service
+++ b/packages/kmod-6.18-nvidia-r595/tesla-license-fallback.service
@@ -11,4 +11,4 @@ ExecStart=/usr/bin/systemctl stop grid-license-check.timer --no-block
 RemainAfterExit=true
 
 [Install]
-WantedBy=nvidia-k8s-device-plugin.service
+WantedBy=nvidia-gridd.service


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Issue number:**

Closes https://github.com/bottlerocket-os/bottlerocket-kernel-kit/issues/464

The `open-gpu-license-fallback.service` and the `tesla-license-fallback.service` were set to start on `nvidia-k8s-device-plugin.service` and thus would not trigger on non-k8s variants. This caused the `grid-license-check.service` to never turn off, filling the journal log with spurious messages.

**Description of changes:**
- Add the `%build` sections to kmod-nvidia specfiles
- Fix type in DevID for `g4dn` instances causing the open driver to be loaded instead of the tesla driver. With this change, we are in-line with what the EKS optimized AMI does
- Change the dependency of the `open-gpu-license-fallback.service` and the `tesla-license-fallback.service` to depend on the `nvidia-gridd.service` which itself depends on `preconfigured.target` ensuring all are started on all variants.

**Testing done:**
- Build and test the a combination of ecs and k8s variants on the 6.1, 6.12, and 6.18 kernels with the 580 driver

- Testing for `g4dn.*` instances:
Before the change:
```bash
bash-5.2# nvidia-smi
Wed Jul  8 00:40:56 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.159.03             Driver Version: 580.159.03     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
| N/A   36C    P8              9W /   70W |       0MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
bash-5.2# modinfo nvidia
filename:       /lib/modules/6.18.30/kernel/drivers/extra/video/nvidia/open-gpu/nvidia.ko
import_ns:      DMA_BUF
alias:          char-major-195-*
description:    NVIDIA core GPU kernel module
version:        580.159.03
supported:      external
license:        Dual MIT/GPL    <------- Open Source Driver

bash-5.2# /usr/bin/ghostdog match-nvidia-driver tesla
Error: tesla is not preferred driver: open-gpu

bash-5.2# /usr/bin/ghostdog match-nvidia-driver grid
Error: grid is not preferred driver: open-gpu

bash-5.2# /usr/bin/ghostdog match-nvidia-driver open-gpu
bash-5.2#
```

After the change
```bash
bash-5.2# nvidia-smi
Wed Jul  8 00:36:59 2026
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.159.03             Driver Version: 580.159.03     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  Tesla T4                       On  |   00000000:00:1E.0 Off |                    0 |
| N/A   35C    P8             10W /   70W |       0MiB /  15360MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
bash-5.2# modinfo nvidia
filename:       /lib/modules/6.18.35/kernel/drivers/extra/video/nvidia/tesla/nvidia.ko
alias:          char-major-195-*
description:    NVIDIA core GPU kernel module
version:        580.159.03
supported:      external
license:        NVIDIA    <------- Proprietary Driver


bash-5.2# /usr/bin/ghostdog match-nvidia-driver tesla
bash-5.2# /usr/bin/ghostdog match-nvidia-driver grid
Error: grid is not preferred driver: tesla

bash-5.2# /usr/bin/ghostdog match-nvidia-driver open-gpu
Error: open-gpu is not preferred driver: tesla
```


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
