### PR TITLE
kernel: fix Nitro Enclaves use-after-free on SLOT_ALLOC failure (6.1, 6.12, 6.18)

### DIFF
--- a/packages/kernel-6.1/1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
+++ b/packages/kernel-6.1/1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
@@ -1,0 +1,56 @@
+From: Yuxiao Wang <yuxiao.wang@certik.com>
+Date: Tue, 9 Sep 2026 12:44:00 +0000
+Subject: [PATCH] nitro_enclaves: fix use-after-free on SLOT_ALLOC failure
+
+When ne_create_vm_ioctl() fails the SLOT_ALLOC request after
+anon_inode_getfile() has succeeded, the error path calls
+fput(enclave_file) and then frees ne_enclave.
+
+In normal userspace context, fput() defers the final __fput() via
+task_work. ne_enclave_release() therefore runs after ne_enclave has
+already been freed and dereferences ne_enclave->slot_uid, causing a
+use-after-free: KASAN: slab-use-after-free in ne_enclave_release.
+
+The enclave has no slot allocated and is not yet linked into the
+enclaves list on this error path, so ne_enclave_release() is expected
+to return early when slot_uid is zero. However, reading slot_uid
+already accesses the freed object.
+
+Clear enclave_file->private_data before fput() on the error path.
+ne_enclave_release() then returns immediately when private_data is
+NULL, leaving the ioctl error path as the sole owner of ne_enclave.
+This is safe because the file has not been fd_install()'d yet.
+
+Tested on an AWS EC2 m5.2xlarge with CONFIG_KASAN=y. Without the
+patch, the reproducer triggers a KASAN slab-use-after-free on every
+SLOT_ALLOC failure. With the patch, no KASAN report is produced and
+the SLOT_ALLOC error is still returned. Normal enclave creation and
+teardown are unaffected.
+
+Fixes: 9c8eb50fe9e2 ("nitro_enclaves: Add logic for terminating an enclave")
+Cc: stable@vger.kernel.org
+Co-developed-by: Zhaofeng Chen <zhaofeng.chen@certik.com>
+Signed-off-by: Zhaofeng Chen <zhaofeng.chen@certik.com>
+Signed-off-by: Yuxiao Wang <yuxiao.wang@certik.com>
+Reviewed-by: Alexander Graf <graf@amazon.com>
+Link: https://lore.kernel.org/stable/20260909124400.27857-1-graf@amazon.com/T/#u
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ drivers/virt/nitro_enclaves/ne_misc_dev.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/virt/nitro_enclaves/ne_misc_dev.c b/drivers/virt/nitro_enclaves/ne_misc_dev.c
+index c91300a..0d7bdad 100644
+--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
++++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
+@@ -1706,6 +1706,7 @@ static int ne_create_vm_ioctl(struct ne_pci_dev *ne_pci_dev, u64 __user *slot_ui
+ 	return enclave_fd;
+
+ put_file:
++	enclave_file->private_data = NULL;
+ 	fput(enclave_file);
+ put_fd:
+ 	put_unused_fd(enclave_fd);
+--
+2.34.1
+

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -60,6 +60,8 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 # Backport patch to ensure NUL-terminated task->comm buffer
 Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
+# Fix use-after-free in the Nitro Enclaves enclave-creation error path
+Patch1007: 1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.12/1009-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
+++ b/packages/kernel-6.12/1009-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
@@ -1,0 +1,56 @@
+From: Yuxiao Wang <yuxiao.wang@certik.com>
+Date: Tue, 9 Sep 2026 12:44:00 +0000
+Subject: [PATCH] nitro_enclaves: fix use-after-free on SLOT_ALLOC failure
+
+When ne_create_vm_ioctl() fails the SLOT_ALLOC request after
+anon_inode_getfile() has succeeded, the error path calls
+fput(enclave_file) and then frees ne_enclave.
+
+In normal userspace context, fput() defers the final __fput() via
+task_work. ne_enclave_release() therefore runs after ne_enclave has
+already been freed and dereferences ne_enclave->slot_uid, causing a
+use-after-free: KASAN: slab-use-after-free in ne_enclave_release.
+
+The enclave has no slot allocated and is not yet linked into the
+enclaves list on this error path, so ne_enclave_release() is expected
+to return early when slot_uid is zero. However, reading slot_uid
+already accesses the freed object.
+
+Clear enclave_file->private_data before fput() on the error path.
+ne_enclave_release() then returns immediately when private_data is
+NULL, leaving the ioctl error path as the sole owner of ne_enclave.
+This is safe because the file has not been fd_install()'d yet.
+
+Tested on an AWS EC2 m5.2xlarge with CONFIG_KASAN=y. Without the
+patch, the reproducer triggers a KASAN slab-use-after-free on every
+SLOT_ALLOC failure. With the patch, no KASAN report is produced and
+the SLOT_ALLOC error is still returned. Normal enclave creation and
+teardown are unaffected.
+
+Fixes: 9c8eb50fe9e2 ("nitro_enclaves: Add logic for terminating an enclave")
+Cc: stable@vger.kernel.org
+Co-developed-by: Zhaofeng Chen <zhaofeng.chen@certik.com>
+Signed-off-by: Zhaofeng Chen <zhaofeng.chen@certik.com>
+Signed-off-by: Yuxiao Wang <yuxiao.wang@certik.com>
+Reviewed-by: Alexander Graf <graf@amazon.com>
+Link: https://lore.kernel.org/stable/20260909124400.27857-1-graf@amazon.com/T/#u
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ drivers/virt/nitro_enclaves/ne_misc_dev.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/virt/nitro_enclaves/ne_misc_dev.c b/drivers/virt/nitro_enclaves/ne_misc_dev.c
+index c91300a..0d7bdad 100644
+--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
++++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
+@@ -1706,6 +1706,7 @@ static int ne_create_vm_ioctl(struct ne_pci_dev *ne_pci_dev, u64 __user *slot_ui
+ 	return enclave_fd;
+
+ put_file:
++	enclave_file->private_data = NULL;
+ 	fput(enclave_file);
+ put_fd:
+ 	put_unused_fd(enclave_fd);
+--
+2.34.1
+

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -71,6 +71,8 @@ Patch1006: 1006-Select-prerequisites-for-gpu-drivers.patch
 # Backport patch to ensure NUL-terminated task->comm buffer
 Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
 Patch1008: 1008-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
+# Fix use-after-free in the Nitro Enclaves enclave-creation error path
+Patch1009: 1009-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.18/1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
+++ b/packages/kernel-6.18/1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
@@ -1,0 +1,56 @@
+From: Yuxiao Wang <yuxiao.wang@certik.com>
+Date: Tue, 9 Sep 2026 12:44:00 +0000
+Subject: [PATCH] nitro_enclaves: fix use-after-free on SLOT_ALLOC failure
+
+When ne_create_vm_ioctl() fails the SLOT_ALLOC request after
+anon_inode_getfile() has succeeded, the error path calls
+fput(enclave_file) and then frees ne_enclave.
+
+In normal userspace context, fput() defers the final __fput() via
+task_work. ne_enclave_release() therefore runs after ne_enclave has
+already been freed and dereferences ne_enclave->slot_uid, causing a
+use-after-free: KASAN: slab-use-after-free in ne_enclave_release.
+
+The enclave has no slot allocated and is not yet linked into the
+enclaves list on this error path, so ne_enclave_release() is expected
+to return early when slot_uid is zero. However, reading slot_uid
+already accesses the freed object.
+
+Clear enclave_file->private_data before fput() on the error path.
+ne_enclave_release() then returns immediately when private_data is
+NULL, leaving the ioctl error path as the sole owner of ne_enclave.
+This is safe because the file has not been fd_install()'d yet.
+
+Tested on an AWS EC2 m5.2xlarge with CONFIG_KASAN=y. Without the
+patch, the reproducer triggers a KASAN slab-use-after-free on every
+SLOT_ALLOC failure. With the patch, no KASAN report is produced and
+the SLOT_ALLOC error is still returned. Normal enclave creation and
+teardown are unaffected.
+
+Fixes: 9c8eb50fe9e2 ("nitro_enclaves: Add logic for terminating an enclave")
+Cc: stable@vger.kernel.org
+Co-developed-by: Zhaofeng Chen <zhaofeng.chen@certik.com>
+Signed-off-by: Zhaofeng Chen <zhaofeng.chen@certik.com>
+Signed-off-by: Yuxiao Wang <yuxiao.wang@certik.com>
+Reviewed-by: Alexander Graf <graf@amazon.com>
+Link: https://lore.kernel.org/stable/20260909124400.27857-1-graf@amazon.com/T/#u
+Signed-off-by: Maher Homsi <maherhom@amazon.com>
+---
+ drivers/virt/nitro_enclaves/ne_misc_dev.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/virt/nitro_enclaves/ne_misc_dev.c b/drivers/virt/nitro_enclaves/ne_misc_dev.c
+index c91300a..0d7bdad 100644
+--- a/drivers/virt/nitro_enclaves/ne_misc_dev.c
++++ b/drivers/virt/nitro_enclaves/ne_misc_dev.c
+@@ -1706,6 +1706,7 @@ static int ne_create_vm_ioctl(struct ne_pci_dev *ne_pci_dev, u64 __user *slot_ui
+ 	return enclave_fd;
+
+ put_file:
++	enclave_file->private_data = NULL;
+ 	fput(enclave_file);
+ put_fd:
+ 	put_unused_fd(enclave_fd);
+--
+2.34.1
+

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -80,6 +80,8 @@ Patch1004: 1004-af_unix-increase-default-max_dgram_qlen-to-512.patch
 # Select prerequisites for GPU drivers.
 Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
 Patch1006: 1006-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
+# Fix use-after-free in the Nitro Enclaves enclave-creation error path
+Patch1007: 1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Description of changes:**
Backports the upstream fix for a use-after-free in the Nitro Enclaves guest driver's enclave-creation error path, applied to all three kernels (6.1, 6.12, 6.18) as one patch per package.

Upstream: https://lore.kernel.org/stable/20260909124400.27857-1-graf@amazon.com/T/#u.

**Testing done:**
Built a kernel-kit AMI and booted it (aws-k8s-1.36, x86_64):
  - Kernel boots cleanly; EC2 status checks pass.
  - No panic in serial console.

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
