### PR TITLE
Include patches to fix use-after-free in epoll for kernel 6.12

### DIFF
--- a/packages/kernel-6.12/1011-eventpoll-split-__ep_remove.patch
+++ b/packages/kernel-6.12/1011-eventpoll-split-__ep_remove.patch
@@ -1,0 +1,84 @@
+From 9006ec190b43983e2573444ff34fcd99c7b4693b Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Thu, 23 Apr 2026 11:56:05 +0200
+Subject: [PATCH] eventpoll: split __ep_remove()
+
+[ Upstream commit 0f7bdfd413000985de09fc39eb9efa1e091a3ce0 ]
+
+Split __ep_remove() to delineate file removal from epoll item removal.
+
+Suggested-by: Linus Torvalds <torvalds@linux-foundation.org>
+Link: https://patch.msgid.link/20260423-work-epoll-uaf-v1-2-2470f9eec0f5@kernel.org
+Signed-off-by: Christian Brauner (Amutable) <brauner@kernel.org>
+[ squash 3d9fd0a ("eventpoll: use hlist_is_singular_node() in
+__ep_remove()") in to fix diff in context lines ]
+Signed-off-by: Mark Bundschuh <mkbund@amazon.com>
+(cherry picked from commit e6c9db1c4d1bb7efe4c04451fb848b4c8bb393be)
+---
+ fs/eventpoll.c | 29 ++++++++++++++++++++++++-----
+ 1 file changed, 24 insertions(+), 5 deletions(-)
+
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index a860cb54658a3..1cba4ae4a076b 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -797,6 +797,9 @@ static void ep_free(struct eventpoll *ep)
+ 	kfree_rcu(ep, rcu);
+ }
+ 
++static void __ep_remove_file(struct eventpoll *ep, struct epitem *epi, struct file *file);
++static bool __ep_remove_epi(struct eventpoll *ep, struct epitem *epi);
++
+ /*
+  * Removes a "struct epitem" from the eventpoll RB tree and deallocates
+  * all the associated resources. Must be called with "mtx" held.
+@@ -808,8 +811,6 @@ static void ep_free(struct eventpoll *ep)
+ static bool __ep_remove(struct eventpoll *ep, struct epitem *epi, bool force)
+ {
+ 	struct file *file = epi->ffd.file;
+-	struct epitems_head *to_free;
+-	struct hlist_head *head;
+ 
+ 	lockdep_assert_irqs_enabled();
+ 
+@@ -825,9 +826,22 @@ static bool __ep_remove(struct eventpoll *ep, struct epitem *epi, bool force)
+ 		return false;
+ 	}
+ 
+-	to_free = NULL;
+-	head = file->f_ep;
+-	if (head->first == &epi->fllink && !epi->fllink.next) {
++	__ep_remove_file(ep, epi, file);
++	return __ep_remove_epi(ep, epi);
++}
++
++/*
++ * Called with &file->f_lock held,
++ * returns with it released
++ */
++static void __ep_remove_file(struct eventpoll *ep, struct epitem *epi, struct file *file)
++{
++	struct epitems_head *to_free = NULL;
++	struct hlist_head *head = file->f_ep;
++
++	lockdep_assert_held(&ep->mtx);
++
++	if (hlist_is_singular_node(&epi->fllink, head)) {
+ 		/* See eventpoll_release() for details. */
+ 		WRITE_ONCE(file->f_ep, NULL);
+ 		if (!is_file_epoll(file)) {
+@@ -840,6 +854,11 @@ static bool __ep_remove(struct eventpoll *ep, struct epitem *epi, bool force)
+ 	hlist_del_rcu(&epi->fllink);
+ 	spin_unlock(&file->f_lock);
+ 	free_ephead(to_free);
++}
++
++static bool __ep_remove_epi(struct eventpoll *ep, struct epitem *epi)
++{
++	lockdep_assert_held(&ep->mtx);
+ 
+ 	rb_erase_cached(&epi->rbn, &ep->rbr);
+ 
+-- 
+2.52.0
+

--- a/packages/kernel-6.12/1012-eventpoll-kill-__ep_remove.patch
+++ b/packages/kernel-6.12/1012-eventpoll-kill-__ep_remove.patch
@@ -1,0 +1,130 @@
+From 13405a0ac586f3bb7b1375d953fc2a5ae7d40c92 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Thu, 23 Apr 2026 11:56:06 +0200
+Subject: [PATCH] eventpoll: kill __ep_remove()
+
+[ Upstream commit e9e5cd40d7c403e19f21d0f7b8b8ba3a76b58330 ]
+
+Remove the boolean conditional in __ep_remove() and restructure the code
+so the check for racing with eventpoll_release_file() are only done in
+the ep_remove_safe() path where they belong.
+
+Link: https://patch.msgid.link/20260423-work-epoll-uaf-v1-3-2470f9eec0f5@kernel.org
+Signed-off-by: Christian Brauner (Amutable) <brauner@kernel.org>
+Signed-off-by: Mark Bundschuh <mkbund@amazon.com>
+(cherry picked from commit 0f255709c784937c4d9d6f42b7af30c1cff1542b)
+---
+ fs/eventpoll.c | 67 ++++++++++++++++++++++----------------------------
+ 1 file changed, 30 insertions(+), 37 deletions(-)
+
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index 1cba4ae4a076b..3ac8a26c3522f 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -797,49 +797,18 @@ static void ep_free(struct eventpoll *ep)
+ 	kfree_rcu(ep, rcu);
+ }
+ 
+-static void __ep_remove_file(struct eventpoll *ep, struct epitem *epi, struct file *file);
+-static bool __ep_remove_epi(struct eventpoll *ep, struct epitem *epi);
+-
+-/*
+- * Removes a "struct epitem" from the eventpoll RB tree and deallocates
+- * all the associated resources. Must be called with "mtx" held.
+- * If the dying flag is set, do the removal only if force is true.
+- * This prevents ep_clear_and_put() from dropping all the ep references
+- * while running concurrently with eventpoll_release_file().
+- * Returns true if the eventpoll can be disposed.
+- */
+-static bool __ep_remove(struct eventpoll *ep, struct epitem *epi, bool force)
+-{
+-	struct file *file = epi->ffd.file;
+-
+-	lockdep_assert_irqs_enabled();
+-
+-	/*
+-	 * Removes poll wait queue hooks.
+-	 */
+-	ep_unregister_pollwait(ep, epi);
+-
+-	/* Remove the current item from the list of epoll hooks */
+-	spin_lock(&file->f_lock);
+-	if (epi->dying && !force) {
+-		spin_unlock(&file->f_lock);
+-		return false;
+-	}
+-
+-	__ep_remove_file(ep, epi, file);
+-	return __ep_remove_epi(ep, epi);
+-}
+-
+ /*
+  * Called with &file->f_lock held,
+  * returns with it released
+  */
+-static void __ep_remove_file(struct eventpoll *ep, struct epitem *epi, struct file *file)
++static void __ep_remove_file(struct eventpoll *ep, struct epitem *epi,
++			     struct file *file)
+ {
+ 	struct epitems_head *to_free = NULL;
+ 	struct hlist_head *head = file->f_ep;
+ 
+ 	lockdep_assert_held(&ep->mtx);
++	lockdep_assert_held(&file->f_lock);
+ 
+ 	if (hlist_is_singular_node(&epi->fllink, head)) {
+ 		/* See eventpoll_release() for details. */
+@@ -886,7 +855,25 @@ static bool __ep_remove_epi(struct eventpoll *ep, struct epitem *epi)
+  */
+ static void ep_remove_safe(struct eventpoll *ep, struct epitem *epi)
+ {
+-	if (__ep_remove(ep, epi, false))
++	struct file *file = epi->ffd.file;
++
++	lockdep_assert_irqs_enabled();
++	lockdep_assert_held(&ep->mtx);
++
++	ep_unregister_pollwait(ep, epi);
++
++	/* sync with eventpoll_release_file() */
++	if (unlikely(READ_ONCE(epi->dying)))
++		return;
++
++	spin_lock(&file->f_lock);
++	if (epi->dying) {
++		spin_unlock(&file->f_lock);
++		return;
++	}
++	__ep_remove_file(ep, epi, file);
++
++	if (__ep_remove_epi(ep, epi))
+ 		WARN_ON_ONCE(ep_refcount_dec_and_test(ep));
+ }
+ 
+@@ -1118,7 +1105,7 @@ void eventpoll_release_file(struct file *file)
+ 	spin_lock(&file->f_lock);
+ 	if (file->f_ep && file->f_ep->first) {
+ 		epi = hlist_entry(file->f_ep->first, struct epitem, fllink);
+-		epi->dying = true;
++		WRITE_ONCE(epi->dying, true);
+ 		spin_unlock(&file->f_lock);
+ 
+ 		/*
+@@ -1127,7 +1114,13 @@ void eventpoll_release_file(struct file *file)
+ 		 */
+ 		ep = epi->ep;
+ 		mutex_lock(&ep->mtx);
+-		dispose = __ep_remove(ep, epi, true);
++
++		ep_unregister_pollwait(ep, epi);
++
++		spin_lock(&file->f_lock);
++		__ep_remove_file(ep, epi, file);
++		dispose = __ep_remove_epi(ep, epi);
++
+ 		mutex_unlock(&ep->mtx);
+ 
+ 		if (dispose && ep_refcount_dec_and_test(ep))
+-- 
+2.52.0
+

--- a/packages/kernel-6.12/1013-eventpoll-move-epi_fget-up.patch
+++ b/packages/kernel-6.12/1013-eventpoll-move-epi_fget-up.patch
@@ -1,0 +1,98 @@
+From acb6b5f001ed053e1d66df425753089ab02092bd Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Thu, 23 Apr 2026 11:56:08 +0200
+Subject: [PATCH] eventpoll: move epi_fget() up
+
+[ Upstream commit 86e87059e6d1fd5115a31949726450ed03c1073b ]
+
+We'll need it when removing files so move it up. No functional change.
+
+Link: https://patch.msgid.link/20260423-work-epoll-uaf-v1-5-2470f9eec0f5@kernel.org
+Signed-off-by: Christian Brauner (Amutable) <brauner@kernel.org>
+[ Kept epi_fget() using atomic_long_inc_not_zero(&file->f_count) instead
+  of the upstream file_ref_get(&file->f_ref): 6.12 has not ported struct
+  file to file_ref (commit 90ee6ed776c0 "fs: port files to file_ref" is
+  absent). No functional change relative to the existing 6.12 epi_fget(). ]
+Signed-off-by: Mark Bundschuh <mkbund@amazon.com>
+(cherry picked from commit e0a83603948ff3d2b55bd06d63259a577f95d4f3)
+---
+ fs/eventpoll.c | 56 +++++++++++++++++++++++++-------------------------
+ 1 file changed, 28 insertions(+), 28 deletions(-)
+
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index 3ac8a26c3522f..86f5cbc8a7d61 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -797,6 +797,34 @@ static void ep_free(struct eventpoll *ep)
+ 	kfree_rcu(ep, rcu);
+ }
+ 
++/*
++ * The ffd.file pointer may be in the process of being torn down due to
++ * being closed, but we may not have finished eventpoll_release() yet.
++ *
++ * Normally, even with the atomic_long_inc_not_zero, the file may have
++ * been free'd and then gotten re-allocated to something else (since
++ * files are not RCU-delayed, they are SLAB_TYPESAFE_BY_RCU).
++ *
++ * But for epoll, users hold the ep->mtx mutex, and as such any file in
++ * the process of being free'd will block in eventpoll_release_file()
++ * and thus the underlying file allocation will not be free'd, and the
++ * file re-use cannot happen.
++ *
++ * For the same reason we can avoid a rcu_read_lock() around the
++ * operation - 'ffd.file' cannot go away even if the refcount has
++ * reached zero (but we must still not call out to ->poll() functions
++ * etc).
++ */
++static struct file *epi_fget(const struct epitem *epi)
++{
++	struct file *file;
++
++	file = epi->ffd.file;
++	if (!atomic_long_inc_not_zero(&file->f_count))
++		file = NULL;
++	return file;
++}
++
+ /*
+  * Called with &file->f_lock held,
+  * returns with it released
+@@ -989,34 +1017,6 @@ static __poll_t __ep_eventpoll_poll(struct file *file, poll_table *wait, int dep
+ 	return res;
+ }
+ 
+-/*
+- * The ffd.file pointer may be in the process of being torn down due to
+- * being closed, but we may not have finished eventpoll_release() yet.
+- *
+- * Normally, even with the atomic_long_inc_not_zero, the file may have
+- * been free'd and then gotten re-allocated to something else (since
+- * files are not RCU-delayed, they are SLAB_TYPESAFE_BY_RCU).
+- *
+- * But for epoll, users hold the ep->mtx mutex, and as such any file in
+- * the process of being free'd will block in eventpoll_release_file()
+- * and thus the underlying file allocation will not be free'd, and the
+- * file re-use cannot happen.
+- *
+- * For the same reason we can avoid a rcu_read_lock() around the
+- * operation - 'ffd.file' cannot go away even if the refcount has
+- * reached zero (but we must still not call out to ->poll() functions
+- * etc).
+- */
+-static struct file *epi_fget(const struct epitem *epi)
+-{
+-	struct file *file;
+-
+-	file = epi->ffd.file;
+-	if (!atomic_long_inc_not_zero(&file->f_count))
+-		file = NULL;
+-	return file;
+-}
+-
+ /*
+  * Differs from ep_eventpoll_poll() in that internal callers already have
+  * the ep->mtx so we need to start from depth=1, such that mutex_lock_nested()
+-- 
+2.52.0
+

--- a/packages/kernel-6.12/1014-eventpoll-fix-ep_remove-struct-eventpoll-struct-file.patch
+++ b/packages/kernel-6.12/1014-eventpoll-fix-ep_remove-struct-eventpoll-struct-file.patch
@@ -1,0 +1,103 @@
+From 8e1e13aec8cfa1c7f3cfd76b4b8905bca8cb6d42 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Thu, 23 Apr 2026 11:56:09 +0200
+Subject: [PATCH] eventpoll: fix ep_remove struct eventpoll / struct file UAF
+
+[ Upstream commit a6dc643c69311677c574a0f17a3f4d66a5f3744b ]
+
+ep_remove() (via ep_remove_file()) cleared file->f_ep under
+file->f_lock but then kept using @file inside the critical section
+(is_file_epoll(), hlist_del_rcu() through the head, spin_unlock).
+A concurrent __fput() taking the eventpoll_release() fastpath in
+that window observed the transient NULL, skipped
+eventpoll_release_file() and ran to f_op->release / file_free().
+
+For the epoll-watches-epoll case, f_op->release is
+ep_eventpoll_release() -> ep_clear_and_put() -> ep_free(), which
+kfree()s the watched struct eventpoll. Its embedded ->refs
+hlist_head is exactly where epi->fllink.pprev points, so the
+subsequent hlist_del_rcu()'s "*pprev = next" scribbles into freed
+kmalloc-192 memory.
+
+In addition, struct file is SLAB_TYPESAFE_BY_RCU, so the slot
+backing @file could be recycled by alloc_empty_file() --
+reinitializing f_lock and f_ep -- while ep_remove() is still
+nominally inside that lock. The upshot is an attacker-controllable
+kmem_cache_free() against the wrong slab cache.
+
+Pin @file via epi_fget() at the top of ep_remove() and gate the
+critical section on the pin succeeding. With the pin held @file
+cannot reach refcount zero, which holds __fput() off and
+transitively keeps the watched struct eventpoll alive across the
+hlist_del_rcu() and the f_lock use, closing both UAFs.
+
+If the pin fails @file has already reached refcount zero and its
+__fput() is in flight. Because we bailed before clearing f_ep,
+that path takes the eventpoll_release() slow path into
+eventpoll_release_file() and blocks on ep->mtx until the waiter
+side's ep_clear_and_put() drops it. The bailed epi's share of
+ep->refcount stays intact, so the trailing ep_refcount_dec_and_test()
+in ep_clear_and_put() cannot free the eventpoll out from under
+eventpoll_release_file(); the orphaned epi is then cleaned up
+there.
+
+A successful pin also proves we are not racing
+eventpoll_release_file() on this epi, so drop the now-redundant
+re-check of epi->dying under f_lock. The cheap lockless
+READ_ONCE(epi->dying) fast-path bailout stays.
+
+Fixes: 58c9b016e128 ("epoll: use refcount to reduce ep_mutex contention")
+Reported-by: Jaeyoung Chung <jjy600901@snu.ac.kr>
+Link: https://patch.msgid.link/20260423-work-epoll-uaf-v1-6-2470f9eec0f5@kernel.org
+Signed-off-by: Christian Brauner (Amutable) <brauner@kernel.org>
+[ change context lines: use __ep_remove_file instead of
+ep_remove_file since 0feaf64 ("eventpoll: drop vestigial __ prefix
+from ep_remove_{file,epi}()") hasn't landed yet, similarly keep
+ep_remove_safe instead of ep_remove since 0bade23 ("eventpoll: rename
+ep_remove_safe() back to ep_remove()") hasn't landed yet ]
+Signed-off-by: Mark Bundschuh <mkbund@amazon.com>
+(cherry picked from commit 735677721062287b94dc72fcd38d1ed2e53cf9ea)
+---
+ fs/eventpoll.c | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/fs/eventpoll.c b/fs/eventpoll.c
+index 86f5cbc8a7d61..0d68799422d18 100644
+--- a/fs/eventpoll.c
++++ b/fs/eventpoll.c
+@@ -883,22 +883,26 @@ static bool __ep_remove_epi(struct eventpoll *ep, struct epitem *epi)
+  */
+ static void ep_remove_safe(struct eventpoll *ep, struct epitem *epi)
+ {
+-	struct file *file = epi->ffd.file;
++	struct file *file __free(fput) = NULL;
+ 
+ 	lockdep_assert_irqs_enabled();
+ 	lockdep_assert_held(&ep->mtx);
+ 
+ 	ep_unregister_pollwait(ep, epi);
+ 
+-	/* sync with eventpoll_release_file() */
++	/* cheap sync with eventpoll_release_file() */
+ 	if (unlikely(READ_ONCE(epi->dying)))
+ 		return;
+ 
+-	spin_lock(&file->f_lock);
+-	if (epi->dying) {
+-		spin_unlock(&file->f_lock);
++	/*
++	 * If we manage to grab a reference it means we're not in
++	 * eventpoll_release_file() and aren't going to be.
++	 */
++	file = epi_fget(epi);
++	if (!file)
+ 		return;
+-	}
++
++	spin_lock(&file->f_lock);
+ 	__ep_remove_file(ep, epi, file);
+ 
+ 	if (__ep_remove_epi(ep, epi))
+-- 
+2.52.0
+

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -53,6 +53,11 @@ Patch1008: 1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 # Fix undersized linear allocation in IPv* paged path
 Patch1009: 1009-ipv6-account-for-fraggap-on-the-paged-allocation-pat.patch
 Patch1010: 1010-ipv4-account-for-fraggap-on-the-paged-allocation-pat.patch
+# Fix use-after-free race in eventpoll file removal path
+Patch1011: 1011-eventpoll-split-__ep_remove.patch
+Patch1012: 1012-eventpoll-kill-__ep_remove.patch
+Patch1013: 1013-eventpoll-move-epi_fget-up.patch
+Patch1014: 1014-eventpoll-fix-ep_remove-struct-eventpoll-struct-file.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Description of changes:**

Include Amazon Linux kernel's patches to fix a use-after-free bug in `epoll`.

Commits:

https://github.com/amazonlinux/linux/commit/e6c9db1c4d1bb7efe4c04451fb848b4c8bb393be
https://github.com/amazonlinux/linux/commit/0f255709c784937c4d9d6f42b7af30c1cff1542b
https://github.com/amazonlinux/linux/commit/e0a83603948ff3d2b55bd06d63259a577f95d4f3
https://github.com/amazonlinux/linux/commit/735677721062287b94dc72fcd38d1ed2e53cf9ea


**Testing done:**

Kernel builds and boots.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
