### PR TITLE
tools: add support for Twoliter.override in docker-run

### DIFF
--- a/tools/docker-run.sh
+++ b/tools/docker-run.sh
@@ -9,7 +9,14 @@ bail() {
 }
 
 find_sdk() {
-  grep -A5 '^\[sdk\]' Twoliter.lock | grep '^source' | cut -d'"' -f2
+  local sdk_source sdk_override
+  sdk_source="$(grep -A5 '^\[sdk\]' Twoliter.lock | grep '^source' | cut -d'"' -f2)"
+  if [[ -s "Twoliter.override" ]]; then
+    echo "Resolving SDK via twoliter update" >&2
+    sdk_override="$(./tools/twoliter/twoliter update 2>&1 \
+      | awk -F'overridden-to: ' 'NF>1 {split($2, a, ")"); print a[1]; exit}')"
+  fi
+  echo "${sdk_override:-$sdk_source}"
 }
 
 SCRIPT_PATH="$1"


### PR DESCRIPTION
**Description of changes:**

`make full-config` ignored `Twoliter.override` while `make` (the normal build path) honored it. This PR makes `tools/docker-run.sh` resolve the Bottlerocket SDK image through Twoliter when an override is present, so `full-config` now runs inside the same (possibly overridden) SDK container as a regular build.

**Why the two paths behaved differently:**

The kernel kit has two ways of launching work in the SDK container:

- **`make` / `make build`** delegates to the **Twoliter binary** (`twoliter build kit ...`). Twoliter itself reads `Twoliter.toml`, layers `Twoliter.override` on top, and resolves the final SDK image. Overrides are therefore honored automatically.

- **`make full-config`** does **not** go through Twoliter. It runs `tools/docker-run.sh`, which picked the SDK image itself by grepping `Twoliter.lock`:

  ```bash
  find_sdk() {
    grep -A5 '^\[sdk\]' Twoliter.lock | grep '^source' | cut -d'"' -f2
  }
  ```

The key insight is that **`Twoliter.override` is intentionally never written into `Twoliter.lock`**. The lock file always records the *canonical* SDK source (e.g. `public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.79.0`) plus its digest, so it remains a reproducible, shareable record. The override is a local, `.gitignore`d redirect that Twoliter applies **at runtime**. Because `docker-run.sh` only read the lock's `source` line, it could never see the override — so `full-config` always tried to pull the canonical image and failed when that image wasn't the one the developer intended to use:

```
Using SDK: public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.79.0 to run the provided script
docker: Error response from daemon: manifest for public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.79.0 not found
```

**Testing done:**

Verified `find_sdk`:

- [x] **With `Twoliter.override` present** → resolves to the overridden image (e.g. `<account>.dkr.ecr.<region>.amazonaws.com/<name>:v0.79.0`).
- [x] **Without `Twoliter.override`** → falls back to the canonical `public.ecr.aws/bottlerocket/bottlerocket-sdk:v0.79.0` from `Twoliter.lock`.
- [x] `bash -n tools/docker-run.sh` passes (syntax check).
- [x] Confirmed the status message is emitted on `stderr` and is not captured into the `SDK` value.
- [x] Built the kernel kit using a new SDK from the tip of develop using an override. 

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
