### PR TITLE
ENA Driver update and patch to drop NULL pointer deref in self-deadlock for kernels

### DIFF
--- a/packages/kernel-6.1/1008-AL2023-6.1-Update-ena-driver-to-2.17.2g.patch
+++ b/packages/kernel-6.1/1008-AL2023-6.1-Update-ena-driver-to-2.17.2g.patch
@@ -1,0 +1,76 @@
+From b9d9a3867cda14f1e4f58ef8bc31a12ab2eb3d0c Mon Sep 17 00:00:00 2001
+From: David Arinzon <darinzon@amazon.com>
+Date: Wed, 8 Jul 2026 14:35:41 +0000
+Subject: [PATCH] AL2023-6.1-Update-ena-driver-to-2.17.2g
+
+Signed-off-by: David Arinzon <darinzon@amazon.com>
+---
+ drivers/amazon/net/ena/Makefile     | 2 +-
+ drivers/amazon/net/ena/ena_netdev.c | 8 ++++----
+ drivers/amazon/net/ena/ena_netdev.h | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/amazon/net/ena/Makefile b/drivers/amazon/net/ena/Makefile
+index 606764d..f65b613 100644
+--- a/drivers/amazon/net/ena/Makefile
++++ b/drivers/amazon/net/ena/Makefile
+@@ -1,7 +1,7 @@
+ #
+ # Makefile for the Elastic Network Adapter (ENA) device drivers.
+ # ENA Source is: https://github.com/amzn/amzn-drivers.
+-# Current ENA source is based on ena_linux_2.17.0 tag.
++# Current ENA source is based on ena_linux_2.17.2 tag.
+ #
+ 
+ obj-$(CONFIG_AMAZON_ENA_ETHERNET) += ena.o
+diff --git a/drivers/amazon/net/ena/ena_netdev.c b/drivers/amazon/net/ena/ena_netdev.c
+index 4a589e8..7827126 100644
+--- a/drivers/amazon/net/ena/ena_netdev.c
++++ b/drivers/amazon/net/ena/ena_netdev.c
+@@ -5858,6 +5858,9 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 	ena_devlink_unregister(adapter->devlink);
+ 	ena_devlink_free(adapter->devlink);
+ 
++	ena_reset_reason_info_free(adapter);
++	ena_free_stats_buffers(adapter);
++
+ 	if (shutdown) {
+ 		netif_device_detach(netdev);
+ 		dev_close(netdev);
+@@ -5865,6 +5868,7 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 	} else {
+ 		rtnl_unlock();
+ 		unregister_netdev(netdev);
++		/* No access to adapter and netdev after this point */
+ 		free_netdev(netdev);
+ 	}
+ 
+@@ -5872,12 +5876,8 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 
+ 	ena_com_flow_steering_destroy(ena_dev);
+ 
+-	ena_reset_reason_info_free(adapter);
+-
+ 	ena_com_delete_debug_area(ena_dev);
+ 
+-	ena_free_stats_buffers(adapter);
+-
+ 	ena_com_delete_host_info(ena_dev);
+ 
+ 	ena_com_delete_customer_metrics_buffer(ena_dev);
+diff --git a/drivers/amazon/net/ena/ena_netdev.h b/drivers/amazon/net/ena/ena_netdev.h
+index da59195..333aea1 100644
+--- a/drivers/amazon/net/ena/ena_netdev.h
++++ b/drivers/amazon/net/ena/ena_netdev.h
+@@ -40,7 +40,7 @@
+ 
+ #define DRV_MODULE_GEN_MAJOR	2
+ #define DRV_MODULE_GEN_MINOR	17
+-#define DRV_MODULE_GEN_SUBMINOR	1
++#define DRV_MODULE_GEN_SUBMINOR	2
+ 
+ #define DRV_MODULE_NAME		"ena"
+ #ifndef DRV_MODULE_GENERATION
+-- 
+2.50.1
+

