### PR TITLE
 Revert selinux overlayfs mmap and mprotect access checks for kernel-6.12 and kernel-6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v9.0.1 (2026-08-27)
+
+## OS Changes
+* Revert selinux change to fix overlayfs mmap and mprotect access checks in kernel-6.12 and kernel-6.18 ([#535])
+
+[#535]: https://github.com/bottlerocket-os/bottlerocket-kernel-kit/pull/535
+
 # v9.0.0 (2026-08-24)
 
 ## OS Changes

--- a/Twoliter.toml
+++ b/Twoliter.toml
@@ -1,5 +1,5 @@
 schema-version = 2
-release-version = "9.0.0"
+release-version = "9.0.1"
 project-vendor = "Bottlerocket"
 
 [vendor.bottlerocket]

--- a/packages/kernel-6.12/1008-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
+++ b/packages/kernel-6.12/1008-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
@@ -1,0 +1,412 @@
+From ee04449cb676ce10415af26a217799eb60e89c76 Mon Sep 17 00:00:00 2001
+From: Sparks Song <shijiao@amazon.com>
+Date: Wed, 26 Aug 2026 18:30:03 +0000
+Subject: [PATCH] Revert "selinux: fix overlayfs mmap() and mprotect() access
+ checks"
+
+This reverts commit 8bacd09f12c27710228562e4d13163e58c5f4a45.
+---
+ security/selinux/hooks.c          | 248 ++++++++----------------------
+ security/selinux/include/objsec.h |  11 --
+ 2 files changed, 64 insertions(+), 195 deletions(-)
+
+diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
+index cd60ece2f..52e712247 100644
+--- a/security/selinux/hooks.c
++++ b/security/selinux/hooks.c
+@@ -1724,72 +1724,49 @@ static inline int file_path_has_perm(const struct cred *cred,
+ static int bpf_fd_pass(const struct file *file, u32 sid);
+ #endif
+ 
+-static int __file_has_perm(const struct cred *cred, const struct file *file,
+-			   u32 av, bool bf_user_file)
+-
++/* Check whether a task can use an open file descriptor to
++   access an inode in a given way.  Check access to the
++   descriptor itself, and then use dentry_has_perm to
++   check a particular permission to the file.
++   Access to the descriptor is implicitly granted if it
++   has the same SID as the process.  If av is zero, then
++   access to the file is not checked, e.g. for cases
++   where only the descriptor is affected like seek. */
++static int file_has_perm(const struct cred *cred,
++			 struct file *file,
++			 u32 av)
+ {
++	struct file_security_struct *fsec = selinux_file(file);
++	struct inode *inode = file_inode(file);
+ 	struct common_audit_data ad;
+-	struct inode *inode;
+-	u32 ssid = cred_sid(cred);
+-	u32 tsid_fd;
++	u32 sid = cred_sid(cred);
+ 	int rc;
+ 
+-	if (bf_user_file) {
+-		struct backing_file_security_struct *bfsec;
+-		const struct path *path;
+-
+-		if (WARN_ON(!(file->f_mode & FMODE_BACKING)))
+-			return -EIO;
+-
+-		bfsec = selinux_backing_file(file);
+-		path = backing_file_user_path(file);
+-		tsid_fd = bfsec->uf_sid;
+-		inode = d_inode(path->dentry);
+-
+-		ad.type = LSM_AUDIT_DATA_PATH;
+-		ad.u.path = *path;
+-	} else {
+-		struct file_security_struct *fsec = selinux_file(file);
+-
+-		tsid_fd = fsec->sid;
+-		inode = file_inode(file);
+-
+-		ad.type = LSM_AUDIT_DATA_FILE;
+-		ad.u.file = file;
+-	}
++	ad.type = LSM_AUDIT_DATA_FILE;
++	ad.u.file = file;
+ 
+-	if (ssid != tsid_fd) {
+-		rc = avc_has_perm(ssid, tsid_fd, SECCLASS_FD, FD__USE, &ad);
++	if (sid != fsec->sid) {
++		rc = avc_has_perm(sid, fsec->sid,
++				  SECCLASS_FD,
++				  FD__USE,
++				  &ad);
+ 		if (rc)
+-			return rc;
++			goto out;
+ 	}
+ 
+ #ifdef CONFIG_BPF_SYSCALL
+-	/* regardless of backing vs user file, use the underlying file here */
+-	rc = bpf_fd_pass(file, ssid);
++	rc = bpf_fd_pass(file, cred_sid(cred));
+ 	if (rc)
+ 		return rc;
+ #endif
+ 
+ 	/* av is zero if only checking access to the descriptor. */
++	rc = 0;
+ 	if (av)
+-		return inode_has_perm(cred, inode, av, &ad);
++		rc = inode_has_perm(cred, inode, av, &ad);
+ 
+-	return 0;
+-}
+-
+-/* Check whether a task can use an open file descriptor to
+-   access an inode in a given way.  Check access to the
+-   descriptor itself, and then use dentry_has_perm to
+-   check a particular permission to the file.
+-   Access to the descriptor is implicitly granted if it
+-   has the same SID as the process.  If av is zero, then
+-   access to the file is not checked, e.g. for cases
+-   where only the descriptor is affected like seek. */
+-static inline int file_has_perm(const struct cred *cred,
+-				const struct file *file, u32 av)
+-{
+-	return __file_has_perm(cred, file, av, false);
++out:
++	return rc;
+ }
+ 
+ /*
+@@ -3676,17 +3653,6 @@ static int selinux_file_alloc_security(struct file *file)
+ 	return 0;
+ }
+ 
+-static int selinux_backing_file_alloc(struct file *backing_file,
+-				      const struct file *user_file)
+-{
+-	struct backing_file_security_struct *bfsec;
+-
+-	bfsec = selinux_backing_file(backing_file);
+-	bfsec->uf_sid = selinux_file(user_file)->sid;
+-
+-	return 0;
+-}
+-
+ /*
+  * Check whether a task has the ioctl permission and cmd
+  * operation to an inode.
+@@ -3804,57 +3770,42 @@ static int selinux_file_ioctl_compat(struct file *file, unsigned int cmd,
+ 
+ static int default_noexec __ro_after_init;
+ 
+-static int __file_map_prot_check(const struct file *file, unsigned long prot,
+-				 bool shared, bool mounter_check,
+-				 bool bf_user_file)
++static int file_map_prot_check(struct file *file, unsigned long prot, int shared)
+ {
+-	struct inode *inode = NULL;
+-	bool prot_exec = prot & PROT_EXEC;
+-	bool prot_write = prot & PROT_WRITE;
+-
+-	if (file) {
+-		if (bf_user_file)
+-			inode = d_inode(backing_file_user_path(file)->dentry);
+-		else
+-			inode = file_inode(file);
+-	}
+-
+-	if (!mounter_check && default_noexec && prot_exec &&
+-	    (!file || IS_PRIVATE(inode) || (!shared && prot_write))) {
+-		int rc;
+-		u32 sid = current_sid();
++	const struct cred *cred = current_cred();
++	u32 sid = cred_sid(cred);
++	int rc = 0;
+ 
++	if (default_noexec &&
++	    (prot & PROT_EXEC) && (!file || IS_PRIVATE(file_inode(file)) ||
++				   (!shared && (prot & PROT_WRITE)))) {
+ 		/*
+-		 * We are making executable an anonymous mapping or a private
+-		 * file mapping that will also be writable.
++		 * We are making executable an anonymous mapping or a
++		 * private file mapping that will also be writable.
++		 * This has an additional check.
+ 		 */
+-		rc = avc_has_perm(sid, sid, SECCLASS_PROCESS, PROCESS__EXECMEM,
+-				  NULL);
++		rc = avc_has_perm(sid, sid, SECCLASS_PROCESS,
++				  PROCESS__EXECMEM, NULL);
+ 		if (rc)
+-			return rc;
++			goto error;
+ 	}
+ 
+ 	if (file) {
+-		const struct cred *cred = mounter_check ?
+-				file->f_cred : current_cred();
+-		/* "read" always possible, "write" only if shared */
++		/* read access is always possible with a mapping */
+ 		u32 av = FILE__READ;
+-		if (shared && prot_write)
++
++		/* write access only matters if the mapping is shared */
++		if (shared && (prot & PROT_WRITE))
+ 			av |= FILE__WRITE;
+-		if (prot_exec)
++
++		if (prot & PROT_EXEC)
+ 			av |= FILE__EXECUTE;
+ 
+-		return __file_has_perm(cred, file, av, bf_user_file);
++		return file_has_perm(cred, file, av);
+ 	}
+ 
+-	return 0;
+-}
+-
+-static inline int file_map_prot_check(const struct file *file,
+-				      unsigned long prot, bool shared,
+-				      bool mounter_check)
+-{
+-	return __file_map_prot_check(file, prot, shared, mounter_check, false);
++error:
++	return rc;
+ }
+ 
+ static int selinux_mmap_addr(unsigned long addr)
+@@ -3870,84 +3821,36 @@ static int selinux_mmap_addr(unsigned long addr)
+ 	return rc;
+ }
+ 
+-static int selinux_mmap_file_common(struct file *file, unsigned long prot,
+-				    bool shared, bool mounter_check)
++static int selinux_mmap_file(struct file *file,
++			     unsigned long reqprot __always_unused,
++			     unsigned long prot, unsigned long flags)
+ {
+-	if (file) {
+-		int rc;
+-		struct common_audit_data ad;
+-		const struct cred *cred = mounter_check ?
+-				file->f_cred : current_cred();
++	struct common_audit_data ad;
++	int rc;
+ 
++	if (file) {
+ 		ad.type = LSM_AUDIT_DATA_FILE;
+ 		ad.u.file = file;
+-		rc = inode_has_perm(cred, file_inode(file), FILE__MAP, &ad);
++		rc = inode_has_perm(current_cred(), file_inode(file),
++				    FILE__MAP, &ad);
+ 		if (rc)
+ 			return rc;
+ 	}
+ 
+-	return file_map_prot_check(file, prot, shared, mounter_check);
+-}
+-
+-static int selinux_mmap_file(struct file *file,
+-			     unsigned long reqprot __always_unused,
+-			     unsigned long prot, unsigned long flags)
+-{
+-	return selinux_mmap_file_common(file, prot,
+-					(flags & MAP_TYPE) == MAP_SHARED,
+-					false);
+-}
+-
+-/**
+- * selinux_mmap_backing_file - Check mmap permissions on a backing file
+- * @vma: memory region
+- * @backing_file: stacked filesystem backing file
+- * @user_file: user visible file
+- *
+- * This is called after selinux_mmap_file() on stacked filesystems, and it
+- * is this function's responsibility to verify access to @backing_file and
+- * setup the SELinux state for possible later use in the mprotect() code path.
+- *
+- * By the time this function is called, mmap() access to @user_file has already
+- * been authorized and @vma->vm_file has been set to point to @backing_file.
+- *
+- * Return zero on success, negative values otherwise.
+- */
+-static int selinux_mmap_backing_file(struct vm_area_struct *vma,
+-				     struct file *backing_file,
+-				     struct file *user_file __always_unused)
+-{
+-	unsigned long prot = 0;
+-
+-	/* translate vma->vm_flags perms into PROT perms */
+-	if (vma->vm_flags & VM_READ)
+-		prot |= PROT_READ;
+-	if (vma->vm_flags & VM_WRITE)
+-		prot |= PROT_WRITE;
+-	if (vma->vm_flags & VM_EXEC)
+-		prot |= PROT_EXEC;
+-
+-	return selinux_mmap_file_common(backing_file, prot,
+-					vma->vm_flags & VM_SHARED,
+-					true);
++	return file_map_prot_check(file, prot,
++				   (flags & MAP_TYPE) == MAP_SHARED);
+ }
+ 
+ static int selinux_file_mprotect(struct vm_area_struct *vma,
+ 				 unsigned long reqprot __always_unused,
+ 				 unsigned long prot)
+ {
+-	int rc;
+ 	const struct cred *cred = current_cred();
+ 	u32 sid = cred_sid(cred);
+-	const struct file *file = vma->vm_file;
+-	bool backing_file;
+-	bool shared = vma->vm_flags & VM_SHARED;
+-
+-	/* check if we need to trigger the "backing files are awful" mode */
+-	backing_file = file && (file->f_mode & FMODE_BACKING);
+ 
+ 	if (default_noexec &&
+ 	    (prot & PROT_EXEC) && !(vma->vm_flags & VM_EXEC)) {
++		int rc = 0;
+ 		/*
+ 		 * We don't use the vma_is_initial_heap() helper as it has
+ 		 * a history of problems and is currently broken on systems
+@@ -3961,15 +3864,11 @@ static int selinux_file_mprotect(struct vm_area_struct *vma,
+ 		    vma->vm_end <= vma->vm_mm->brk) {
+ 			rc = avc_has_perm(sid, sid, SECCLASS_PROCESS,
+ 					  PROCESS__EXECHEAP, NULL);
+-			if (rc)
+-				return rc;
+-		} else if (!file && (vma_is_initial_stack(vma) ||
++		} else if (!vma->vm_file && (vma_is_initial_stack(vma) ||
+ 			    vma_is_stack_for_current(vma))) {
+ 			rc = avc_has_perm(sid, sid, SECCLASS_PROCESS,
+ 					  PROCESS__EXECSTACK, NULL);
+-			if (rc)
+-				return rc;
+-		} else if (file && vma->anon_vma) {
++		} else if (vma->vm_file && vma->anon_vma) {
+ 			/*
+ 			 * We are making executable a file mapping that has
+ 			 * had some COW done. Since pages might have been
+@@ -3977,29 +3876,13 @@ static int selinux_file_mprotect(struct vm_area_struct *vma,
+ 			 * modified content.  This typically should only
+ 			 * occur for text relocations.
+ 			 */
+-			rc = __file_has_perm(cred, file, FILE__EXECMOD,
+-					     backing_file);
+-			if (rc)
+-				return rc;
+-			if (backing_file) {
+-				rc = file_has_perm(file->f_cred, file,
+-						   FILE__EXECMOD);
+-				if (rc)
+-					return rc;
+-			}
++			rc = file_has_perm(cred, vma->vm_file, FILE__EXECMOD);
+ 		}
+-	}
+-
+-	rc = __file_map_prot_check(file, prot, shared, false, backing_file);
+-	if (rc)
+-		return rc;
+-	if (backing_file) {
+-		rc = file_map_prot_check(file, prot, shared, true);
+ 		if (rc)
+ 			return rc;
+ 	}
+ 
+-	return 0;
++	return file_map_prot_check(vma->vm_file, prot, vma->vm_flags&VM_SHARED);
+ }
+ 
+ static int selinux_file_lock(struct file *file, unsigned int cmd)
+@@ -7095,7 +6978,6 @@ static void selinux_bpf_token_free(struct bpf_token *token)
+ struct lsm_blob_sizes selinux_blob_sizes __ro_after_init = {
+ 	.lbs_cred = sizeof(struct task_security_struct),
+ 	.lbs_file = sizeof(struct file_security_struct),
+-	.lbs_backing_file = sizeof(struct backing_file_security_struct),
+ 	.lbs_inode = sizeof(struct inode_security_struct),
+ 	.lbs_ipc = sizeof(struct ipc_security_struct),
+ 	.lbs_key = sizeof(struct key_security_struct),
+@@ -7301,11 +7183,9 @@ static struct security_hook_list selinux_hooks[] __ro_after_init = {
+ 
+ 	LSM_HOOK_INIT(file_permission, selinux_file_permission),
+ 	LSM_HOOK_INIT(file_alloc_security, selinux_file_alloc_security),
+-	LSM_HOOK_INIT(backing_file_alloc, selinux_backing_file_alloc),
+ 	LSM_HOOK_INIT(file_ioctl, selinux_file_ioctl),
+ 	LSM_HOOK_INIT(file_ioctl_compat, selinux_file_ioctl_compat),
+ 	LSM_HOOK_INIT(mmap_file, selinux_mmap_file),
+-	LSM_HOOK_INIT(mmap_backing_file, selinux_mmap_backing_file),
+ 	LSM_HOOK_INIT(mmap_addr, selinux_mmap_addr),
+ 	LSM_HOOK_INIT(file_mprotect, selinux_file_mprotect),
+ 	LSM_HOOK_INIT(file_lock, selinux_file_lock),
+diff --git a/security/selinux/include/objsec.h b/security/selinux/include/objsec.h
+index dc42282a2..c88cae81e 100644
+--- a/security/selinux/include/objsec.h
++++ b/security/selinux/include/objsec.h
+@@ -61,10 +61,6 @@ struct file_security_struct {
+ 	u32 pseqno; /* Policy seqno at the time of file open */
+ };
+ 
+-struct backing_file_security_struct {
+-	u32 uf_sid; /* associated user file fsec->sid */
+-};
+-
+ struct superblock_security_struct {
+ 	u32 sid; /* SID of file system superblock */
+ 	u32 def_sid; /* default SID for labeling */
+@@ -163,13 +159,6 @@ static inline struct file_security_struct *selinux_file(const struct file *file)
+ 	return file->f_security + selinux_blob_sizes.lbs_file;
+ }
+ 
+-static inline struct backing_file_security_struct *
+-selinux_backing_file(const struct file *backing_file)
+-{
+-	void *blob = backing_file_security(backing_file);
+-	return blob + selinux_blob_sizes.lbs_backing_file;
+-}
+-
+ static inline struct inode_security_struct *
+ selinux_inode(const struct inode *inode)
+ {
+-- 
+2.47.3
+

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -70,6 +70,7 @@ Patch1005: 1005-Lustre-cast-unsigned-long-to-pointer.patch
 Patch1006: 1006-Select-prerequisites-for-gpu-drivers.patch
 # Backport patch to ensure NUL-terminated task->comm buffer
 Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
+Patch1008: 1008-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.18/1006-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
+++ b/packages/kernel-6.18/1006-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
@@ -1,0 +1,412 @@
+From 8335dbaacb1fc136747a736e1b476f9aaf77cd56 Mon Sep 17 00:00:00 2001
+From: Sparks Song <shijiao@amazon.com>
+Date: Wed, 26 Aug 2026 23:16:35 +0000
+Subject: [PATCH] Revert "selinux: fix overlayfs mmap() and mprotect() access
+ checks"
+
+This reverts commit d844702198395d3f80222777030f69db6be6b709.
+---
+ security/selinux/hooks.c          | 248 ++++++++----------------------
+ security/selinux/include/objsec.h |  11 --
+ 2 files changed, 64 insertions(+), 195 deletions(-)
+
+diff --git a/security/selinux/hooks.c b/security/selinux/hooks.c
+index af188e19c130..5efd444674ef 100644
+--- a/security/selinux/hooks.c
++++ b/security/selinux/hooks.c
+@@ -1739,72 +1739,49 @@ static inline int file_path_has_perm(const struct cred *cred,
+ static int bpf_fd_pass(const struct file *file, u32 sid);
+ #endif
+ 
+-static int __file_has_perm(const struct cred *cred, const struct file *file,
+-			   u32 av, bool bf_user_file)
+-
++/* Check whether a task can use an open file descriptor to
++   access an inode in a given way.  Check access to the
++   descriptor itself, and then use dentry_has_perm to
++   check a particular permission to the file.
++   Access to the descriptor is implicitly granted if it
++   has the same SID as the process.  If av is zero, then
++   access to the file is not checked, e.g. for cases
++   where only the descriptor is affected like seek. */
++static int file_has_perm(const struct cred *cred,
++			 struct file *file,
++			 u32 av)
+ {
++	struct file_security_struct *fsec = selinux_file(file);
++	struct inode *inode = file_inode(file);
+ 	struct common_audit_data ad;
+-	struct inode *inode;
+-	u32 ssid = cred_sid(cred);
+-	u32 tsid_fd;
++	u32 sid = cred_sid(cred);
+ 	int rc;
+ 
+-	if (bf_user_file) {
+-		struct backing_file_security_struct *bfsec;
+-		const struct path *path;
+-
+-		if (WARN_ON(!(file->f_mode & FMODE_BACKING)))
+-			return -EIO;
+-
+-		bfsec = selinux_backing_file(file);
+-		path = backing_file_user_path(file);
+-		tsid_fd = bfsec->uf_sid;
+-		inode = d_inode(path->dentry);
+-
+-		ad.type = LSM_AUDIT_DATA_PATH;
+-		ad.u.path = *path;
+-	} else {
+-		struct file_security_struct *fsec = selinux_file(file);
+-
+-		tsid_fd = fsec->sid;
+-		inode = file_inode(file);
+-
+-		ad.type = LSM_AUDIT_DATA_FILE;
+-		ad.u.file = file;
+-	}
++	ad.type = LSM_AUDIT_DATA_FILE;
++	ad.u.file = file;
+ 
+-	if (ssid != tsid_fd) {
+-		rc = avc_has_perm(ssid, tsid_fd, SECCLASS_FD, FD__USE, &ad);
++	if (sid != fsec->sid) {
++		rc = avc_has_perm(sid, fsec->sid,
++				  SECCLASS_FD,
++				  FD__USE,
++				  &ad);
+ 		if (rc)
+-			return rc;
++			goto out;
+ 	}
+ 
+ #ifdef CONFIG_BPF_SYSCALL
+-	/* regardless of backing vs user file, use the underlying file here */
+-	rc = bpf_fd_pass(file, ssid);
++	rc = bpf_fd_pass(file, cred_sid(cred));
+ 	if (rc)
+ 		return rc;
+ #endif
+ 
+ 	/* av is zero if only checking access to the descriptor. */
++	rc = 0;
+ 	if (av)
+-		return inode_has_perm(cred, inode, av, &ad);
++		rc = inode_has_perm(cred, inode, av, &ad);
+ 
+-	return 0;
+-}
+-
+-/* Check whether a task can use an open file descriptor to
+-   access an inode in a given way.  Check access to the
+-   descriptor itself, and then use dentry_has_perm to
+-   check a particular permission to the file.
+-   Access to the descriptor is implicitly granted if it
+-   has the same SID as the process.  If av is zero, then
+-   access to the file is not checked, e.g. for cases
+-   where only the descriptor is affected like seek. */
+-static inline int file_has_perm(const struct cred *cred,
+-				const struct file *file, u32 av)
+-{
+-	return __file_has_perm(cred, file, av, false);
++out:
++	return rc;
+ }
+ 
+ /*
+@@ -3822,17 +3799,6 @@ static int selinux_file_alloc_security(struct file *file)
+ 	return 0;
+ }
+ 
+-static int selinux_backing_file_alloc(struct file *backing_file,
+-				      const struct file *user_file)
+-{
+-	struct backing_file_security_struct *bfsec;
+-
+-	bfsec = selinux_backing_file(backing_file);
+-	bfsec->uf_sid = selinux_file(user_file)->sid;
+-
+-	return 0;
+-}
+-
+ /*
+  * Check whether a task has the ioctl permission and cmd
+  * operation to an inode.
+@@ -3950,57 +3916,42 @@ static int selinux_file_ioctl_compat(struct file *file, unsigned int cmd,
+ 
+ static int default_noexec __ro_after_init;
+ 
+-static int __file_map_prot_check(const struct file *file, unsigned long prot,
+-				 bool shared, bool mounter_check,
+-				 bool bf_user_file)
++static int file_map_prot_check(struct file *file, unsigned long prot, int shared)
+ {
+-	struct inode *inode = NULL;
+-	bool prot_exec = prot & PROT_EXEC;
+-	bool prot_write = prot & PROT_WRITE;
+-
+-	if (file) {
+-		if (bf_user_file)
+-			inode = d_inode(backing_file_user_path(file)->dentry);
+-		else
+-			inode = file_inode(file);
+-	}
+-
+-	if (!mounter_check && default_noexec && prot_exec &&
+-	    (!file || IS_PRIVATE(inode) || (!shared && prot_write))) {
+-		int rc;
+-		u32 sid = current_sid();
++	const struct cred *cred = current_cred();
++	u32 sid = cred_sid(cred);
++	int rc = 0;
+ 
++	if (default_noexec &&
++	    (prot & PROT_EXEC) && (!file || IS_PRIVATE(file_inode(file)) ||
++				   (!shared && (prot & PROT_WRITE)))) {
+ 		/*
+-		 * We are making executable an anonymous mapping or a private
+-		 * file mapping that will also be writable.
++		 * We are making executable an anonymous mapping or a
++		 * private file mapping that will also be writable.
++		 * This has an additional check.
+ 		 */
+-		rc = avc_has_perm(sid, sid, SECCLASS_PROCESS, PROCESS__EXECMEM,
+-				  NULL);
++		rc = avc_has_perm(sid, sid, SECCLASS_PROCESS,
++				  PROCESS__EXECMEM, NULL);
+ 		if (rc)
+-			return rc;
++			goto error;
+ 	}
+ 
+ 	if (file) {
+-		const struct cred *cred = mounter_check ?
+-				file->f_cred : current_cred();
+-		/* "read" always possible, "write" only if shared */
++		/* read access is always possible with a mapping */
+ 		u32 av = FILE__READ;
+-		if (shared && prot_write)
++
++		/* write access only matters if the mapping is shared */
++		if (shared && (prot & PROT_WRITE))
+ 			av |= FILE__WRITE;
+-		if (prot_exec)
++
++		if (prot & PROT_EXEC)
+ 			av |= FILE__EXECUTE;
+ 
+-		return __file_has_perm(cred, file, av, bf_user_file);
++		return file_has_perm(cred, file, av);
+ 	}
+ 
+-	return 0;
+-}
+-
+-static inline int file_map_prot_check(const struct file *file,
+-				      unsigned long prot, bool shared,
+-				      bool mounter_check)
+-{
+-	return __file_map_prot_check(file, prot, shared, mounter_check, false);
++error:
++	return rc;
+ }
+ 
+ static int selinux_mmap_addr(unsigned long addr)
+@@ -4016,84 +3967,36 @@ static int selinux_mmap_addr(unsigned long addr)
+ 	return rc;
+ }
+ 
+-static int selinux_mmap_file_common(struct file *file, unsigned long prot,
+-				    bool shared, bool mounter_check)
++static int selinux_mmap_file(struct file *file,
++			     unsigned long reqprot __always_unused,
++			     unsigned long prot, unsigned long flags)
+ {
+-	if (file) {
+-		int rc;
+-		struct common_audit_data ad;
+-		const struct cred *cred = mounter_check ?
+-				file->f_cred : current_cred();
++	struct common_audit_data ad;
++	int rc;
+ 
++	if (file) {
+ 		ad.type = LSM_AUDIT_DATA_FILE;
+ 		ad.u.file = file;
+-		rc = inode_has_perm(cred, file_inode(file), FILE__MAP, &ad);
++		rc = inode_has_perm(current_cred(), file_inode(file),
++				    FILE__MAP, &ad);
+ 		if (rc)
+ 			return rc;
+ 	}
+ 
+-	return file_map_prot_check(file, prot, shared, mounter_check);
+-}
+-
+-static int selinux_mmap_file(struct file *file,
+-			     unsigned long reqprot __always_unused,
+-			     unsigned long prot, unsigned long flags)
+-{
+-	return selinux_mmap_file_common(file, prot,
+-					(flags & MAP_TYPE) == MAP_SHARED,
+-					false);
+-}
+-
+-/**
+- * selinux_mmap_backing_file - Check mmap permissions on a backing file
+- * @vma: memory region
+- * @backing_file: stacked filesystem backing file
+- * @user_file: user visible file
+- *
+- * This is called after selinux_mmap_file() on stacked filesystems, and it
+- * is this function's responsibility to verify access to @backing_file and
+- * setup the SELinux state for possible later use in the mprotect() code path.
+- *
+- * By the time this function is called, mmap() access to @user_file has already
+- * been authorized and @vma->vm_file has been set to point to @backing_file.
+- *
+- * Return zero on success, negative values otherwise.
+- */
+-static int selinux_mmap_backing_file(struct vm_area_struct *vma,
+-				     struct file *backing_file,
+-				     struct file *user_file __always_unused)
+-{
+-	unsigned long prot = 0;
+-
+-	/* translate vma->vm_flags perms into PROT perms */
+-	if (vma->vm_flags & VM_READ)
+-		prot |= PROT_READ;
+-	if (vma->vm_flags & VM_WRITE)
+-		prot |= PROT_WRITE;
+-	if (vma->vm_flags & VM_EXEC)
+-		prot |= PROT_EXEC;
+-
+-	return selinux_mmap_file_common(backing_file, prot,
+-					vma->vm_flags & VM_SHARED,
+-					true);
++	return file_map_prot_check(file, prot,
++				   (flags & MAP_TYPE) == MAP_SHARED);
+ }
+ 
+ static int selinux_file_mprotect(struct vm_area_struct *vma,
+ 				 unsigned long reqprot __always_unused,
+ 				 unsigned long prot)
+ {
+-	int rc;
+ 	const struct cred *cred = current_cred();
+ 	u32 sid = cred_sid(cred);
+-	const struct file *file = vma->vm_file;
+-	bool backing_file;
+-	bool shared = vma->vm_flags & VM_SHARED;
+-
+-	/* check if we need to trigger the "backing files are awful" mode */
+-	backing_file = file && (file->f_mode & FMODE_BACKING);
+ 
+ 	if (default_noexec &&
+ 	    (prot & PROT_EXEC) && !(vma->vm_flags & VM_EXEC)) {
++		int rc = 0;
+ 		/*
+ 		 * We don't use the vma_is_initial_heap() helper as it has
+ 		 * a history of problems and is currently broken on systems
+@@ -4107,15 +4010,11 @@ static int selinux_file_mprotect(struct vm_area_struct *vma,
+ 		    vma->vm_end <= vma->vm_mm->brk) {
+ 			rc = avc_has_perm(sid, sid, SECCLASS_PROCESS,
+ 					  PROCESS__EXECHEAP, NULL);
+-			if (rc)
+-				return rc;
+-		} else if (!file && (vma_is_initial_stack(vma) ||
++		} else if (!vma->vm_file && (vma_is_initial_stack(vma) ||
+ 			    vma_is_stack_for_current(vma))) {
+ 			rc = avc_has_perm(sid, sid, SECCLASS_PROCESS,
+ 					  PROCESS__EXECSTACK, NULL);
+-			if (rc)
+-				return rc;
+-		} else if (file && vma->anon_vma) {
++		} else if (vma->vm_file && vma->anon_vma) {
+ 			/*
+ 			 * We are making executable a file mapping that has
+ 			 * had some COW done. Since pages might have been
+@@ -4123,29 +4022,13 @@ static int selinux_file_mprotect(struct vm_area_struct *vma,
+ 			 * modified content.  This typically should only
+ 			 * occur for text relocations.
+ 			 */
+-			rc = __file_has_perm(cred, file, FILE__EXECMOD,
+-					     backing_file);
+-			if (rc)
+-				return rc;
+-			if (backing_file) {
+-				rc = file_has_perm(file->f_cred, file,
+-						   FILE__EXECMOD);
+-				if (rc)
+-					return rc;
+-			}
++			rc = file_has_perm(cred, vma->vm_file, FILE__EXECMOD);
+ 		}
+-	}
+-
+-	rc = __file_map_prot_check(file, prot, shared, false, backing_file);
+-	if (rc)
+-		return rc;
+-	if (backing_file) {
+-		rc = file_map_prot_check(file, prot, shared, true);
+ 		if (rc)
+ 			return rc;
+ 	}
+ 
+-	return 0;
++	return file_map_prot_check(vma->vm_file, prot, vma->vm_flags&VM_SHARED);
+ }
+ 
+ static int selinux_file_lock(struct file *file, unsigned int cmd)
+@@ -7275,7 +7158,6 @@ struct lsm_blob_sizes selinux_blob_sizes __ro_after_init = {
+ 	.lbs_cred = sizeof(struct cred_security_struct),
+ 	.lbs_task = sizeof(struct task_security_struct),
+ 	.lbs_file = sizeof(struct file_security_struct),
+-	.lbs_backing_file = sizeof(struct backing_file_security_struct),
+ 	.lbs_inode = sizeof(struct inode_security_struct),
+ 	.lbs_ipc = sizeof(struct ipc_security_struct),
+ 	.lbs_key = sizeof(struct key_security_struct),
+@@ -7499,11 +7381,9 @@ static struct security_hook_list selinux_hooks[] __ro_after_init = {
+ 
+ 	LSM_HOOK_INIT(file_permission, selinux_file_permission),
+ 	LSM_HOOK_INIT(file_alloc_security, selinux_file_alloc_security),
+-	LSM_HOOK_INIT(backing_file_alloc, selinux_backing_file_alloc),
+ 	LSM_HOOK_INIT(file_ioctl, selinux_file_ioctl),
+ 	LSM_HOOK_INIT(file_ioctl_compat, selinux_file_ioctl_compat),
+ 	LSM_HOOK_INIT(mmap_file, selinux_mmap_file),
+-	LSM_HOOK_INIT(mmap_backing_file, selinux_mmap_backing_file),
+ 	LSM_HOOK_INIT(mmap_addr, selinux_mmap_addr),
+ 	LSM_HOOK_INIT(file_mprotect, selinux_file_mprotect),
+ 	LSM_HOOK_INIT(file_lock, selinux_file_lock),
+diff --git a/security/selinux/include/objsec.h b/security/selinux/include/objsec.h
+index fcb46793898f..816fde5a5896 100644
+--- a/security/selinux/include/objsec.h
++++ b/security/selinux/include/objsec.h
+@@ -86,10 +86,6 @@ struct file_security_struct {
+ 	u32 pseqno; /* Policy seqno at the time of file open */
+ };
+ 
+-struct backing_file_security_struct {
+-	u32 uf_sid; /* associated user file fsec->sid */
+-};
+-
+ struct superblock_security_struct {
+ 	u32 sid; /* SID of file system superblock */
+ 	u32 def_sid; /* default SID for labeling */
+@@ -194,13 +190,6 @@ static inline struct file_security_struct *selinux_file(const struct file *file)
+ 	return file->f_security + selinux_blob_sizes.lbs_file;
+ }
+ 
+-static inline struct backing_file_security_struct *
+-selinux_backing_file(const struct file *backing_file)
+-{
+-	void *blob = backing_file_security(backing_file);
+-	return blob + selinux_blob_sizes.lbs_backing_file;
+-}
+-
+ static inline struct inode_security_struct *
+ selinux_inode(const struct inode *inode)
+ {
+-- 
+2.47.0
+

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -79,6 +79,7 @@ Patch1003: 1003-initramfs-unlink-INITRAMFS_FORCE-from-CMDLINE_-EXTEN.patch
 Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # Select prerequisites for GPU drivers.
 Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
+Patch1006: 1006-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION

  **Description of changes:**
  - Restore the selinux overlayfs mmap/mprotect revert (added in #496, dropped in v8.0.0 #526) for kernel-6.12 and kernel-6.18.
  - Without it, `file:execmod` on overlayfs is checked against the mounter (`runtime_t`) instead of the process, so UPX-packed/JIT container binaries are denied and crash at startup.
  kernel-6.1 is unaffected.

  **Testing done:**
  Built aws-k8s-1.35 (6.12.100) and aws-k8s-1.36 (6.18.41) AMIs from this branch and ran the execmod reproducer as `control_t` on overlayfs under SELinux enforcing. On both kernels the previously-failing sequence now passes:

```
  === test_execmod: mmap(R|W, MAP_PRIVATE) -> write (COW) -> mprotect(R|X) ===
  mprotect(R|X) SUCCEEDED (no denial here)
  Exit 0, no `avc: denied` in dmesg.
```

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
