### PR TITLE
advisories: fix advisories for 7.0.0

### DIFF
--- a/advisories/7.0.0/BRSA-ej9q9ah5isba.toml
+++ b/advisories/7.0.0/BRSA-ej9q9ah5isba.toml
@@ -24,4 +24,4 @@ patched-epoch = "1"
 author = "agarrcia"
 issue-date = 2026-07-10T20:49:58Z
 arches = ["aarch64", "x86_64"]
-version = "6.3.2"
+version = "7.0.0"


### PR DESCRIPTION
**Description of changes:**

We didn't release 6.3.2 we released 7.0.0. Move the advisory file to the correct directory.


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