--- a/packages/kernel-6.1/1009-Revert-futex-requeue-Prevent-NULL-pointer-dereferenc.patch
+++ b/packages/kernel-6.1/1009-Revert-futex-requeue-Prevent-NULL-pointer-dereferenc.patch
@@ -1,0 +1,33 @@
+From d5cc0433591558f86e36a9bc3abd15ae9b991c73 Mon Sep 17 00:00:00 2001
+From: Piyush Jena <jepiyush@amazon.com>
+Date: Thu, 9 Jul 2026 23:27:09 +0000
+Subject: [PATCH] Revert "futex/requeue: Prevent NULL pointer dereference in
+ remove_waiter() on self-deadlock"
+
+This reverts commit b7b1013b729154502c30c22c71ab025e1edd89d0.
+
+Signed-off-by: Piyush Jena <jepiyush@amazon.com>
+---
+ kernel/futex/requeue.c | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/kernel/futex/requeue.c b/kernel/futex/requeue.c
+index 8cf1234be..60b08247b 100644
+--- a/kernel/futex/requeue.c
++++ b/kernel/futex/requeue.c
+@@ -629,12 +629,6 @@ int futex_requeue(u32 __user *uaddr1, unsigned int flags, u32 __user *uaddr2,
+ 			continue;
+ 		}
+ 
+-		/* Self-deadlock: non-top waiter already owns the PI futex. */
+-		if (rt_mutex_owner(&pi_state->pi_mutex) == this->task) {
+-			ret = -EDEADLK;
+-			break;
+-		}
+-
+ 		ret = rt_mutex_start_proxy_lock(&pi_state->pi_mutex,
+ 						this->rt_waiter,
+ 						this->task);
+-- 
+2.52.0
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -49,6 +49,7 @@ Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1007: 1007-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 Patch1008: 1008-AL2023-6.1-Update-ena-driver-to-2.17.2g.patch
+Patch1009: 1009-Revert-futex-requeue-Prevent-NULL-pointer-dereferenc.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -48,6 +48,7 @@ Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1007: 1007-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+Patch1008: 1008-AL2023-6.1-Update-ena-driver-to-2.17.2g.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.12/1009-AL2023-6.12-Update-ena-driver-to-2.17.2g.patch
+++ b/packages/kernel-6.12/1009-AL2023-6.12-Update-ena-driver-to-2.17.2g.patch
@@ -1,0 +1,76 @@
+From 3f1d4ba7efeec7fa6d5fdb83c66f9632ab317a1e Mon Sep 17 00:00:00 2001
+From: David Arinzon <darinzon@amazon.com>
+Date: Wed, 8 Jul 2026 14:36:02 +0000
+Subject: [PATCH] AL2023-6.12-Update-ena-driver-to-2.17.2g
+
+Signed-off-by: David Arinzon <darinzon@amazon.com>
+---
+ drivers/amazon/net/ena/Makefile     | 2 +-
+ drivers/amazon/net/ena/ena_netdev.c | 8 ++++----
+ drivers/amazon/net/ena/ena_netdev.h | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/amazon/net/ena/Makefile b/drivers/amazon/net/ena/Makefile
+index 877a906..1e48bea 100644
+--- a/drivers/amazon/net/ena/Makefile
++++ b/drivers/amazon/net/ena/Makefile
+@@ -1,7 +1,7 @@
+ #
+ # Makefile for the Elastic Network Adapter (ENA) device drivers.
+ # ENA Source is: https://github.com/amzn/amzn-drivers.
+-# Current ENA source is based on ena_linux_2.17.0 tag.
++# Current ENA source is based on ena_linux_2.17.2 tag.
+ #
+ 
+ obj-$(CONFIG_AMAZON_ENA_ETHERNET) += ena.o
+diff --git a/drivers/amazon/net/ena/ena_netdev.c b/drivers/amazon/net/ena/ena_netdev.c
+index 4a589e8..7827126 100644
+--- a/drivers/amazon/net/ena/ena_netdev.c
++++ b/drivers/amazon/net/ena/ena_netdev.c
+@@ -5858,6 +5858,9 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 	ena_devlink_unregister(adapter->devlink);
+ 	ena_devlink_free(adapter->devlink);
+ 
++	ena_reset_reason_info_free(adapter);
++	ena_free_stats_buffers(adapter);
++
+ 	if (shutdown) {
+ 		netif_device_detach(netdev);
+ 		dev_close(netdev);
+@@ -5865,6 +5868,7 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 	} else {
+ 		rtnl_unlock();
+ 		unregister_netdev(netdev);
++		/* No access to adapter and netdev after this point */
+ 		free_netdev(netdev);
+ 	}
+ 
+@@ -5872,12 +5876,8 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 
+ 	ena_com_flow_steering_destroy(ena_dev);
+ 
+-	ena_reset_reason_info_free(adapter);
+-
+ 	ena_com_delete_debug_area(ena_dev);
+ 
+-	ena_free_stats_buffers(adapter);
+-
+ 	ena_com_delete_host_info(ena_dev);
+ 
+ 	ena_com_delete_customer_metrics_buffer(ena_dev);
+diff --git a/drivers/amazon/net/ena/ena_netdev.h b/drivers/amazon/net/ena/ena_netdev.h
+index da59195..333aea1 100644
+--- a/drivers/amazon/net/ena/ena_netdev.h
++++ b/drivers/amazon/net/ena/ena_netdev.h
+@@ -40,7 +40,7 @@
+ 
+ #define DRV_MODULE_GEN_MAJOR	2
+ #define DRV_MODULE_GEN_MINOR	17
+-#define DRV_MODULE_GEN_SUBMINOR	1
++#define DRV_MODULE_GEN_SUBMINOR	2
+ 
+ #define DRV_MODULE_NAME		"ena"
+ #ifndef DRV_MODULE_GENERATION
+-- 
+2.50.1
+

