### PR TITLE
Kernel kit bump

### DIFF
--- a/packages/kernel-6.1/Cargo.toml
+++ b/packages/kernel-6.1/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/389bbd29f73bf593fee136509d1bebeec2f530c696a0c466fabc61bae5d9a3e0/kernel-6.1.176-221.367.amzn2023.src.rpm"
-sha512 = "494b48639e7a7c8ecffa05d9622e6d6657949f5e4b7e12e389592ae2f47fdc58956920a985362e80e7f4bb48282caade6e72213274308a3217550762e077dbdd"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/46640a00f234691081b201b814662f6a7262c523aa1b0ea12f17bcc6191e391f/kernel-6.1.176-223.369.amzn2023.src.rpm"
+sha512 = "8b47f933ff07d51f9483aa3861f244899d722486edf2a23c992c65ec6603177968a6beb85a8456ddbf2acca734872aa3f35171791b7bc41c35cd3137999c0813"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -10,7 +10,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/389bbd29f73bf593fee136509d1bebeec2f530c696a0c466fabc61bae5d9a3e0/kernel-6.1.176-221.367.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/46640a00f234691081b201b814662f6a7262c523aa1b0ea12f17bcc6191e391f/kernel-6.1.176-223.369.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 # Use latest-2.24-neuron-srpm-url.sh to get this.
 Source2: https://yum.repos.neuron.amazonaws.com/aws-neuronx-dkms-%{neuron_inf1_ver}.0.noarch.rpm

--- a/packages/kernel-6.12/Cargo.toml
+++ b/packages/kernel-6.12/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/cbd8dd4f126159d4d8b0d41c2757c9d4ed7a61168785e9ca164966cd0eb30444/kernel6.12-6.12.94-123.190.amzn2023.src.rpm"
-sha512 = "f28380e60e4ad02a11a65c0a38ed018aabaca99d320dbfd901d7e80e2ca11d028268dcf575a55e7d9cb1b3a480d03697e1b3b6fc3f49842cae8de5f79bc411b2"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/5f1a0fef7b8863f6e98bb5399868917d96115ee49e4feb5587b6450f7bffff84/kernel6.12-6.12.94-123.192.amzn2023.src.rpm"
+sha512 = "26df3a27888a2dfa84172d77bdf9c8315fd33a2392c53ffadb123449bdf0371731ecf123f904e9832e8c9a3f9fafd34d5d585d55ec9867bf87e31688d706bb10"
 force-upstream = true
 
 [[package.metadata.build-package.external-files]]

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -12,7 +12,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/cbd8dd4f126159d4d8b0d41c2757c9d4ed7a61168785e9ca164966cd0eb30444/kernel6.12-6.12.94-123.190.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/5f1a0fef7b8863f6e98bb5399868917d96115ee49e4feb5587b6450f7bffff84/kernel6.12-6.12.94-123.192.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 
 # Custom Bottlerocket kernel configurations.

--- a/packages/kernel-6.18/Cargo.toml
+++ b/packages/kernel-6.18/Cargo.toml
@@ -13,8 +13,8 @@ path = "../packages.rs"
 
 [[package.metadata.build-package.external-files]]
 # Use latest-kernel-srpm-url.sh to get this.
-url = "https://cdn.amazonlinux.com/al2023/blobstore/d6f6d1064fe12ef9ce02192d324111d2c0b7b99870fd30315af6f3ca4a121886/kernel6.18-6.18.38-73.137.amzn2023.src.rpm"
-sha512 = "cd54a57702ce2bfa352e352057569be992d1a127b3d24cb91837c47d73443777b6873f1ea188154642744900743019258da56630be1af7e69d575a0d1709f7e9"
+url = "https://cdn.amazonlinux.com/al2023/blobstore/acca1f3a49e3c6f54292736a5452b03ef38b63cbed81f596f4451a3733d06f3c/kernel6.18-6.18.38-76.139.amzn2023.src.rpm"
+sha512 = "b22d1e764ac5dd97a03e9ef57667fa94335aa70e7d7caf82c14e6a181a21ca8f0f2f528b172b028ee902d116e90328b18084872da84140c6d13da468bed14711"
 force-upstream = true
 
 

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -14,7 +14,7 @@ Summary: The Linux kernel
 License: GPL-2.0 WITH Linux-syscall-note
 URL: https://www.kernel.org/
 # Use latest-kernel-srpm-url.sh to get this.
-Source0: https://cdn.amazonlinux.com/al2023/blobstore/d6f6d1064fe12ef9ce02192d324111d2c0b7b99870fd30315af6f3ca4a121886/kernel6.18-6.18.38-73.137.amzn2023.src.rpm
+Source0: https://cdn.amazonlinux.com/al2023/blobstore/acca1f3a49e3c6f54292736a5452b03ef38b63cbed81f596f4451a3733d06f3c/kernel6.18-6.18.38-76.139.amzn2023.src.rpm
 Source1: gpgkey-B21C50FA44A99720EAA72F7FE951904AD832C631.asc
 
 # Custom Bottlerocket kernel configurations.


### PR DESCRIPTION
<!--
Tips:
- Please read CONTRIBUTING.md to understand our process and our requests for PRs.
- Please file an issue before creating a PR so we can discuss the change and confirm it's not already being worked on.
-->

**Description of changes:**
* update kernel-6.1 to 6.1.176-223.369
* update kernel-6.12 to 6.12.94-123.192
* update kernel-6.18 to 6.18.38-76.139

### Patch summary
#### 6.1
Patches that changed:
None
Patches that were dropped:
None
Patches that were added:
0367-net-openvswitch-reject-oversized-nested-action-attrs.patch
0368-xfs-resample-the-data-fork-mapping-after-cycling-ILO.patch

#### 6.12
Patches that changed:
None
Patches that were dropped:
None
Patches that were added:
0190-xfs-resample-the-data-fork-mapping-after-cycling-ILO.patch
0191-net-openvswitch-reject-oversized-nested-action-attrs.patch

#### 6.18
Patches that changed:
None
Patches that were dropped:
None
Patches that were added:
0137-xfs-resample-the-data-fork-mapping-after-cycling-ILO.patch
0138-net-openvswitch-reject-oversized-nested-action-attrs.patch

**Testing done:**
Check GH actions


**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
