### PR TITLE
Add patch to initialize modname and offset in print_rec()

### DIFF
--- a/packages/kernel-6.1/1008-ftrace-initialize-modname-and-offset-in-print_rec.patch
+++ b/packages/kernel-6.1/1008-ftrace-initialize-modname-and-offset-in-print_rec.patch
@@ -1,0 +1,33 @@
+From: Aaron Ahmed <aarnahmd@amazon.com>
+Date: Thu, 10 Sep 2026 00:50:16 +0000
+Subject: ftrace: initialize modname and offset in print_rec()
+
+print_rec() declares 'char *modname' and 'unsigned long offset' without
+initializers. kallsyms_lookup() only writes them on success. On failure,
+the garbage values pass the if(modname) check and seq_printf() dereferences
+the garbage pointer, producing a general protection fault.
+
+Fix by initializing both to zero/NULL so a failed lookup safely skips
+the module-name print.
+
+Signed-off-by: Aaron Ahmed <aarnahmd@amazon.com>
+Signed-off-by: Gavin Inglis <giinglis@amazon.com>
+---
+ kernel/trace/ftrace.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/trace/ftrace.c b/kernel/trace/ftrace.c
+--- a/kernel/trace/ftrace.c
++++ b/kernel/trace/ftrace.c
+@@ -4306,9 +4306,9 @@ subsys_initcall(ftrace_check_for_weak_functions);
+
+ static int print_rec(struct seq_file *m, unsigned long ip)
+ {
+-	unsigned long offset;
++	unsigned long offset = 0;
+ 	char str[KSYM_SYMBOL_LEN];
+-	char *modname;
++	char *modname = NULL;
+ 	const char *ret;
+
+ 	ret = kallsyms_lookup(ip, NULL, &offset, &modname, str);

--- a/packages/kernel-6.1/kernel-6.1.spec
+++ b/packages/kernel-6.1/kernel-6.1.spec
@@ -62,6 +62,8 @@ Patch1005: 1005-Revert-Revert-drm-fb_helper-improve-CONFIG_FB-depend.patch
 Patch1006: 1006-strscpy-write-destination-buffer-only-once.patch
 # Fix use-after-free in the Nitro Enclaves enclave-creation error path
 Patch1007: 1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
+# Initialize modname and offset in ftrace print_rec() to avoid GP fault
+Patch1008: 1008-ftrace-initialize-modname-and-offset-in-print_rec.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.12/1010-ftrace-initialize-modname-and-offset-in-print_rec.patch
+++ b/packages/kernel-6.12/1010-ftrace-initialize-modname-and-offset-in-print_rec.patch
@@ -1,0 +1,33 @@
+From: Aaron Ahmed <aarnahmd@amazon.com>
+Date: Thu, 10 Sep 2026 00:50:16 +0000
+Subject: ftrace: initialize modname and offset in print_rec()
+
+print_rec() declares 'char *modname' and 'unsigned long offset' without
+initializers. kallsyms_lookup() only writes them on success. On failure,
+the garbage values pass the if(modname) check and seq_printf() dereferences
+the garbage pointer, producing a general protection fault.
+
+Fix by initializing both to zero/NULL so a failed lookup safely skips
+the module-name print.
+
+Signed-off-by: Aaron Ahmed <aarnahmd@amazon.com>
+Signed-off-by: Gavin Inglis <giinglis@amazon.com>
+---
+ kernel/trace/ftrace.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/trace/ftrace.c b/kernel/trace/ftrace.c
+--- a/kernel/trace/ftrace.c
++++ b/kernel/trace/ftrace.c
+@@ -4306,9 +4306,9 @@ subsys_initcall(ftrace_check_for_weak_functions);
+
+ static int print_rec(struct seq_file *m, unsigned long ip)
+ {
+-	unsigned long offset;
++	unsigned long offset = 0;
+ 	char str[KSYM_SYMBOL_LEN];
+-	char *modname;
++	char *modname = NULL;
+ 	const char *ret;
+
+ 	ret = kallsyms_lookup(ip, NULL, &offset, &modname, str);

--- a/packages/kernel-6.12/kernel-6.12.spec
+++ b/packages/kernel-6.12/kernel-6.12.spec
@@ -73,6 +73,8 @@ Patch1007: 1007-strscpy-write-destination-buffer-only-once.patch
 Patch1008: 1008-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
 # Fix use-after-free in the Nitro Enclaves enclave-creation error path
 Patch1009: 1009-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
+# Initialize modname and offset in ftrace print_rec() to avoid GP fault
+Patch1010: 1010-ftrace-initialize-modname-and-offset-in-print_rec.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel

--- a/packages/kernel-6.18/1008-ftrace-initialize-modname-and-offset-in-print_rec.patch
+++ b/packages/kernel-6.18/1008-ftrace-initialize-modname-and-offset-in-print_rec.patch
@@ -1,0 +1,33 @@
+From: Aaron Ahmed <aarnahmd@amazon.com>
+Date: Thu, 10 Sep 2026 00:50:16 +0000
+Subject: ftrace: initialize modname and offset in print_rec()
+
+print_rec() declares 'char *modname' and 'unsigned long offset' without
+initializers. kallsyms_lookup() only writes them on success. On failure,
+the garbage values pass the if(modname) check and seq_printf() dereferences
+the garbage pointer, producing a general protection fault.
+
+Fix by initializing both to zero/NULL so a failed lookup safely skips
+the module-name print.
+
+Signed-off-by: Aaron Ahmed <aarnahmd@amazon.com>
+Signed-off-by: Gavin Inglis <giinglis@amazon.com>
+---
+ kernel/trace/ftrace.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/trace/ftrace.c b/kernel/trace/ftrace.c
+--- a/kernel/trace/ftrace.c
++++ b/kernel/trace/ftrace.c
+@@ -4306,9 +4306,9 @@ subsys_initcall(ftrace_check_for_weak_functions);
+
+ static int print_rec(struct seq_file *m, unsigned long ip)
+ {
+-	unsigned long offset;
++	unsigned long offset = 0;
+ 	char str[KSYM_SYMBOL_LEN];
+-	char *modname;
++	char *modname = NULL;
+ 	const char *ret;
+
+ 	ret = kallsyms_lookup(ip, NULL, &offset, &modname, str);

--- a/packages/kernel-6.18/kernel-6.18.spec
+++ b/packages/kernel-6.18/kernel-6.18.spec
@@ -82,6 +82,8 @@ Patch1005: 1005-drm-simpledrm-Select-prerequisites-for-gpu-drivers.patch
 Patch1006: 1006-Revert-selinux-fix-overlayfs-mmap-and-mprotect-acces.patch
 # Fix use-after-free in the Nitro Enclaves enclave-creation error path
 Patch1007: 1007-nitro_enclaves-fix-use-after-free-on-SLOT_ALLOC-fail.patch
+# Initialize modname and offset in ftrace print_rec() to avoid GP fault
+Patch1008: 1008-ftrace-initialize-modname-and-offset-in-print_rec.patch
 
 BuildRequires: bc
 BuildRequires: elfutils-devel


### PR DESCRIPTION
**Description of changes:**

In the kernel, `print_rec()` declares `char *modname` and `unsigned long offset` without initializers. `kallsyms_lookup()` only writes them on success. On failure, the garbage values pass the `if(modname)` check and `seq_printf()` dereferences the garbage pointer. Fix by initializing both to zero/NULL so a failed lookup safely skips the module-name print.

**Testing done:**

`make ARCH=x86_64 && make ARCH=aarch64`

**Terms of contribution:**

By submitting this pull request, I agree that this contribution is dual-licensed under the terms of both the Apache License, version 2.0, and the MIT license.