--- a/packages/kernel-6.12/1010-locking-mutex-Remove-wakeups-from-under-mutex-wait_l.patch
+++ b/packages/kernel-6.12/1010-locking-mutex-Remove-wakeups-from-under-mutex-wait_l.patch
@@ -1,0 +1,543 @@
+From: Peter Zijlstra <peterz@infradead.org>
+Date: Tue, 16 Jun 2026 15:06:00 -0400
+Subject: locking/mutex: Remove wakeups from under mutex::wait_lock
+
+[ Upstream commit 894d1b3db41cf7e6ae0304429a1747b3c3f390bc ]
+
+In preparation to nest mutex::wait_lock under rq::lock we need
+to remove wakeups from under it.
+
+Do this by utilizing wake_qs to defer the wakeup until after the
+lock is dropped.
+
+[Heavily changed after 55f036ca7e74 ("locking: WW mutex cleanup") and
+08295b3b5bee ("locking: Implement an algorithm choice for Wound-Wait
+mutexes")]
+[jstultz: rebased to mainline, added extra wake_up_q & init
+ to avoid hangs, similar to Connor's rework of this patch]
+
+Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Signed-off-by: Juri Lelli <juri.lelli@redhat.com>
+Signed-off-by: John Stultz <jstultz@google.com>
+Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Reviewed-by: Metin Kaya <metin.kaya@arm.com>
+Acked-by: Davidlohr Bueso <dave@stgolabs.net>
+Tested-by: K Prateek Nayak <kprateek.nayak@amd.com>
+Tested-by: Metin Kaya <metin.kaya@arm.com>
+Link: https://lore.kernel.org/r/20241009235352.1614323-2-jstultz@google.com
+Stable-dep-of: 40a25d59e85b ("locking/rtmutex: Skip remove_waiter() when waiter is not enqueued")
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Hazem Mohamed Abuelfotoh <abuehaze@amazon.com>
+
+diff --git a/kernel/futex/pi.c b/kernel/futex/pi.c
+--- a/kernel/futex/pi.c
++++ b/kernel/futex/pi.c
+@@ -922,6 +922,7 @@ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int tryl
+ 	struct rt_mutex_waiter rt_waiter;
+ 	struct futex_hash_bucket *hb;
+ 	struct futex_q q = futex_q_init;
++	DEFINE_WAKE_Q(wake_q);
+ 	int res, ret;
+ 
+ 	if (!IS_ENABLED(CONFIG_FUTEX_PI))
+@@ -1019,8 +1020,11 @@ int futex_lock_pi(u32 __user *uaddr, unsigned int flags, ktime_t *time, int tryl
+ 	 * such that futex_unlock_pi() is guaranteed to observe the waiter when
+ 	 * it sees the futex_q::pi_state.
+ 	 */
+-	ret = __rt_mutex_start_proxy_lock(&q.pi_state->pi_mutex, &rt_waiter, current);
++	ret = __rt_mutex_start_proxy_lock(&q.pi_state->pi_mutex, &rt_waiter, current, &wake_q);
++	preempt_disable();
+ 	raw_spin_unlock_irq(&q.pi_state->pi_mutex.wait_lock);
++	wake_up_q(&wake_q);
++	preempt_enable();
+ 
+ 	if (ret) {
+ 		if (ret == 1)
+diff --git a/kernel/locking/mutex.c b/kernel/locking/mutex.c
+--- a/kernel/locking/mutex.c
++++ b/kernel/locking/mutex.c
+@@ -575,6 +575,7 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 		    struct lockdep_map *nest_lock, unsigned long ip,
+ 		    struct ww_acquire_ctx *ww_ctx, const bool use_ww_ctx)
+ {
++	DEFINE_WAKE_Q(wake_q);
+ 	struct mutex_waiter waiter;
+ 	struct ww_mutex *ww;
+ 	int ret;
+@@ -625,7 +626,7 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 	 */
+ 	if (__mutex_trylock(lock)) {
+ 		if (ww_ctx)
+-			__ww_mutex_check_waiters(lock, ww_ctx);
++			__ww_mutex_check_waiters(lock, ww_ctx, &wake_q);
+ 
+ 		goto skip_wait;
+ 	}
+@@ -645,7 +646,7 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 		 * Add in stamp order, waking up waiters that must kill
+ 		 * themselves.
+ 		 */
+-		ret = __ww_mutex_add_waiter(&waiter, lock, ww_ctx);
++		ret = __ww_mutex_add_waiter(&waiter, lock, ww_ctx, &wake_q);
+ 		if (ret)
+ 			goto err_early_kill;
+ 	}
+@@ -681,6 +682,10 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 		}
+ 
+ 		raw_spin_unlock(&lock->wait_lock);
++		/* Make sure we do wakeups before calling schedule */
++		wake_up_q(&wake_q);
++		wake_q_init(&wake_q);
++
+ 		schedule_preempt_disabled();
+ 
+ 		first = __mutex_waiter_is_first(lock, &waiter);
+@@ -714,7 +719,7 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 		 */
+ 		if (!ww_ctx->is_wait_die &&
+ 		    !__mutex_waiter_is_first(lock, &waiter))
+-			__ww_mutex_check_waiters(lock, ww_ctx);
++			__ww_mutex_check_waiters(lock, ww_ctx, &wake_q);
+ 	}
+ 
+ 	__mutex_remove_waiter(lock, &waiter);
+@@ -730,6 +735,7 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 		ww_mutex_lock_acquired(ww, ww_ctx);
+ 
+ 	raw_spin_unlock(&lock->wait_lock);
++	wake_up_q(&wake_q);
+ 	preempt_enable();
+ 	return 0;
+ 
+@@ -741,6 +747,7 @@ __mutex_lock_common(struct mutex *lock, unsigned int state, unsigned int subclas
+ 	raw_spin_unlock(&lock->wait_lock);
+ 	debug_mutex_free_waiter(&waiter);
+ 	mutex_release(&lock->dep_map, ip);
++	wake_up_q(&wake_q);
+ 	preempt_enable();
+ 	return ret;
+ }
+@@ -951,9 +958,10 @@ static noinline void __sched __mutex_unlock_slowpath(struct mutex *lock, unsigne
+ 	if (owner & MUTEX_FLAG_HANDOFF)
+ 		__mutex_handoff(lock, next);
+ 
++	preempt_disable();
+ 	raw_spin_unlock(&lock->wait_lock);
+-
+ 	wake_up_q(&wake_q);
++	preempt_enable();
+ }
+ 
+ #ifndef CONFIG_DEBUG_LOCK_ALLOC
+diff --git a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -34,13 +34,15 @@
+ 
+ static inline int __ww_mutex_add_waiter(struct rt_mutex_waiter *waiter,
+ 					struct rt_mutex *lock,
+-					struct ww_acquire_ctx *ww_ctx)
++					struct ww_acquire_ctx *ww_ctx,
++					struct wake_q_head *wake_q)
+ {
+ 	return 0;
+ }
+ 
+ static inline void __ww_mutex_check_waiters(struct rt_mutex *lock,
+-					    struct ww_acquire_ctx *ww_ctx)
++					    struct ww_acquire_ctx *ww_ctx,
++					    struct wake_q_head *wake_q)
+ {
+ }
+ 
+@@ -1201,7 +1203,8 @@ static int __sched task_blocks_on_rt_mutex(struct rt_mutex_base *lock,
+ 					   struct rt_mutex_waiter *waiter,
+ 					   struct task_struct *task,
+ 					   struct ww_acquire_ctx *ww_ctx,
+-					   enum rtmutex_chainwalk chwalk)
++					   enum rtmutex_chainwalk chwalk,
++					   struct wake_q_head *wake_q)
+ {
+ 	struct task_struct *owner = rt_mutex_owner(lock);
+ 	struct rt_mutex_waiter *top_waiter = waiter;
+@@ -1245,7 +1248,10 @@ static int __sched task_blocks_on_rt_mutex(struct rt_mutex_base *lock,
+ 
+ 		/* Check whether the waiter should back out immediately */
+ 		rtm = container_of(lock, struct rt_mutex, rtmutex);
+-		res = __ww_mutex_add_waiter(waiter, rtm, ww_ctx);
++		preempt_disable();
++		res = __ww_mutex_add_waiter(waiter, rtm, ww_ctx, wake_q);
++		wake_up_q(wake_q);
++		preempt_enable();
+ 		if (res) {
+ 			raw_spin_lock(&task->pi_lock);
+ 			rt_mutex_dequeue(lock, waiter);
+@@ -1677,12 +1683,14 @@ static void __sched rt_mutex_handle_deadlock(int res, int detect_deadlock,
+  * @state:	The task state for sleeping
+  * @chwalk:	Indicator whether full or partial chainwalk is requested
+  * @waiter:	Initializer waiter for blocking
++ * @wake_q:	The wake_q to wake tasks after we release the wait_lock
+  */
+ static int __sched __rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 				       struct ww_acquire_ctx *ww_ctx,
+ 				       unsigned int state,
+ 				       enum rtmutex_chainwalk chwalk,
+-				       struct rt_mutex_waiter *waiter)
++				       struct rt_mutex_waiter *waiter,
++				       struct wake_q_head *wake_q)
+ {
+ 	struct rt_mutex *rtm = container_of(lock, struct rt_mutex, rtmutex);
+ 	struct ww_mutex *ww = ww_container_of(rtm);
+@@ -1693,7 +1701,7 @@ static int __sched __rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 	/* Try to acquire the lock again: */
+ 	if (try_to_take_rt_mutex(lock, current, NULL)) {
+ 		if (build_ww_mutex() && ww_ctx) {
+-			__ww_mutex_check_waiters(rtm, ww_ctx);
++			__ww_mutex_check_waiters(rtm, ww_ctx, wake_q);
+ 			ww_mutex_lock_acquired(ww, ww_ctx);
+ 		}
+ 		return 0;
+@@ -1703,7 +1711,7 @@ static int __sched __rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 
+ 	trace_contention_begin(lock, LCB_F_RT);
+ 
+-	ret = task_blocks_on_rt_mutex(lock, waiter, current, ww_ctx, chwalk);
++	ret = task_blocks_on_rt_mutex(lock, waiter, current, ww_ctx, chwalk, wake_q);
+ 	if (likely(!ret))
+ 		ret = rt_mutex_slowlock_block(lock, ww_ctx, state, NULL, waiter);
+ 
+@@ -1711,7 +1719,7 @@ static int __sched __rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 		/* acquired the lock */
+ 		if (build_ww_mutex() && ww_ctx) {
+ 			if (!ww_ctx->is_wait_die)
+-				__ww_mutex_check_waiters(rtm, ww_ctx);
++				__ww_mutex_check_waiters(rtm, ww_ctx, wake_q);
+ 			ww_mutex_lock_acquired(ww, ww_ctx);
+ 		}
+ 	} else {
+@@ -1733,7 +1741,8 @@ static int __sched __rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 
+ static inline int __rt_mutex_slowlock_locked(struct rt_mutex_base *lock,
+ 					     struct ww_acquire_ctx *ww_ctx,
+-					     unsigned int state)
++					     unsigned int state,
++					     struct wake_q_head *wake_q)
+ {
+ 	struct rt_mutex_waiter waiter;
+ 	int ret;
+@@ -1742,7 +1751,7 @@ static inline int __rt_mutex_slowlock_locked(struct rt_mutex_base *lock,
+ 	waiter.ww_ctx = ww_ctx;
+ 
+ 	ret = __rt_mutex_slowlock(lock, ww_ctx, state, RT_MUTEX_MIN_CHAINWALK,
+-				  &waiter);
++				  &waiter, wake_q);
+ 
+ 	debug_rt_mutex_free_waiter(&waiter);
+ 	return ret;
+@@ -1758,6 +1767,7 @@ static int __sched rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 				     struct ww_acquire_ctx *ww_ctx,
+ 				     unsigned int state)
+ {
++	DEFINE_WAKE_Q(wake_q);
+ 	unsigned long flags;
+ 	int ret;
+ 
+@@ -1779,8 +1789,11 @@ static int __sched rt_mutex_slowlock(struct rt_mutex_base *lock,
+ 	 * irqsave/restore variants.
+ 	 */
+ 	raw_spin_lock_irqsave(&lock->wait_lock, flags);
+-	ret = __rt_mutex_slowlock_locked(lock, ww_ctx, state);
++	ret = __rt_mutex_slowlock_locked(lock, ww_ctx, state, &wake_q);
++	preempt_disable();
+ 	raw_spin_unlock_irqrestore(&lock->wait_lock, flags);
++	wake_up_q(&wake_q);
++	preempt_enable();
+ 	rt_mutex_post_schedule();
+ 
+ 	return ret;
+@@ -1806,8 +1819,10 @@ static __always_inline int __rt_mutex_lock(struct rt_mutex_base *lock,
+ /**
+  * rtlock_slowlock_locked - Slow path lock acquisition for RT locks
+  * @lock:	The underlying RT mutex
++ * @wake_q:	The wake_q to wake tasks after we release the wait_lock
+  */
+-static void __sched rtlock_slowlock_locked(struct rt_mutex_base *lock)
++static void __sched rtlock_slowlock_locked(struct rt_mutex_base *lock,
++					   struct wake_q_head *wake_q)
+ {
+ 	struct rt_mutex_waiter waiter;
+ 	struct task_struct *owner;
+@@ -1824,7 +1839,7 @@ static void __sched rtlock_slowlock_locked(struct rt_mutex_base *lock)
+ 
+ 	trace_contention_begin(lock, LCB_F_RT);
+ 
+-	task_blocks_on_rt_mutex(lock, &waiter, current, NULL, RT_MUTEX_MIN_CHAINWALK);
++	task_blocks_on_rt_mutex(lock, &waiter, current, NULL, RT_MUTEX_MIN_CHAINWALK, wake_q);
+ 
+ 	for (;;) {
+ 		/* Try to acquire the lock again */
+@@ -1835,7 +1850,11 @@ static void __sched rtlock_slowlock_locked(struct rt_mutex_base *lock)
+ 			owner = rt_mutex_owner(lock);
+ 		else
+ 			owner = NULL;
++		preempt_disable();
+ 		raw_spin_unlock_irq(&lock->wait_lock);
++		wake_up_q(wake_q);
++		wake_q_init(wake_q);
++		preempt_enable();
+ 
+ 		if (!owner || !rtmutex_spin_on_owner(lock, &waiter, owner))
+ 			schedule_rtlock();
+@@ -1860,10 +1879,14 @@ static void __sched rtlock_slowlock_locked(struct rt_mutex_base *lock)
+ static __always_inline void __sched rtlock_slowlock(struct rt_mutex_base *lock)
+ {
+ 	unsigned long flags;
++	DEFINE_WAKE_Q(wake_q);
+ 
+ 	raw_spin_lock_irqsave(&lock->wait_lock, flags);
+-	rtlock_slowlock_locked(lock);
++	rtlock_slowlock_locked(lock, &wake_q);
++	preempt_disable();
+ 	raw_spin_unlock_irqrestore(&lock->wait_lock, flags);
++	wake_up_q(&wake_q);
++	preempt_enable();
+ }
+ 
+ #endif /* RT_MUTEX_BUILD_SPINLOCKS */
+diff --git a/kernel/locking/rtmutex_api.c b/kernel/locking/rtmutex_api.c
+--- a/kernel/locking/rtmutex_api.c
++++ b/kernel/locking/rtmutex_api.c
+@@ -275,6 +275,7 @@ void __sched rt_mutex_proxy_unlock(struct rt_mutex_base *lock)
+  * @lock:		the rt_mutex to take
+  * @waiter:		the pre-initialized rt_mutex_waiter
+  * @task:		the task to prepare
++ * @wake_q:		the wake_q to wake tasks after we release the wait_lock
+  *
+  * Starts the rt_mutex acquire; it enqueues the @waiter and does deadlock
+  * detection. It does not wait, see rt_mutex_wait_proxy_lock() for that.
+@@ -291,7 +292,8 @@ void __sched rt_mutex_proxy_unlock(struct rt_mutex_base *lock)
+  */
+ int __sched __rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 					struct rt_mutex_waiter *waiter,
+-					struct task_struct *task)
++					struct task_struct *task,
++					struct wake_q_head *wake_q)
+ {
+ 	int ret;
+ 
+@@ -302,7 +304,7 @@ int __sched __rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 
+ 	/* We enforce deadlock detection for futexes */
+ 	ret = task_blocks_on_rt_mutex(lock, waiter, task, NULL,
+-				      RT_MUTEX_FULL_CHAINWALK);
++				      RT_MUTEX_FULL_CHAINWALK, wake_q);
+ 
+ 	if (ret && !rt_mutex_owner(lock)) {
+ 		/*
+@@ -341,12 +343,16 @@ int __sched rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 				      struct task_struct *task)
+ {
+ 	int ret;
++	DEFINE_WAKE_Q(wake_q);
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+-	ret = __rt_mutex_start_proxy_lock(lock, waiter, task);
++	ret = __rt_mutex_start_proxy_lock(lock, waiter, task, &wake_q);
+ 	if (unlikely(ret))
+ 		remove_waiter(lock, waiter);
++	preempt_disable();
+ 	raw_spin_unlock_irq(&lock->wait_lock);
++	wake_up_q(&wake_q);
++	preempt_enable();
+ 
+ 	return ret;
+ }
+diff --git a/kernel/locking/rtmutex_common.h b/kernel/locking/rtmutex_common.h
+--- a/kernel/locking/rtmutex_common.h
++++ b/kernel/locking/rtmutex_common.h
+@@ -83,7 +83,8 @@ extern void rt_mutex_init_proxy_locked(struct rt_mutex_base *lock,
+ extern void rt_mutex_proxy_unlock(struct rt_mutex_base *lock);
+ extern int __rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 				     struct rt_mutex_waiter *waiter,
+-				     struct task_struct *task);
++				     struct task_struct *task,
++				     struct wake_q_head *);
+ extern int rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 				     struct rt_mutex_waiter *waiter,
+ 				     struct task_struct *task);
+diff --git a/kernel/locking/rwbase_rt.c b/kernel/locking/rwbase_rt.c
+--- a/kernel/locking/rwbase_rt.c
++++ b/kernel/locking/rwbase_rt.c
+@@ -69,6 +69,7 @@ static int __sched __rwbase_read_lock(struct rwbase_rt *rwb,
+ 				      unsigned int state)
+ {
+ 	struct rt_mutex_base *rtm = &rwb->rtmutex;
++	DEFINE_WAKE_Q(wake_q);
+ 	int ret;
+ 
+ 	rwbase_pre_schedule();
+@@ -110,7 +111,7 @@ static int __sched __rwbase_read_lock(struct rwbase_rt *rwb,
+ 	 * For rwlocks this returns 0 unconditionally, so the below
+ 	 * !ret conditionals are optimized out.
+ 	 */
+-	ret = rwbase_rtmutex_slowlock_locked(rtm, state);
++	ret = rwbase_rtmutex_slowlock_locked(rtm, state, &wake_q);
+ 
+ 	/*
+ 	 * On success the rtmutex is held, so there can't be a writer
+@@ -121,7 +122,12 @@ static int __sched __rwbase_read_lock(struct rwbase_rt *rwb,
+ 	 */
+ 	if (!ret)
+ 		atomic_inc(&rwb->readers);
++
++	preempt_disable();
+ 	raw_spin_unlock_irq(&rtm->wait_lock);
++	wake_up_q(&wake_q);
++	preempt_enable();
++
+ 	if (!ret)
+ 		rwbase_rtmutex_unlock(rtm);
+ 
+diff --git a/kernel/locking/rwsem.c b/kernel/locking/rwsem.c
+--- a/kernel/locking/rwsem.c
++++ b/kernel/locking/rwsem.c
+@@ -1413,8 +1413,8 @@ static inline void __downgrade_write(struct rw_semaphore *sem)
+ #define rwbase_rtmutex_lock_state(rtm, state)		\
+ 	__rt_mutex_lock(rtm, state)
+ 
+-#define rwbase_rtmutex_slowlock_locked(rtm, state)	\
+-	__rt_mutex_slowlock_locked(rtm, NULL, state)
++#define rwbase_rtmutex_slowlock_locked(rtm, state, wq)	\
++	__rt_mutex_slowlock_locked(rtm, NULL, state, wq)
+ 
+ #define rwbase_rtmutex_unlock(rtm)			\
+ 	__rt_mutex_unlock(rtm)
+diff --git a/kernel/locking/spinlock_rt.c b/kernel/locking/spinlock_rt.c
+--- a/kernel/locking/spinlock_rt.c
++++ b/kernel/locking/spinlock_rt.c
+@@ -162,9 +162,10 @@ rwbase_rtmutex_lock_state(struct rt_mutex_base *rtm, unsigned int state)
+ }
+ 
+ static __always_inline int
+-rwbase_rtmutex_slowlock_locked(struct rt_mutex_base *rtm, unsigned int state)
++rwbase_rtmutex_slowlock_locked(struct rt_mutex_base *rtm, unsigned int state,
++			       struct wake_q_head *wake_q)
+ {
+-	rtlock_slowlock_locked(rtm);
++	rtlock_slowlock_locked(rtm, wake_q);
+ 	return 0;
+ }
+ 
+diff --git a/kernel/locking/ww_mutex.h b/kernel/locking/ww_mutex.h
+--- a/kernel/locking/ww_mutex.h
++++ b/kernel/locking/ww_mutex.h
+@@ -275,7 +275,7 @@ __ww_ctx_less(struct ww_acquire_ctx *a, struct ww_acquire_ctx *b)
+  */
+ static bool
+ __ww_mutex_die(struct MUTEX *lock, struct MUTEX_WAITER *waiter,
+-	       struct ww_acquire_ctx *ww_ctx)
++	       struct ww_acquire_ctx *ww_ctx, struct wake_q_head *wake_q)
+ {
+ 	if (!ww_ctx->is_wait_die)
+ 		return false;
+@@ -284,7 +284,7 @@ __ww_mutex_die(struct MUTEX *lock, struct MUTEX_WAITER *waiter,
+ #ifndef WW_RT
+ 		debug_mutex_wake_waiter(lock, waiter);
+ #endif
+-		wake_up_process(waiter->task);
++		wake_q_add(wake_q, waiter->task);
+ 	}
+ 
+ 	return true;
+@@ -299,7 +299,8 @@ __ww_mutex_die(struct MUTEX *lock, struct MUTEX_WAITER *waiter,
+  */
+ static bool __ww_mutex_wound(struct MUTEX *lock,
+ 			     struct ww_acquire_ctx *ww_ctx,
+-			     struct ww_acquire_ctx *hold_ctx)
++			     struct ww_acquire_ctx *hold_ctx,
++			     struct wake_q_head *wake_q)
+ {
+ 	struct task_struct *owner = __ww_mutex_owner(lock);
+ 
+@@ -331,7 +332,7 @@ static bool __ww_mutex_wound(struct MUTEX *lock,
+ 		 * wakeup pending to re-read the wounded state.
+ 		 */
+ 		if (owner != current)
+-			wake_up_process(owner);
++			wake_q_add(wake_q, owner);
+ 
+ 		return true;
+ 	}
+@@ -352,7 +353,8 @@ static bool __ww_mutex_wound(struct MUTEX *lock,
+  * The current task must not be on the wait list.
+  */
+ static void
+-__ww_mutex_check_waiters(struct MUTEX *lock, struct ww_acquire_ctx *ww_ctx)
++__ww_mutex_check_waiters(struct MUTEX *lock, struct ww_acquire_ctx *ww_ctx,
++			 struct wake_q_head *wake_q)
+ {
+ 	struct MUTEX_WAITER *cur;
+ 
+@@ -364,8 +366,8 @@ __ww_mutex_check_waiters(struct MUTEX *lock, struct ww_acquire_ctx *ww_ctx)
+ 		if (!cur->ww_ctx)
+ 			continue;
+ 
+-		if (__ww_mutex_die(lock, cur, ww_ctx) ||
+-		    __ww_mutex_wound(lock, cur->ww_ctx, ww_ctx))
++		if (__ww_mutex_die(lock, cur, ww_ctx, wake_q) ||
++		    __ww_mutex_wound(lock, cur->ww_ctx, ww_ctx, wake_q))
+ 			break;
+ 	}
+ }
+@@ -377,6 +379,8 @@ __ww_mutex_check_waiters(struct MUTEX *lock, struct ww_acquire_ctx *ww_ctx)
+ static __always_inline void
+ ww_mutex_set_context_fastpath(struct ww_mutex *lock, struct ww_acquire_ctx *ctx)
+ {
++	DEFINE_WAKE_Q(wake_q);
++
+ 	ww_mutex_lock_acquired(lock, ctx);
+ 
+ 	/*
+@@ -405,8 +409,11 @@ ww_mutex_set_context_fastpath(struct ww_mutex *lock, struct ww_acquire_ctx *ctx)
+ 	 * die or wound us.
+ 	 */
+ 	lock_wait_lock(&lock->base);
+-	__ww_mutex_check_waiters(&lock->base, ctx);
++	__ww_mutex_check_waiters(&lock->base, ctx, &wake_q);
++	preempt_disable();
+ 	unlock_wait_lock(&lock->base);
++	wake_up_q(&wake_q);
++	preempt_enable();
+ }
+ 
+ static __always_inline int
+@@ -488,7 +495,8 @@ __ww_mutex_check_kill(struct MUTEX *lock, struct MUTEX_WAITER *waiter,
+ static inline int
+ __ww_mutex_add_waiter(struct MUTEX_WAITER *waiter,
+ 		      struct MUTEX *lock,
+-		      struct ww_acquire_ctx *ww_ctx)
++		      struct ww_acquire_ctx *ww_ctx,
++		      struct wake_q_head *wake_q)
+ {
+ 	struct MUTEX_WAITER *cur, *pos = NULL;
+ 	bool is_wait_die;
+@@ -532,7 +540,7 @@ __ww_mutex_add_waiter(struct MUTEX_WAITER *waiter,
+ 		pos = cur;
+ 
+ 		/* Wait-Die: ensure younger waiters die. */
+-		__ww_mutex_die(lock, cur, ww_ctx);
++		__ww_mutex_die(lock, cur, ww_ctx, wake_q);
+ 	}
+ 
+ 	__ww_waiter_add(lock, waiter, pos);
+@@ -550,7 +558,7 @@ __ww_mutex_add_waiter(struct MUTEX_WAITER *waiter,
+ 		 * such that either we or the fastpath will wound @ww->ctx.
+ 		 */
+ 		smp_mb();
+-		__ww_mutex_wound(lock, ww_ctx, ww->ctx);
++		__ww_mutex_wound(lock, ww_ctx, ww->ctx, wake_q);
+ 	}
+ 
+ 	return 0;

--- a/packages/kernel-6.12/1011-locking-rtmutex-Fix-wake_q-logic-in-task_blocks_on_r.patch
+++ b/packages/kernel-6.12/1011-locking-rtmutex-Fix-wake_q-logic-in-task_blocks_on_r.patch
@@ -1,0 +1,56 @@
+From: John Stultz <jstultz@google.com>
+Date: Thu, 14 Nov 2024 11:00:47 -0800
+Subject: locking: rtmutex: Fix wake_q logic in task_blocks_on_rt_mutex
+
+commit 82f9cc094975240885c93effbca7f4603f5de1bf upstream.
+
+Anders had bisected a crash using PREEMPT_RT with linux-next and
+isolated it down to commit 894d1b3db41c ("locking/mutex: Remove
+wakeups from under mutex::wait_lock"), where it seemed the
+wake_q structure was somehow getting corrupted causing a null
+pointer traversal.
+
+I was able to easily repoduce this with PREEMPT_RT and managed
+to isolate down that through various call stacks we were
+actually calling wake_up_q() twice on the same wake_q.
+
+I found that in the problematic commit, I had added the
+wake_up_q() call in task_blocks_on_rt_mutex() around
+__ww_mutex_add_waiter(), following a similar pattern in
+__mutex_lock_common().
+
+However, its just wrong. We haven't dropped the lock->wait_lock,
+so its contrary to the point of the original patch. And it
+didn't match the __mutex_lock_common() logic of re-initializing
+the wake_q after calling it midway in the stack.
+
+Looking at it now, the wake_up_q() call is incorrect and should
+just be removed. So drop the erronious logic I had added.
+
+Fixes: 894d1b3db41c ("locking/mutex: Remove wakeups from under mutex::wait_lock")
+Closes: https://lore.kernel.org/lkml/6afb936f-17c7-43fa-90e0-b9e780866097@app.fastmail.com/
+Reported-by: Anders Roxell <anders.roxell@linaro.org>
+Reported-by: Arnd Bergmann <arnd@arndb.de>
+Signed-off-by: John Stultz <jstultz@google.com>
+Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Reviewed-by: Juri Lelli <juri.lelli@redhat.com>
+Tested-by: Anders Roxell <anders.roxell@linaro.org>
+Tested-by: K Prateek Nayak <kprateek.nayak@amd.com>
+Link: https://lore.kernel.org/r/20241114190051.552665-1-jstultz@google.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Hazem Mohamed Abuelfotoh <abuehaze@amazon.com>
+
+diff --git a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -1248,10 +1248,7 @@ static int __sched task_blocks_on_rt_mutex(struct rt_mutex_base *lock,
+ 
+ 		/* Check whether the waiter should back out immediately */
+ 		rtm = container_of(lock, struct rt_mutex, rtmutex);
+-		preempt_disable();
+ 		res = __ww_mutex_add_waiter(waiter, rtm, ww_ctx, wake_q);
+-		wake_up_q(wake_q);
+-		preempt_enable();
+ 		if (res) {
+ 			raw_spin_lock(&task->pi_lock);
+ 			rt_mutex_dequeue(lock, waiter);

--- a/packages/kernel-6.12/1012-locking-rtmutex-Skip-remove_waiter-when-waiter-is-no.patch
+++ b/packages/kernel-6.12/1012-locking-rtmutex-Skip-remove_waiter-when-waiter-is-no.patch
@@ -1,0 +1,62 @@
+From: Davidlohr Bueso <dave@stgolabs.net>
+Date: Tue, 16 Jun 2026 15:06:01 -0400
+Subject: locking/rtmutex: Skip remove_waiter() when waiter is not enqueued
+
+[ Upstream commit 40a25d59e85b3c8709ac2424d44f65610467871e ]
+
+syzbot triggered the following splat in remove_waiter() via
+FUTEX_CMP_REQUEUE_PI:
+
+  KASAN: null-ptr-deref in range [0x0000000000000a88-0x0000000000000a8f]
+   class_raw_spinlock_constructor
+   remove_waiter+0x159/0x1200 kernel/locking/rtmutex.c:1561
+   rt_mutex_start_proxy_lock+0x103/0x120
+   futex_requeue+0x10e4/0x20d0
+   __x64_sys_futex+0x34f/0x4d0
+
+task_blocks_on_rt_mutex() does not arm the waiter upon deadlock detection,
+leaving waiter->task nil, where 3bfdc63936dd ("rtmutex: Use waiter::task instead
+of current in remove_waiter()") made this fatal.
+
+Furthermore, rt_mutex_start_proxy_lock() should not be calling into remove_waiter()
+upon a successfully grabbing the rtmutex. 1a1fb985f2e2 ("futex: Handle early deadlock
+return correctly"), moved the remove_waiter() out of __rt_mutex_start_proxy_lock()
+(where 'ret' was only ever 0 or < 0) into the wrapper. Tighten this check to
+account for try_to_take_rt_mutex().
+
+Fixes: 3bfdc63936dd ("rtmutex: Use waiter::task instead of current in remove_waiter()")
+Reported-by: syzbot+78147abe6c524f183ee9@syzkaller.appspotmail.com
+Signed-off-by: Davidlohr Bueso <dave@stgolabs.net>
+Signed-off-by: Thomas Gleixner <tglx@kernel.org>
+Cc: stable@vger.kernel.org
+Closes: https://lore.kernel.org/all/69f114ac.050a0220.ac8b.0003.GAE@google.com/
+Link: https://patch.msgid.link/20260507112913.1019537-1-dave@stgolabs.net
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+Signed-off-by: Hazem Mohamed Abuelfotoh <abuehaze@amazon.com>
+
+diff --git a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
+--- a/kernel/locking/rtmutex.c
++++ b/kernel/locking/rtmutex.c
+@@ -1547,6 +1547,9 @@ static void __sched remove_waiter(struct rt_mutex_base *lock,
+ 
+ 	lockdep_assert_held(&lock->wait_lock);
+ 
++	if (!waiter_task) /* never enqueued */
++		return;
++
+ 	scoped_guard(raw_spinlock, &waiter_task->pi_lock) {
+ 		rt_mutex_dequeue(lock, waiter);
+ 		waiter_task->pi_blocked_on = NULL;
+diff --git a/kernel/locking/rtmutex_api.c b/kernel/locking/rtmutex_api.c
+--- a/kernel/locking/rtmutex_api.c
++++ b/kernel/locking/rtmutex_api.c
+@@ -347,7 +347,7 @@ int __sched rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ 	ret = __rt_mutex_start_proxy_lock(lock, waiter, task, &wake_q);
+-	if (unlikely(ret))
++	if (unlikely(ret < 0))
+ 		remove_waiter(lock, waiter);
+ 	preempt_disable();
+ 	raw_spin_unlock_irq(&lock->wait_lock);

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -50,6 +50,7 @@ Patch1006: 1006-Select-prerequisites-for-gpu-drivers.patch
 Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1008: 1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+Patch1009: 1009-AL2023-6.12-Update-ena-driver-to-2.17.2g.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -51,6 +51,9 @@ Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1008: 1008-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 Patch1009: 1009-AL2023-6.12-Update-ena-driver-to-2.17.2g.patch
+Patch1010: 1010-locking-mutex-Remove-wakeups-from-under-mutex-wait_l.patch
+Patch1011: 1011-locking-rtmutex-Fix-wake_q-logic-in-task_blocks_on_r.patch
+Patch1012: 1012-locking-rtmutex-Skip-remove_waiter-when-waiter-is-no.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.18/1007-AL2023-6.18-Update-ena-driver-to-2.17.2g.patch
+++ b/packages/kernel-6.18/1007-AL2023-6.18-Update-ena-driver-to-2.17.2g.patch
@@ -1,0 +1,76 @@
+From b04c2bc36d128d5189ef39a5b4d0844c0da835cb Mon Sep 17 00:00:00 2001
+From: David Arinzon <darinzon@amazon.com>
+Date: Wed, 8 Jul 2026 14:36:00 +0000
+Subject: [PATCH] AL2023-6.18-Update-ena-driver-to-2.17.2g
+
+Signed-off-by: David Arinzon <darinzon@amazon.com>
+---
+ drivers/amazon/net/ena/Makefile     | 2 +-
+ drivers/amazon/net/ena/ena_netdev.c | 8 ++++----
+ drivers/amazon/net/ena/ena_netdev.h | 2 +-
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/amazon/net/ena/Makefile b/drivers/amazon/net/ena/Makefile
+index 877a906..1e48bea 100644
+--- a/drivers/amazon/net/ena/Makefile
++++ b/drivers/amazon/net/ena/Makefile
+@@ -1,7 +1,7 @@
+ #
+ # Makefile for the Elastic Network Adapter (ENA) device drivers.
+ # ENA Source is: https://github.com/amzn/amzn-drivers.
+-# Current ENA source is based on ena_linux_2.17.0 tag.
++# Current ENA source is based on ena_linux_2.17.2 tag.
+ #
+ 
+ obj-$(CONFIG_AMAZON_ENA_ETHERNET) += ena.o
+diff --git a/drivers/amazon/net/ena/ena_netdev.c b/drivers/amazon/net/ena/ena_netdev.c
+index 4a589e8..7827126 100644
+--- a/drivers/amazon/net/ena/ena_netdev.c
++++ b/drivers/amazon/net/ena/ena_netdev.c
+@@ -5858,6 +5858,9 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 	ena_devlink_unregister(adapter->devlink);
+ 	ena_devlink_free(adapter->devlink);
+ 
++	ena_reset_reason_info_free(adapter);
++	ena_free_stats_buffers(adapter);
++
+ 	if (shutdown) {
+ 		netif_device_detach(netdev);
+ 		dev_close(netdev);
+@@ -5865,6 +5868,7 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 	} else {
+ 		rtnl_unlock();
+ 		unregister_netdev(netdev);
++		/* No access to adapter and netdev after this point */
+ 		free_netdev(netdev);
+ 	}
+ 
+@@ -5872,12 +5876,8 @@ static void __ena_shutoff(struct pci_dev *pdev, bool shutdown)
+ 
+ 	ena_com_flow_steering_destroy(ena_dev);
+ 
+-	ena_reset_reason_info_free(adapter);
+-
+ 	ena_com_delete_debug_area(ena_dev);
+ 
+-	ena_free_stats_buffers(adapter);
+-
+ 	ena_com_delete_host_info(ena_dev);
+ 
+ 	ena_com_delete_customer_metrics_buffer(ena_dev);
+diff --git a/drivers/amazon/net/ena/ena_netdev.h b/drivers/amazon/net/ena/ena_netdev.h
+index da59195..333aea1 100644
+--- a/drivers/amazon/net/ena/ena_netdev.h
++++ b/drivers/amazon/net/ena/ena_netdev.h
+@@ -40,7 +40,7 @@
+ 
+ #define DRV_MODULE_GEN_MAJOR	2
+ #define DRV_MODULE_GEN_MINOR	17
+-#define DRV_MODULE_GEN_SUBMINOR	1
++#define DRV_MODULE_GEN_SUBMINOR	2
+ 
+ #define DRV_MODULE_NAME		"ena"
+ #ifndef DRV_MODULE_GENERATION
+-- 
+2.50.1
+

--- a/packages/kernel-6.18/1008-futex-requeue-Revert-Prevent-NULL-pointer-dereferenc.patch
+++ b/packages/kernel-6.18/1008-futex-requeue-Revert-Prevent-NULL-pointer-dereferenc.patch
@@ -1,0 +1,43 @@
+From: Sebastian Andrzej Siewior <bigeasy@linutronix.de>
+Date: Wed, 1 Jul 2026 15:11:50 +0200
+Subject: futex/requeue: Revert "Prevent NULL pointer dereference in
+ remove_waiter() on self-deadlock""
+
+The commit cited below should not have been merged. It attemted to fix an
+existing problem ansd thereby introduced new problems by keeping the
+pi_state in state Q_REQUEUE_PI_IN_PROGRESS and leaking it.
+
+Based on the commit description the intention was to handle the case
+when task_blocks_on_rt_mutex() returns -EDEADLK and the following
+remove_waiter() dereferences the NULL pointer in waiter->task.
+
+That is already handled by Davidlohr in commit 40a25d59e85b3
+("locking/rtmutex: Skip remove_waiter() when waiter is not enqueued") and
+requires no further acting.
+
+Revert the commit breaking the "waiter == owner" case again.
+
+Fixes: 74e144274af39 ("futex/requeue: Prevent NULL pointer dereference in remove_waiter() on self-deadlock")
+Reported-by: Michael Bommarito <michael.bommarito@gmail.com>
+Signed-off-by: Sebastian Andrzej Siewior <bigeasy@linutronix.de>
+Signed-off-by: Thomas Gleixner <tglx@kernel.org>
+Cc: stable@vger.kernel.org
+Link: https://patch.msgid.link/20260701131150.0Ijhq4Dw@linutronix.de
+Closes: https://lore.kernel.org/all/20260629020049.2082397-1-michael.bommarito@gmail.com
+
+diff --git a/kernel/futex/requeue.c b/kernel/futex/requeue.c
+--- a/kernel/futex/requeue.c
++++ b/kernel/futex/requeue.c
+@@ -643,12 +643,6 @@ int futex_requeue(u32 __user *uaddr1, unsigned int flags1,
+ 				continue;
+ 			}
+ 
+-			/* Self-deadlock: non-top waiter already owns the PI futex. */
+-			if (rt_mutex_owner(&pi_state->pi_mutex) == this->task) {
+-				ret = -EDEADLK;
+-				break;
+-			}
+-
+ 			ret = rt_mutex_start_proxy_lock(&pi_state->pi_mutex,
+ 							this->rt_waiter,
+ 							this->task);

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -44,6 +44,7 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1006: 1006-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
+Patch1007: 1007-AL2023-6.18-Update-ena-driver-to-2.17.2g.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -45,6 +45,7 @@ Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
 # Disable incomplete measurement into PCR 9 on aarch64.
 Patch1006: 1006-efi-libstub-don-t-measure-kernel-command-line-into-P.patch
 Patch1007: 1007-AL2023-6.18-Update-ena-driver-to-2.17.2g.patch
+Patch1008: 1008-futex-requeue-Revert-Prevent-NULL-pointer-dereferenc.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Description of changes:**
- ENA driver updates
- add patch to fix ghostlock

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
